### PR TITLE
chore(release): v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Sentry WMS will be documented in this file.
 
+## [v1.10.1] - 2026-05-11
+
+Patch release. Two operator-experience changes on top of the v1.10.0 POS surface: the admin token validator now accepts the dockd and POS slugs it would not before, and the admin Imports page gains a fifth tab for bulk inventory-adjustment CSV uploads.
+
+**Mobile.** Zero mobile/ diffs on this branch. v1.9.0 APK (versionCode 6) remains the working baseline; no new APK build for v1.10.1. Operators running the v1.9.0 mobile app continue to work against a v1.10.1 backend with no upgrade.
+
+### Added
+
+- **Inventory adjustment CSV import** (#329): new `inventory-adjustments` arm on `POST /api/admin/import/<type>` alongside items / bins / purchase-orders / sales-orders. Required columns: `sku`, `warehouse`, `bin`, `qty` (signed integer), `memo` (optional, <=500 chars). Each accepted row resolves `sku` against `items.sku`, `warehouse` against `warehouses.warehouse_code`, `bin` against `bins.bin_code` (must belong to the resolved warehouse), and writes an `inventory_adjustments` row with `reason_code='CORRECTION'`, `status='APPROVED'`, `reason_detail=memo` so the on-hand change applies inline. Positive qty goes through `services.inventory_service.add_inventory` (advisory-locked, creates the inventory row when absent); negative qty takes `FOR UPDATE` on the inventory row and rejects with a row-level error when available on-hand is insufficient. One `audit_log` row (`ACTION_ADJUST`) and one `adjustment.applied/1` outbox event fire per row so subscribers see one event per imported correction. Existing 5000-record cap and V-015 formula-prefix sanitiser apply unchanged. Admin Imports page gains an "Inventory Adjustments" tab with template download (5 columns, 3 example rows). New alignment test pins the template header to the server schema field list so a future schema change fails the test instead of an operator's import.
+
+### Fixed
+
+- **`admin/tokens` validator accepts `dockd.dispatch` and `pos.dispatch`**: `CreateTokenRequest` and `UpdateTokenRequest` only recognized V150 outbound slugs in `_known_slugs_only`, so `POST /api/admin/tokens` with `endpoints=['pos.dispatch']` or `['dockd.dispatch']` returned 400 `unknown_endpoint_slugs` even though the auth middleware honors both slugs at request time and scope-catalog advertises them. Operators could not issue dockd or POS tokens through the admin API. New `_KNOWN_ENDPOINT_SLUGS = V150 keys + V190_DOCKD_SLUG + V1100_POS_SLUG` is the single source the validator's accept set and "unknown slug" error message both read from.
+
 ## [v1.10.0] - 2026-05-09
 
 "POS endpoint surface" release. Sentry now serves a dedicated counter-sale API for an external POS Service: four endpoints under `/api/v1/pos/` (`GET /availability`, `POST /validate-cart`, `POST /checkout`, `POST /refund`) authenticated by a new fourth direction `pos.dispatch` alongside outbound polling, inbound POST, and dockd. Checkout and refund are atomic single-transaction routes with row-level `SELECT ... FOR UPDATE` on the inventory rows being decremented or re-incremented, idempotent on a per-route `idempotency_key` (UUID4) with a SHA-256 body hash so a retry with the same key + same body replays the cached response and a retry with the same key + different body returns 409. Refund enforces a 90-day window, a card-vs-cash tender lock, and a once-per-original-SO guard via `refunded_at` / `refund_so_id` on the original sales_orders row. Pricing stays out of Sentry: per-line `unit_price_cents` / `tax_cents` / `line_total_cents` ride on the wire and land in `audit_log.details` for archival, while the POS Service owns its own pricing source.

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "react": "^19.2.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/admin/src/pages/Imports.jsx
+++ b/admin/src/pages/Imports.jsx
@@ -28,6 +28,10 @@ SO-5002,1,Jane Doe,555-0102,456 Oak Ave,WIDGET-002,3`,
 C-01-01-01,C-01-01-01,STORAGE,1,C,Pickable,100,100,Shelf C Row 1 Level 1
 C-01-02-01,C-01-02-01,STORAGE,1,C,Pickable,101,101,Shelf C Row 2 Level 1
 D-01-01-01,D-01-01-01,PICKING,1,D,Pickable,200,200,Pick zone D`,
+  'inventory-adjustments': `sku,warehouse,bin,qty,memo
+WIDGET-001,WH-01,PICK-01,5,Found stock during cycle count
+WIDGET-002,WH-01,PICK-02,-3,Damaged in handling
+GADGET-001,WH-01,BULK-01,10,Vendor credit`,
 };
 
 function downloadTemplate(type) {
@@ -47,6 +51,7 @@ const IMPORT_TYPES = [
   { value: 'bins', label: 'Bins', desc: 'Import bin locations with zone, aisle, and type' },
   { value: 'purchase-orders', label: 'Purchase Orders', desc: 'Import POs with vendor and line items' },
   { value: 'sales-orders', label: 'Sales Orders', desc: 'Import SOs with customer and line items' },
+  { value: 'inventory-adjustments', label: 'Inventory Adjustments', desc: 'Bulk adjust on-hand quantities (auto-approved). Signed qty: positive adds, negative subtracts. Memo lands on the adjustment record.' },
 ];
 
 export default function Imports() {

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -384,7 +384,7 @@ export default function Settings() {
       <div className="settings-section">
         <h3>About</h3>
         <div className="detail-grid">
-          <span className="detail-label">Version</span><span className="mono">1.10.0</span>
+          <span className="detail-label">Version</span><span className="mono">1.10.1</span>
           <span className="detail-label">Repository</span><span><a href="https://github.com/hightower-systems/sentry-wms" target="_blank" rel="noopener noreferrer">github.com/hightower-systems/sentry-wms</a></span>
         </div>
       </div>

--- a/admin/src/test/imports.test.jsx
+++ b/admin/src/test/imports.test.jsx
@@ -62,6 +62,15 @@ describe('CSV import templates', () => {
     expect(cols).toContain('customer_address');
   });
 
+  it('inventory-adjustments template carries the five fields the server schema requires', () => {
+    const cols = headers('inventory-adjustments');
+    expect(cols).toContain('sku');
+    expect(cols).toContain('warehouse');
+    expect(cols).toContain('bin');
+    expect(cols).toContain('qty');
+    expect(cols).toContain('memo');
+  });
+
   it('every template has at least one example row after the header', () => {
     for (const key of Object.keys(CSV_TEMPLATES)) {
       const lines = CSV_TEMPLATES[key].split('\n').filter(Boolean);

--- a/api/routes/admin/admin_items.py
+++ b/api/routes/admin/admin_items.py
@@ -11,13 +11,20 @@ from pydantic import ValidationError
 from middleware.auth_middleware import require_auth, require_role
 from middleware.db import with_db
 from routes.admin import admin_bp
+from datetime import timezone
+
+from constants import ACTION_ADJUST, ADJ_APPROVED
 from schemas.csv_import import (
     BinImportRow,
+    InventoryAdjustmentImportRow,
     ItemImportRow,
     PurchaseOrderImportRow,
     SalesOrderImportRow,
 )
 from schemas.items import CreateItemRequest, CreatePreferredBinRequest, UpdateItemRequest, UpdatePreferredBinRequest
+from services.audit_service import write_audit_log
+from services.events_service import emit_event, get_user_external_id
+from services.inventory_service import add_inventory
 from utils.validation import validate_body
 
 
@@ -365,6 +372,7 @@ _IMPORT_ROW_SCHEMAS = {
     "bins": BinImportRow,
     "purchase-orders": PurchaseOrderImportRow,
     "sales-orders": SalesOrderImportRow,
+    "inventory-adjustments": InventoryAdjustmentImportRow,
 }
 
 
@@ -419,6 +427,8 @@ def csv_import(entity_type):
                 _import_purchase_order(g.db, row, default_warehouse_id)
             elif entity_type == "sales-orders":
                 _import_sales_order(g.db, row, default_warehouse_id)
+            elif entity_type == "inventory-adjustments":
+                _import_inventory_adjustment(g.db, row)
             imported += 1
         except _SkipRow as e:
             errors.append({"row": idx, "error": str(e)})
@@ -630,6 +640,129 @@ def _import_sales_order(db, row: SalesOrderImportRow, default_warehouse_id=None)
     db.execute(
         text("INSERT INTO sales_order_lines (so_id, item_id, quantity_ordered, line_number) VALUES (:sid, :iid, :qty, :ln)"),
         {"sid": so_id, "iid": item_row.item_id, "qty": quantity, "ln": max_ln + 1},
+    )
+
+
+def _import_inventory_adjustment(db, row: InventoryAdjustmentImportRow):
+    """Resolve sku/warehouse/bin, apply the on-hand change, write the
+    inventory_adjustments row as APPROVED, audit-log it, and emit
+    adjustment.applied/1. Mirrors the auto-approve direct-adjustment
+    endpoint (admin_users.create_inventory_adjustment) one-row-per-call
+    so subscribers receive one event per imported correction."""
+    item = db.execute(
+        text("SELECT item_id, external_id FROM items WHERE sku = :sku"),
+        {"sku": row.sku},
+    ).fetchone()
+    if not item:
+        raise _SkipRow(f"Item not found for sku '{row.sku}'")
+
+    wh = db.execute(
+        text("SELECT warehouse_id FROM warehouses WHERE warehouse_code = :code"),
+        {"code": row.warehouse},
+    ).fetchone()
+    if not wh:
+        raise _SkipRow(f"Warehouse not found for code '{row.warehouse}'")
+
+    bin_row = db.execute(
+        text(
+            "SELECT bin_id, external_id FROM bins "
+            "WHERE bin_code = :code AND warehouse_id = :wid"
+        ),
+        {"code": row.bin, "wid": wh.warehouse_id},
+    ).fetchone()
+    if not bin_row:
+        raise _SkipRow(
+            f"Bin '{row.bin}' not found in warehouse '{row.warehouse}'"
+        )
+
+    qty_change = row.qty
+    if qty_change > 0:
+        add_inventory(db, item.item_id, bin_row.bin_id, wh.warehouse_id, qty_change)
+    else:
+        inv = db.execute(
+            text(
+                "SELECT inventory_id, quantity_on_hand FROM inventory "
+                "WHERE item_id = :iid AND bin_id = :bid FOR UPDATE"
+            ),
+            {"iid": item.item_id, "bid": bin_row.bin_id},
+        ).fetchone()
+        available = inv.quantity_on_hand if inv else 0
+        if available < -qty_change:
+            raise _SkipRow(
+                f"Insufficient inventory at bin '{row.bin}' for sku "
+                f"'{row.sku}': available {available}, requested {-qty_change}"
+            )
+        new_qty = available + qty_change
+        if new_qty == 0:
+            db.execute(
+                text("DELETE FROM inventory WHERE inventory_id = :inv_id"),
+                {"inv_id": inv.inventory_id},
+            )
+        else:
+            db.execute(
+                text(
+                    "UPDATE inventory SET quantity_on_hand = :qty, "
+                    "updated_at = NOW() WHERE inventory_id = :inv_id"
+                ),
+                {"qty": new_qty, "inv_id": inv.inventory_id},
+            )
+
+    adj = db.execute(
+        text(
+            """
+            INSERT INTO inventory_adjustments
+                (item_id, bin_id, warehouse_id, quantity_change,
+                 reason_code, reason_detail, status, adjusted_by,
+                 adjusted_at, external_id)
+            VALUES (:iid, :bid, :wid, :qty_change, 'CORRECTION', :detail,
+                    :status, :user_id, NOW(), :ext_id)
+            RETURNING adjustment_id, adjusted_at, external_id
+            """
+        ),
+        {
+            "iid": item.item_id,
+            "bid": bin_row.bin_id,
+            "wid": wh.warehouse_id,
+            "qty_change": qty_change,
+            "detail": row.memo,
+            "status": ADJ_APPROVED,
+            "user_id": g.current_user["user_id"],
+            "ext_id": str(uuid.uuid4()),
+        },
+    ).fetchone()
+
+    write_audit_log(
+        db, ACTION_ADJUST, "ITEM", item.item_id,
+        user_id=g.current_user["user_id"],
+        warehouse_id=wh.warehouse_id,
+        details={
+            "adjustment_id": adj.adjustment_id,
+            "source": "csv_import",
+            "bin_id": bin_row.bin_id,
+            "quantity_change": qty_change,
+            "reason_code": "CORRECTION",
+            "memo": row.memo,
+        },
+    )
+
+    emit_event(
+        db,
+        event_type="adjustment.applied",
+        event_version=1,
+        aggregate_type="inventory_adjustment",
+        aggregate_id=adj.adjustment_id,
+        aggregate_external_id=adj.external_id,
+        warehouse_id=wh.warehouse_id,
+        source_txn_id=g.source_txn_id,
+        payload={
+            "adjustment_external_id": str(adj.external_id),
+            "item_external_id": str(item.external_id),
+            "bin_external_id": str(bin_row.external_id),
+            "quantity_delta": qty_change,
+            "reason_code": "CORRECTION",
+            "applied_by_user_external_id": get_user_external_id(db, g.current_user["username"]),
+            "applied_at": adj.adjusted_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
     )
 
 

--- a/api/schemas/csv_import.py
+++ b/api/schemas/csv_import.py
@@ -208,3 +208,35 @@ class TransferOrderImportRow(_BaseImportRow):
     @classmethod
     def _no_formula(cls, v):
         return _reject_formula_prefix(v)
+
+
+# ---------------------------------------------------------------------------
+# Inventory adjustments (v1.10.1 #329)
+# ---------------------------------------------------------------------------
+
+
+class InventoryAdjustmentImportRow(_BaseImportRow):
+    """One row in the inventory adjustment CSV import. Each row resolves
+    to a single auto-approved inventory_adjustments insert plus the
+    matching inventory on-hand mutation. qty is signed: positive adds,
+    negative subtracts (with a sufficient-stock check at apply time).
+    memo lands in inventory_adjustments.reason_detail; reason_code is
+    fixed to CORRECTION on this path."""
+
+    sku: str = Field(..., min_length=1, max_length=128)
+    warehouse: str = Field(..., min_length=1, max_length=64)
+    bin: str = Field(..., min_length=1, max_length=64)
+    qty: int = Field(..., ge=-1000000, le=1000000)
+    memo: Optional[str] = Field(None, max_length=500)
+
+    @field_validator("sku", "warehouse", "bin", "memo", mode="before")
+    @classmethod
+    def _no_formula(cls, v):
+        return _reject_formula_prefix(v)
+
+    @field_validator("qty")
+    @classmethod
+    def _qty_nonzero(cls, v: int) -> int:
+        if v == 0:
+            raise ValueError("qty must be non-zero")
+        return v

--- a/api/schemas/tokens.py
+++ b/api/schemas/tokens.py
@@ -8,10 +8,22 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from middleware.auth_middleware import (
     V150_ENDPOINT_SLUGS,
     V170_INBOUND_RESOURCE_BY_ENDPOINT,
+    V190_DOCKD_SLUG,
+    V1100_POS_SLUG,
 )
 
 
 _INBOUND_RESOURCE_KEYS = frozenset(V170_INBOUND_RESOURCE_BY_ENDPOINT.values())
+
+# Direction-bearing slugs accepted by the create/update token validators.
+# V150 outbound slugs map 1:1 to a Flask endpoint; V190 dockd and V1100
+# POS each cover a 1:N surface under a single slug. Listed together so
+# the validator's "unknown slug" message is honest about every value the
+# auth middleware will actually honor at request time.
+_KNOWN_ENDPOINT_SLUGS = (
+    frozenset(V150_ENDPOINT_SLUGS.keys())
+    | {V190_DOCKD_SLUG, V1100_POS_SLUG}
+)
 
 
 class CreateTokenRequest(BaseModel):
@@ -47,11 +59,11 @@ class CreateTokenRequest(BaseModel):
     @field_validator("endpoints")
     @classmethod
     def _known_slugs_only(cls, v: List[str]) -> List[str]:
-        unknown = sorted({s for s in v if s not in V150_ENDPOINT_SLUGS})
+        unknown = sorted({s for s in v if s not in _KNOWN_ENDPOINT_SLUGS})
         if unknown:
             raise ValueError(
                 f"unknown endpoint slugs: {unknown}. "
-                f"valid: {sorted(V150_ENDPOINT_SLUGS.keys())}"
+                f"valid: {sorted(_KNOWN_ENDPOINT_SLUGS)}"
             )
         return v
 
@@ -134,10 +146,10 @@ class UpdateTokenRequest(BaseModel):
             return v
         if not v:
             raise ValueError("endpoints must be non-empty when provided")
-        unknown = sorted({s for s in v if s not in V150_ENDPOINT_SLUGS})
+        unknown = sorted({s for s in v if s not in _KNOWN_ENDPOINT_SLUGS})
         if unknown:
             raise ValueError(
                 f"unknown endpoint slugs: {unknown}. "
-                f"valid: {sorted(V150_ENDPOINT_SLUGS.keys())}"
+                f"valid: {sorted(_KNOWN_ENDPOINT_SLUGS)}"
             )
         return v

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -744,6 +744,142 @@ class TestCsvImport:
         assert resp.status_code == 400
         assert "5000" in resp.get_json()["error"]
 
+    def test_import_inventory_adjustments_positive_and_negative(self, client, auth_headers):
+        """v1.10.1 #329: bulk inventory adjustments via CSV import.
+
+        Seed has TST-001 with 50 on-hand in bin A-01-01 (warehouse APT-LAB).
+        Apply +5 then -3 to that bin; verify final on-hand = 52,
+        two APPROVED inventory_adjustments rows, and two
+        adjustment.applied events on the integration_events outbox.
+        """
+        before = _query_val(
+            "SELECT inv.quantity_on_hand FROM inventory inv "
+            "JOIN items i ON i.item_id = inv.item_id "
+            "JOIN bins b ON b.bin_id = inv.bin_id "
+            "WHERE i.sku = 'TST-001' AND b.bin_code = 'A-01-01'"
+        )
+        assert before == 50
+
+        resp = client.post(
+            "/api/admin/import/inventory-adjustments",
+            json={
+                "records": [
+                    {"sku": "TST-001", "warehouse": "APT-LAB", "bin": "A-01-01", "qty": 5, "memo": "Found extras"},
+                    {"sku": "TST-001", "warehouse": "APT-LAB", "bin": "A-01-01", "qty": -3, "memo": "Damaged"},
+                ]
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["imported"] == 2
+        assert data["skipped"] == 0
+
+        after = _query_val(
+            "SELECT inv.quantity_on_hand FROM inventory inv "
+            "JOIN items i ON i.item_id = inv.item_id "
+            "JOIN bins b ON b.bin_id = inv.bin_id "
+            "WHERE i.sku = 'TST-001' AND b.bin_code = 'A-01-01'"
+        )
+        assert after == 52
+
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT reason_code, status, quantity_change "
+            "FROM inventory_adjustments ia "
+            "JOIN items i ON i.item_id = ia.item_id "
+            "WHERE i.sku = 'TST-001' "
+            "ORDER BY adjustment_id DESC LIMIT 2"
+        )
+        rows = cur.fetchall()
+        cur.close()
+        assert len(rows) == 2
+        for reason_code, status, _qc in rows:
+            assert reason_code == "CORRECTION"
+            assert status == "APPROVED"
+
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT (payload->>'quantity_delta')::int AS delta "
+            "FROM integration_events "
+            "WHERE event_type = 'adjustment.applied' "
+            "ORDER BY event_id DESC LIMIT 2"
+        )
+        deltas = sorted(r[0] for r in cur.fetchall())
+        cur.close()
+        assert deltas == [-3, 5]
+
+    def test_import_inventory_adjustments_unknown_sku_skips_row(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/import/inventory-adjustments",
+            json={
+                "records": [
+                    {"sku": "NO-SUCH-SKU", "warehouse": "APT-LAB", "bin": "A-01-01", "qty": 1, "memo": ""},
+                ]
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["imported"] == 0
+        assert data["skipped"] == 1
+        assert "Item not found" in data["errors"][0]["error"]
+
+    def test_import_inventory_adjustments_bin_must_belong_to_warehouse(self, client, auth_headers):
+        """A bin code that exists but lives in a different warehouse is
+        rejected with a row-level error, not silently applied to the
+        wrong warehouse."""
+        resp = client.post(
+            "/api/admin/import/inventory-adjustments",
+            json={
+                "records": [
+                    {"sku": "TST-001", "warehouse": "VIRTUAL", "bin": "A-01-01", "qty": 1, "memo": ""},
+                ]
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["imported"] == 0
+        assert data["skipped"] == 1
+        assert "not found in warehouse" in data["errors"][0]["error"]
+
+    def test_import_inventory_adjustments_insufficient_stock_skips_row(self, client, auth_headers):
+        """A negative qty exceeding available on-hand is rejected with
+        a row-level error; the inventory row is not mutated."""
+        resp = client.post(
+            "/api/admin/import/inventory-adjustments",
+            json={
+                "records": [
+                    {"sku": "TST-001", "warehouse": "APT-LAB", "bin": "A-01-01", "qty": -100000, "memo": ""},
+                ]
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["imported"] == 0
+        assert data["skipped"] == 1
+        assert "Insufficient inventory" in data["errors"][0]["error"]
+
+    def test_import_inventory_adjustments_zero_qty_rejected(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/import/inventory-adjustments",
+            json={
+                "records": [
+                    {"sku": "TST-001", "warehouse": "APT-LAB", "bin": "A-01-01", "qty": 0, "memo": ""},
+                ]
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["imported"] == 0
+        assert data["skipped"] == 1
+        assert "qty" in data["errors"][0]["error"]
+
 
 # ── Dashboard Stats ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Patch release on top of the v1.10.0 POS surface. Two operator-experience changes:

- **fix(admin/tokens)**: validator accepts `dockd.dispatch` and `pos.dispatch` so operators can issue dockd/POS tokens through the admin API. Pre-fix, `POST /api/admin/tokens` with `endpoints=['pos.dispatch']` or `['dockd.dispatch']` returned 400 `unknown_endpoint_slugs` even though the auth middleware honored both at request time.
- **feat(inventory)**: new `inventory-adjustments` arm on `POST /api/admin/import/<type>` (#329). CSV columns: `sku`, `warehouse`, `bin`, `qty` (signed), `memo`. Each accepted row auto-approves on import; one `audit_log` row + one `adjustment.applied/1` outbox event per row.

## Commits

- `ec91d2a` -- fix(admin/tokens): accept dockd.dispatch and pos.dispatch in CreateToken/UpdateToken validators
- `9c91434` -- feat(inventory): CSV import for adjustments (Closes #329)
- `9848614` -- chore(release): v1.10.1 CHANGELOG + admin version bumps + lockfile (Closes #334)

## Mobile

Zero mobile/ diffs on this branch. v1.9.0 APK (versionCode 6) remains the working baseline. No new APK build for v1.10.1.

## Pre-merge gate

- [x] CI green
- [x] Manual admin browser sweep
- [x] Chainway C6000 smoke test

## Post-merge

README banner + milestone table catchup + `docs/changelog.md` lands on `main` in a follow-up `docs:` commit matching the v1.10.0 pattern.