### PR TITLE
chore(deps): security bumps + documented pip-audit deferrals

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -47,12 +47,26 @@ jobs:
         # v1.5.1: every v1.4-deferred --ignore-vuln is resolved.
         # cryptography 44 -> 46.0.7 (#59) drops GHSA-r6ph-v2qm-q3c2
         # and GHSA-m959-cc7f-wv43; pytest 8 -> 9 (#60) drops
-        # GHSA-6w46-j5rx-g56g. pip-audit runs with no allowlist.
+        # GHSA-6w46-j5rx-g56g.
+        #
+        # v1.13.0 deferrals (no upstream fix available yet):
+        # - PYSEC-2024-271 (flask-cors): log-injection-when-debug-logging.
+        #   Bumped 6.0.0 -> 6.0.2 (latest) for defense in depth, but OSV
+        #   still flags 6.x. Production runs at INFO log level, so the
+        #   debug-only CRLF injection vector is not reachable. Remove
+        #   when upstream ships a fix.
+        # - PYSEC-2025-183 (pyjwt): vendor-disputed; "key length is
+        #   chosen by the application using the library." Our JWT signing
+        #   secret is generated via secrets.token_urlsafe(>=32), so the
+        #   weak-default-key concern does not apply. Remove when the
+        #   advisory is withdrawn or upstream pins a min-key-length.
         run: |
           pip-audit \
             --requirement api/requirements.txt \
             --strict \
-            --vulnerability-service osv
+            --vulnerability-service osv \
+            --ignore-vuln PYSEC-2024-271 \
+            --ignore-vuln PYSEC-2025-183
 
   npm-audit-admin:
     runs-on: ubuntu-latest

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -3068,9 +3068,9 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
-      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3090,12 +3090,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
-      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,7 +2,7 @@ flask==3.1.3
 flask-cors==6.0.2
 sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
-pyjwt==2.12.0
+pyjwt==2.13.0
 bcrypt==4.2.1
 python-dotenv==1.2.2
 gunicorn==23.0.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,5 @@
 flask==3.1.3
-flask-cors==6.0.0
+flask-cors==6.0.2
 sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
 pyjwt==2.12.0

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1590,16 +1590,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@expo/bunyan/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.5.tgz",
@@ -1806,22 +1796,24 @@
       }
     },
     "node_modules/@expo/eas-build-job": {
-      "version": "18.8.0",
-      "resolved": "https://registry.npmjs.org/@expo/eas-build-job/-/eas-build-job-18.8.0.tgz",
-      "integrity": "sha512-wXZAkU6WtZ+MoZOcqNVs0gKWp+UUlSBobmE9nnkXwmlAsPyWXZ6U64069P6cfw6R5TOJk4otHNyaNr4FW8oqpA==",
+      "version": "18.13.1",
+      "resolved": "https://registry.npmjs.org/@expo/eas-build-job/-/eas-build-job-18.13.1.tgz",
+      "integrity": "sha512-4AA6rulUwhmIE1mtpbfzz7uda8xuMKjuhtueBzh7bvRMx1Ph8vqLkyR6vCD9SGeKcMqJTa2sQsrEfwhqjcBljw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@expo/logger": "18.5.0",
+        "@expo/results": "1.0.0",
+        "@expo/turtle-spawn": "18.5.0",
         "joi": "^17.13.1",
         "semver": "^7.6.2",
         "zod": "^4.3.5"
       }
     },
     "node_modules/@expo/eas-build-job/node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1833,9 +1825,9 @@
       }
     },
     "node_modules/@expo/eas-build-job/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1846,14 +1838,14 @@
       }
     },
     "node_modules/@expo/eas-json": {
-      "version": "18.8.0",
-      "resolved": "https://registry.npmjs.org/@expo/eas-json/-/eas-json-18.8.0.tgz",
-      "integrity": "sha512-3Xx2Nc/PHu5zL6/7rCN9loc+sGq+9ARdSDOAbxvu2tMy7+ktmxp34cGMHcKyUXZx/mW9Fc0JkeidFR3k4TQbSg==",
+      "version": "18.13.1",
+      "resolved": "https://registry.npmjs.org/@expo/eas-json/-/eas-json-18.13.1.tgz",
+      "integrity": "sha512-kbDAiYpwn+n6UjtSFmy0PsFm8caJ4u92GsHuIrtuy+hCzOfPhS+mp1GkSiFDAFmK75iS3x83flwxAMTEnvv9rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.23.5",
-        "@expo/eas-build-job": "18.8.0",
+        "@expo/eas-build-job": "18.13.1",
         "chalk": "4.1.2",
         "env-string": "1.0.1",
         "fs-extra": "11.2.0",
@@ -2018,9 +2010,9 @@
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.4.tgz",
-      "integrity": "sha512-eYlxcrGdR2/j2M6pEDXo9zU9KXXF1vhP+V+Tl+lyY+bU8lnzrN6c637mz6Ye3em2ANy8hhUR03Raf8VsT9Ogng==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.5.tgz",
+      "integrity": "sha512-mdVoAMcux1WlM6kd1RoWiHRNqKqS+J6mKmWQ/BKgeh937S/fcW58EE68O6nc4KDXtWi3PBeNHskOFcgyIuD4hw==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -2030,7 +2022,7 @@
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
         "ignore": "^5.3.1",
-        "minimatch": "^9.0.0",
+        "minimatch": "^10.2.2",
         "p-limit": "^3.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
@@ -2056,18 +2048,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/fingerprint/node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2077,25 +2057,10 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@expo/fingerprint/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2228,9 +2193,9 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "54.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.14.tgz",
-      "integrity": "sha512-hxpLyDfOR4L23tJ9W1IbJJsG7k4lv2sotohBm/kTYyiG+pe1SYCAWsRmgk+H42o/wWf/HQjE5k45S5TomGLxNA==",
+      "version": "54.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
+      "integrity": "sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2238,7 +2203,7 @@
         "@babel/generator": "^7.20.5",
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8",
-        "@expo/json-file": "~10.0.8",
+        "@expo/json-file": "~10.0.16",
         "@expo/metro": "~54.2.0",
         "@expo/spawn-async": "^1.7.2",
         "browserslist": "^4.25.0",
@@ -2251,7 +2216,7 @@
         "hermes-parser": "^0.29.1",
         "jsc-safe-url": "^0.2.4",
         "lightningcss": "^1.30.1",
-        "minimatch": "^9.0.0",
+        "picomatch": "^4.0.3",
         "postcss": "~8.4.32",
         "resolve-from": "^5.0.0"
       },
@@ -2336,19 +2301,28 @@
       }
     },
     "node_modules/@expo/metro-config/node_modules/@expo/json-file": {
-      "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
-      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.20.0",
+        "@babel/code-frame": "~7.10.4",
         "json5": "^2.2.3"
       }
     },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
     "node_modules/@expo/metro-config/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -2385,18 +2359,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@expo/metro-config/node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/metro-config/node_modules/hermes-estree": {
       "version": "0.29.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
@@ -2412,25 +2374,22 @@
         "hermes-estree": "0.29.1"
       }
     },
-    "node_modules/@expo/metro-config/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
+    "node_modules/@expo/metro-config/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@expo/metro-config/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3108,9 +3067,9 @@
       }
     },
     "node_modules/@expo/require-utils": {
-      "version": "55.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.4.tgz",
-      "integrity": "sha512-JAANvXqV7MOysWeVWgaiDzikoyDjJWOV/ulOW60Zb3kXJfrx2oZOtGtDXDFKD1mXuahQgoM5QOjuZhF7gFRNjA==",
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.5.tgz",
+      "integrity": "sha512-U4K/CQ2VpXuwfNGsN+daKmYOt15hCP8v/pXaYH6eut7kdYZo6SfJ1yr67BIcJ+1Gzzs+QzTxswAZChKpXmceyw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -3155,16 +3114,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@expo/rudder-sdk-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@expo/schema-utils": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.8.tgz",
@@ -3190,13 +3139,13 @@
       }
     },
     "node_modules/@expo/steps": {
-      "version": "18.8.0",
-      "resolved": "https://registry.npmjs.org/@expo/steps/-/steps-18.8.0.tgz",
-      "integrity": "sha512-Q/TjLLI+pXN/stS43+7KSedgKppPO9W4m2eCTg/7nU0DMlryaeL0qRr21YHO0jQQt5S3raKlFNX4SYEqkZIHbA==",
+      "version": "18.13.1",
+      "resolved": "https://registry.npmjs.org/@expo/steps/-/steps-18.13.1.tgz",
+      "integrity": "sha512-V3ush+Jq23qd0ExOvRwTuBJ/HV717il6VMdANapWoM1hUWhyKsNypaF6DMKYejawnGClddrrGO8hNeQ7NfYgKw==",
       "dev": true,
       "license": "BUSL-1.1",
       "dependencies": {
-        "@expo/eas-build-job": "18.8.0",
+        "@expo/eas-build-job": "18.13.1",
         "@expo/logger": "18.5.0",
         "@expo/spawn-async": "^1.7.2",
         "arg": "^5.0.2",
@@ -3213,9 +3162,9 @@
       }
     },
     "node_modules/@expo/steps/node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3224,6 +3173,21 @@
         "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/@expo/steps/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@expo/sudo-prompt": {
@@ -3238,6 +3202,17 @@
       "integrity": "sha512-PD45CGlCL8kG0U3YcH1NvYxQThw5XAS7qE9bgP4L7dakm8lsMz+p8BQ1IjBFMmImawVWsV3py6JZINaEebXLnw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@expo/turtle-spawn": {
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/@expo/turtle-spawn/-/turtle-spawn-18.5.0.tgz",
+      "integrity": "sha512-ZVDlE/GyuGJBzkSOrnbNWIAcPrtOuDybrMNvBLO8kTIQXZhHjsHn8c4kcG29JyI/er+9J+15OoaEtUAYQw+S3g==",
+      "dev": true,
+      "license": "BUSL-1.1",
+      "dependencies": {
+        "@expo/logger": "18.5.0",
+        "@expo/spawn-async": "^1.7.2"
+      }
     },
     "node_modules/@expo/vector-icons": {
       "version": "15.1.1",
@@ -3257,9 +3232,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/xcpretty": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.3.tgz",
-      "integrity": "sha512-wC562eD3gS6vO2tWHToFhlFnmHKfKHgF1oyvojeSkLK/ZYop1bMU+7cOMiF9Sq70CzcsLy/EMRy/uRc76QmNRw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz",
+      "integrity": "sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -3277,9 +3252,19 @@
       "license": "Python-2.0"
     },
     "node_modules/@expo/xcpretty/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3728,9 +3713,9 @@
       }
     },
     "node_modules/@oclif/core/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6376,9 +6361,9 @@
       }
     },
     "node_modules/eas-cli": {
-      "version": "18.8.1",
-      "resolved": "https://registry.npmjs.org/eas-cli/-/eas-cli-18.8.1.tgz",
-      "integrity": "sha512-C3U2qDj1yKt7Xztx9wBBT5on8w9dIzxpbpGO3qZ9tK58QiHAo3mKIgS5IujzY3r/K2VuAq6zZc9g3zhAgOkL3Q==",
+      "version": "18.13.1",
+      "resolved": "https://registry.npmjs.org/eas-cli/-/eas-cli-18.13.1.tgz",
+      "integrity": "sha512-OlusTcdrjfpIKsieU7JXYKugXTBOklfPj56ySYTJiZBnIWV+EtwXHAL13h5RTu+I7qMAK2ZbcBYk6ig4TZWe5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6386,8 +6371,8 @@
         "@expo/code-signing-certificates": "0.0.5",
         "@expo/config": "55.0.10",
         "@expo/config-plugins": "55.0.7",
-        "@expo/eas-build-job": "18.8.0",
-        "@expo/eas-json": "18.8.0",
+        "@expo/eas-build-job": "18.13.1",
+        "@expo/eas-json": "18.13.1",
         "@expo/env": "^1.0.0",
         "@expo/json-file": "8.3.3",
         "@expo/logger": "18.5.0",
@@ -6402,7 +6387,7 @@
         "@expo/results": "1.0.0",
         "@expo/rudder-sdk-node": "1.1.1",
         "@expo/spawn-async": "1.7.2",
-        "@expo/steps": "18.8.0",
+        "@expo/steps": "18.13.1",
         "@expo/timeago.js": "1.0.0",
         "@oclif/core": "^4.8.3",
         "@oclif/plugin-autocomplete": "^3.2.40",
@@ -6417,6 +6402,7 @@
         "chalk": "4.1.2",
         "cli-progress": "3.12.0",
         "dateformat": "4.6.3",
+        "debug": "4.4.3",
         "diff": "7.0.0",
         "dotenv": "16.3.1",
         "env-paths": "2.2.0",
@@ -6569,6 +6555,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eas-cli/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/eas-cli/node_modules/yallist": {
@@ -6844,29 +6845,29 @@
       }
     },
     "node_modules/expo": {
-      "version": "54.0.33",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
-      "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
+      "version": "54.0.35",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.35.tgz",
+      "integrity": "sha512-E+tXpQwjGm5fK/uwa55p0Xx/kuo5dXDKfVJ95IargTNa5KiFt26lSTXXa9KnHbI4EDLwFD38/xTKZvzPTlGTdg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.23",
+        "@expo/cli": "54.0.25",
         "@expo/config": "~12.0.13",
         "@expo/config-plugins": "~54.0.4",
         "@expo/devtools": "0.1.8",
-        "@expo/fingerprint": "0.15.4",
+        "@expo/fingerprint": "0.15.5",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "54.0.14",
+        "@expo/metro-config": "54.0.16",
         "@expo/vector-icons": "^15.0.3",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~54.0.10",
-        "expo-asset": "~12.0.12",
+        "babel-preset-expo": "~54.0.11",
+        "expo-asset": "~12.0.13",
         "expo-constants": "~18.0.13",
-        "expo-file-system": "~19.0.21",
-        "expo-font": "~14.0.11",
+        "expo-file-system": "~19.0.23",
+        "expo-font": "~14.0.12",
         "expo-keep-awake": "~15.0.8",
-        "expo-modules-autolinking": "3.0.24",
-        "expo-modules-core": "3.0.29",
+        "expo-modules-autolinking": "3.0.26",
+        "expo-modules-core": "3.0.30",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -6896,13 +6897,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "12.0.12",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
-      "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
+      "integrity": "sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.8.8",
-        "expo-constants": "~18.0.12"
+        "expo-constants": "~18.0.13"
       },
       "peerDependencies": {
         "expo": "*",
@@ -7108,9 +7109,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "19.0.21",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
-      "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
+      "version": "19.0.23",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.23.tgz",
+      "integrity": "sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -7118,9 +7119,9 @@
       }
     },
     "node_modules/expo-font": {
-      "version": "14.0.11",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
-      "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
+      "version": "14.0.12",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
+      "integrity": "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ==",
       "license": "MIT",
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
@@ -7142,9 +7143,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
-      "integrity": "sha512-TP+6HTwhL7orDvsz2VzauyQlXJcAWyU3ANsZ7JGL4DQu8XaZv/A41ZchbtAYLfozNA2Ya1Hzmhx65hXryBMjaQ==",
+      "version": "3.0.26",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.26.tgz",
+      "integrity": "sha512-WOaud6UKg16ciCOj8raKcMOoKFMHLXKI29U29yhgu1lf+Y7VxJyCktUcYo6AM+ccZ7zLD1uWZdMtgnpf+95OXA==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -7158,9 +7159,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "3.0.29",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.29.tgz",
-      "integrity": "sha512-LzipcjGqk8gvkrOUf7O2mejNWugPkf3lmd9GkqL9WuNyeN2fRwU0Dn77e3ZUKI3k6sI+DNwjkq4Nu9fNN9WS7Q==",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.30.tgz",
+      "integrity": "sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
@@ -7180,36 +7181,36 @@
       }
     },
     "node_modules/expo-server": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.5.tgz",
-      "integrity": "sha512-IGR++flYH70rhLyeXF0Phle56/k4cee87WeQ4mamS+MkVAVP+dDlOHf2nN06Z9Y2KhU0Gp1k+y61KkghF7HdhA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.7.tgz",
+      "integrity": "sha512-mcmyML3oXcqFUXUxtdtCL1O00ztNI2v76d+MdniXRUgHNxIcHZ05zo+DqBaOOT6LQnPk4vA4YHqQl7iGUfRb3g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
       }
     },
     "node_modules/expo-splash-screen": {
-      "version": "55.0.18",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-55.0.18.tgz",
-      "integrity": "sha512-5+sA2L2e0v7GVWl2+j24lSNnC39HtycCCtJXHiC2N+voWLtZp0qMLAKZY/1vhkzjYzDzfkUcZiRzkdhwT9x+2Q==",
+      "version": "55.0.21",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-55.0.21.tgz",
+      "integrity": "sha512-hFGEap69ggCckbHIdDXMe5rqfBR9TwcnY5gBhyaACUxU64w827T6prOQcIvLmAdv00kp3Gqt7hgE+mNn37EF+A==",
       "license": "MIT",
       "dependencies": {
-        "@expo/prebuild-config": "^55.0.15"
+        "@expo/prebuild-config": "^55.0.18"
       },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-splash-screen/node_modules/@expo/config": {
-      "version": "55.0.15",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.15.tgz",
-      "integrity": "sha512-lHc0ELIQ8126jYOMZpLv3WIuvordW98jFg5aT/J1/12n2ycuXu01XLZkJsdw0avO34cusUYb1It+MvY8JiMduA==",
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.17.tgz",
+      "integrity": "sha512-Y3VaRg7Jllg3MhlUOTQqHm6/dttsqcjYlnS9enhAllZvPUpTHnRA4YPETtUZlxkdMJy6y3UZe986pd/KfJ6OTg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~55.0.8",
+        "@expo/config-plugins": "~55.0.9",
         "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "^10.0.13",
-        "@expo/require-utils": "^55.0.4",
+        "@expo/json-file": "^10.0.14",
+        "@expo/require-utils": "^55.0.5",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -7219,14 +7220,14 @@
       }
     },
     "node_modules/expo-splash-screen/node_modules/@expo/config-plugins": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
-      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
+      "version": "55.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.10.tgz",
+      "integrity": "sha512-1txnRnMLIO5lM/Of/VyvDkCwZap0YFvCyfSTIlUQamhwhx6Rh7r8TXfcIstaDYUQ7X6GTMkNxLXWbcYS6ZAFDw==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "~10.0.13",
-        "@expo/plist": "^0.5.2",
+        "@expo/json-file": "~10.0.15",
+        "@expo/plist": "^0.5.4",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
@@ -7239,13 +7240,32 @@
         "xml2js": "0.6.0"
       }
     },
-    "node_modules/expo-splash-screen/node_modules/@expo/image-utils": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.13.tgz",
-      "integrity": "sha512-1I//yBQeTY6p0u1ihqGNDAr35EbSG8uFEupFrIF0jd++h9EWH33521yZJU1yE+mwGlzCb61g3ehu78siMhXBlA==",
+    "node_modules/expo-splash-screen/node_modules/@expo/config-plugins/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/require-utils": "^55.0.4",
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo-splash-screen/node_modules/@expo/config-plugins/node_modules/@expo/json-file": {
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/expo-splash-screen/node_modules/@expo/image-utils": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.14.tgz",
+      "integrity": "sha512-5Sn+jG4Cw+shC2wDMXoqSAJnvERbiwzHn05FpWtD5IBflfTIs5gUmjzwiGVyjOdlMSQhgRrw/AymPbmO9h9mpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/require-utils": "^55.0.5",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
@@ -7255,9 +7275,9 @@
       }
     },
     "node_modules/expo-splash-screen/node_modules/@expo/json-file": {
-      "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
-      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
+      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -7265,9 +7285,9 @@
       }
     },
     "node_modules/expo-splash-screen/node_modules/@expo/plist": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
-      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.4.tgz",
+      "integrity": "sha512-Jqppj0FULNq6Zp5JtQrFICl8TtpMjwwUbxEcEC2T3z7m+TOrTQEHZXz3D3Ay7vhbmvD+VMgfWJ4ARclJXeN8Eg==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -7276,17 +7296,17 @@
       }
     },
     "node_modules/expo-splash-screen/node_modules/@expo/prebuild-config": {
-      "version": "55.0.15",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-55.0.15.tgz",
-      "integrity": "sha512-UcCzVhVBE42UbY5U3t/q1Rk2fSFW/B50LJpB6oFpXhImJfvLKu7ayOFU9XcHd38K89i4GqSia/xXuxQvu4RUBg==",
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-55.0.18.tgz",
+      "integrity": "sha512-2oKXyy5pyM87DJqXW5Z+Sakle6rApFFtpPhWOiNsOdoh6rOAD+EqVgyrs2OEEic8CE0tTt27w3SRfSZe/PZrxg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~55.0.15",
-        "@expo/config-plugins": "~55.0.8",
+        "@expo/config": "~55.0.17",
+        "@expo/config-plugins": "~55.0.9",
         "@expo/config-types": "^55.0.5",
-        "@expo/image-utils": "^0.8.13",
-        "@expo/json-file": "^10.0.13",
-        "@react-native/normalize-colors": "0.83.4",
+        "@expo/image-utils": "^0.8.14",
+        "@expo/json-file": "^10.0.14",
+        "@react-native/normalize-colors": "0.83.6",
         "debug": "^4.3.1",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0",
@@ -7297,9 +7317,9 @@
       }
     },
     "node_modules/expo-splash-screen/node_modules/@react-native/normalize-colors": {
-      "version": "0.83.4",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.83.4.tgz",
-      "integrity": "sha512-9ezxaHjxqTkTOLg62SGg7YhFaE+fxa/jlrWP0nwf7eGFHlGOiTAaRR2KUfiN3K05e+EMbEhgcH/c7bgaXeGyJw==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.83.6.tgz",
+      "integrity": "sha512-bTM24b5v4qN3h52oflnv+OujFORn/kVi06WaWhnQQw14/ycilPqIsqsa+DpIBqdBrXxvLa9fXtCRrQtGATZCEw==",
       "license": "MIT"
     },
     "node_modules/expo-splash-screen/node_modules/glob": {
@@ -7320,9 +7340,9 @@
       }
     },
     "node_modules/expo-splash-screen/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7354,9 +7374,9 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "54.0.23",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.23.tgz",
-      "integrity": "sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==",
+      "version": "54.0.25",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
+      "integrity": "sha512-WnUqIb8oMBhtwSfIqdCHCzcaDIpLNXItRVd5miuvWi4GO0SGo89PSsAkbVJ+LJgcaY+v5rbgMELJS9I/CqOulA==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
@@ -7366,12 +7386,12 @@
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.0.8",
         "@expo/image-utils": "^0.8.8",
-        "@expo/json-file": "^10.0.8",
+        "@expo/json-file": "^10.0.16",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "~54.0.14",
+        "@expo/metro-config": "~54.0.16",
         "@expo/osascript": "^2.3.8",
         "@expo/package-manager": "^1.9.10",
-        "@expo/plist": "^0.4.8",
+        "@expo/plist": "^0.4.9",
         "@expo/prebuild-config": "^54.0.8",
         "@expo/schema-utils": "^0.1.8",
         "@expo/spawn-async": "^1.7.2",
@@ -7391,16 +7411,16 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
-        "expo-server": "^1.0.5",
+        "expo-server": "^1.0.7",
         "freeport-async": "^2.0.0",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
-        "lan-network": "^0.1.6",
+        "lan-network": "^0.2.1",
         "minimatch": "^9.0.0",
         "node-forge": "^1.3.3",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
-        "picomatch": "^3.0.1",
+        "picomatch": "^4.0.3",
         "pretty-bytes": "^5.6.0",
         "pretty-format": "^29.7.0",
         "progress": "^2.0.3",
@@ -7492,6 +7512,25 @@
         "xml2js": "0.6.0"
       }
     },
+    "node_modules/expo/node_modules/@expo/config-plugins/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo/node_modules/@expo/config-plugins/node_modules/@expo/json-file": {
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
     "node_modules/expo/node_modules/@expo/config-types": {
       "version": "54.0.10",
       "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
@@ -7521,12 +7560,12 @@
       }
     },
     "node_modules/expo/node_modules/@expo/image-utils": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.13.tgz",
-      "integrity": "sha512-1I//yBQeTY6p0u1ihqGNDAr35EbSG8uFEupFrIF0jd++h9EWH33521yZJU1yE+mwGlzCb61g3ehu78siMhXBlA==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.14.tgz",
+      "integrity": "sha512-5Sn+jG4Cw+shC2wDMXoqSAJnvERbiwzHn05FpWtD5IBflfTIs5gUmjzwiGVyjOdlMSQhgRrw/AymPbmO9h9mpQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/require-utils": "^55.0.4",
+        "@expo/require-utils": "^55.0.5",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
@@ -7536,9 +7575,9 @@
       }
     },
     "node_modules/expo/node_modules/@expo/json-file": {
-      "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
-      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
+      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -7546,21 +7585,21 @@
       }
     },
     "node_modules/expo/node_modules/@expo/osascript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.4.2.tgz",
-      "integrity": "sha512-/XP7PSYF2hzOZzqfjgkoWtllyeTN8dW3aM4P6YgKcmmPikKL5FdoyQhti4eh6RK5a5VrUXJTOlTNIpIHsfB5Iw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.6.0.tgz",
+      "integrity": "sha512-QvqDBlJXa8CS2vRORJ4wEflY1m0vVI07uSJdIRgBrLxRPBcsrXxrtU7+wXRXMqfq9zLwNP9XbvRsXF2omoDylg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/spawn-async": "^1.7.2"
+        "@expo/spawn-async": "^1.8.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/expo/node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -7587,6 +7626,18 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo/node_modules/@expo/spawn-async": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
+      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/expo/node_modules/@react-native/babel-plugin-codegen": {
@@ -7763,9 +7814,9 @@
       }
     },
     "node_modules/expo/node_modules/babel-preset-expo": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.10.tgz",
-      "integrity": "sha512-wTt7POavLFypLcPW/uC5v8y+mtQKDJiyGLzYCjqr9tx0Qc3vCXcDKk1iCFIj/++Iy5CWhhTflEa7VvVPNWeCfw==",
+      "version": "54.0.11",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.11.tgz",
+      "integrity": "sha512-dEpeFDtYEFzmWtWVwvt7sUCZH0fxXPfbJlgXd7XNZSQDa/Ki/hTOj9exMTzqR2oyPHDNcE9VxYCJ4oS6xw4Pjg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
@@ -7988,12 +8039,12 @@
       }
     },
     "node_modules/expo/node_modules/picomatch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
-      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -8030,9 +8081,9 @@
       }
     },
     "node_modules/expo/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8066,9 +8117,9 @@
       }
     },
     "node_modules/expo/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9408,9 +9459,9 @@
       }
     },
     "node_modules/lan-network": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.1.7.tgz",
-      "integrity": "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.2.1.tgz",
+      "integrity": "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==",
       "license": "MIT",
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
@@ -10404,9 +10455,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
       "dev": true,
       "license": "MIT",
       "optional": true
@@ -12030,9 +12081,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12857,9 +12908,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -13021,14 +13072,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -13622,9 +13670,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {


### PR DESCRIPTION
## Summary

Dependency bumps clearing the gating pip-audit job, two HIGH npm advisories in the admin tree, and the shell-quote critical that landed in the mobile tree on 2026-06-12:

- `3be99e5` -- flask-cors 6.0.0 -> 6.0.2 (latest available), plus inline pip-audit deferrals for PYSEC-2024-271 (CRLF log injection reachable only under debug logging; production runs at INFO and above) and PYSEC-2025-183 (vendor-disputed pyjwt key-length advisory; our signing key is generated via `secrets.token_urlsafe(>=32)`). Both deferrals are spelled out in audit.yml with rationale and removal criteria, per the existing workflow convention.
- `f90776a` -- pyjwt 2.12.0 -> 2.13.0.
- `b495d4a` -- react-router + react-router-dom to 7.17.0, the latest patched 7.x, clearing two HIGH advisories. In-range under the existing `^7.14.0` caret; lockfile updated top-level and self-reference.
- `5617670` -- mobile lockfile-only `npm audit fix` clearing shell-quote <=1.8.3 (GHSA-w7jw-789q-3m8p, critical, reachable through the expo prebuild chain), the single high+ finding gating npm-audit-mobile / npm-audit-mobile-dev. Remaining mobile findings are moderate/low and below the gate level.

## Mobile

`mobile/package-lock.json` only -- in-range transitive bumps from `npm audit fix`; `mobile/package.json` pins and carets unchanged. No mobile source diffs, no APK implications.

## Pre-merge gate

- [x] Full api suite + admin vitest green locally on this branch
- [x] Both mobile audit commands pass locally (`npm audit --omit=dev --audit-level=high`, `npm audit --audit-level=high`)
- [ ] CI green
