### PR TITLE
fix(db): pick line FKs move to ON DELETE SET NULL

### DIFF
--- a/db/migrations/058_pick_tasks_line_fk_set_null.sql
+++ b/db/migrations/058_pick_tasks_line_fk_set_null.sql
@@ -1,0 +1,67 @@
+-- 058: pick_tasks.{so_line_id, to_line_id} FK -> ON DELETE SET NULL.
+--
+-- pick_tasks are durable audit records of physical pick events
+-- (item / bin / qty / who / when / status). The line-level FKs were
+-- created with the PostgreSQL default ON DELETE NO ACTION (RESTRICT),
+-- which meant any code path that deleted a sales_order_lines or
+-- transfer_order_lines row would fail if any pick_task in any status
+-- still pointed at it. Two real paths hit this:
+--
+--   * Partial fulfillment (upcoming) shrinks a line to zero by DELETE
+--     sales_order_lines. Validation keeps the obvious case
+--     (fully-picked line) from getting to the DELETE, but any
+--     pick_task left behind in SHORT / SKIPPED state still blocks
+--     the DELETE with an FK violation.
+--   * Future delete-line code paths inherit the same footgun: forget
+--     to clean up historical pick_tasks first, and the DELETE 409s.
+--
+-- ON DELETE SET NULL expresses the actual semantic at the schema
+-- level: the pick_task survives line deletion as a free-standing
+-- audit row, only the line pointer goes NULL. The pick_task keeps
+-- pick_task_id, batch_id, so_id (still required by the target_xor
+-- check), item_id, bin_id, quantity_to_pick, quantity_picked,
+-- status, picked_by, picked_at, scan_confirmed -- which is the full
+-- value of the audit record. The line pointer was only meaningful
+-- while the line existed.
+--
+-- Scope: so_line_id and to_line_id only. batch_id / so_id / to_id /
+-- bin_id / item_id stay RESTRICT because:
+--   * batch_id / so_id / to_id are parent-aggregate references; the
+--     parents are not hard-deleted in normal operation (cancel
+--     leaves the row, only flips status).
+--   * bin_id / item_id losing their references would destroy the
+--     audit value (the record IS "I picked X units of item Y from
+--     bin Z"; nulling either makes the row meaningless).
+--
+-- Data safety: this migration does not touch any pick_tasks rows.
+-- It only changes what the DB does on a future sales_order_lines or
+-- transfer_order_lines DELETE. Existing pick_tasks with valid line
+-- pointers stay exactly as they are. Rollback (re-add the original
+-- FK with default RESTRICT) is safe because any pick_tasks with
+-- NULL so_line_id / to_line_id from intervening DELETEs are still
+-- valid under RESTRICT (RESTRICT only blocks parent-row DELETEs
+-- that would orphan a non-NULL reference).
+--
+-- v1.8.0 migration discipline (V-213): SET lock_timeout /
+-- statement_timeout, BEGIN/COMMIT-wrapped. The DROP + ADD on a
+-- single FK is fast: it acquires ACCESS EXCLUSIVE on pick_tasks
+-- briefly, no full-table scan, no row rewrite.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+ALTER TABLE pick_tasks
+    DROP CONSTRAINT pick_tasks_so_line_id_fkey,
+    ADD CONSTRAINT pick_tasks_so_line_id_fkey
+        FOREIGN KEY (so_line_id) REFERENCES sales_order_lines(so_line_id)
+        ON DELETE SET NULL;
+
+ALTER TABLE pick_tasks
+    DROP CONSTRAINT pick_tasks_to_line_id_fkey,
+    ADD CONSTRAINT pick_tasks_to_line_id_fkey
+        FOREIGN KEY (to_line_id) REFERENCES transfer_order_lines(to_line_id)
+        ON DELETE SET NULL;
+
+COMMIT;

--- a/db/migrations/059_wave_pick_breakdown_line_fk_set_null.sql
+++ b/db/migrations/059_wave_pick_breakdown_line_fk_set_null.sql
@@ -1,0 +1,52 @@
+-- 059: wave_pick_breakdown.so_line_id FK -> ON DELETE SET NULL.
+--
+-- Companion to mig 058 (pick_tasks.{so_line_id,to_line_id} -> SET NULL).
+-- That migration moved pick_tasks off RESTRICT so a line delete can
+-- remove a sales_order_lines row without first scrubbing every
+-- historical pick_task. wave_pick_breakdown has the same shape -- a
+-- per-SO audit row referencing sales_order_lines(so_line_id) with the
+-- default-RESTRICT FK. Real symptom observed in production:
+--
+--     IntegrityError ... constraint=wave_pick_breakdown_so_line_id_fkey
+--     detail=Key (so_line_id)=(4871) is still referenced from table
+--     "wave_pick_breakdown"
+--
+-- Reproduction: admin Edit modal -> Release picked quantities (clears
+-- pending pick_tasks via _release_so_line_allocation) -> click "X" to
+-- delete the line. The DELETE on sales_order_lines fires inside the
+-- update_sales_order_line / delete_sales_order_line handler and is
+-- blocked by the wave_pick_breakdown FK.
+--
+-- Why SET NULL (not CASCADE): wave_pick_breakdown is an in-progress
+-- pick-wave breakdown that doubles as audit. Keeping the row with
+-- quantity / quantity_picked / short_quantity intact (with so_line_id
+-- now NULL) preserves the wave-side audit trail when the SO line is
+-- deleted under it -- same trade-off mig 058 makes for pick_tasks.
+--
+-- The NOT NULL on so_line_id must be dropped before SET NULL can fire;
+-- DROP NOT NULL is metadata-only in PG (no table rewrite).
+--
+-- Data safety: this migration touches NO wave_pick_breakdown rows.
+-- It only changes what the DB does on a future sales_order_lines DELETE.
+-- Existing rows with valid so_line_id stay exactly as they are.
+--
+-- v1.8.0 migration discipline (V-213): SET lock_timeout /
+-- statement_timeout, BEGIN/COMMIT-wrapped. The DROP+ADD on a single
+-- FK + DROP NOT NULL on one column are fast: ACCESS EXCLUSIVE on
+-- wave_pick_breakdown briefly, no scan, no row rewrite.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+ALTER TABLE wave_pick_breakdown
+    ALTER COLUMN so_line_id DROP NOT NULL;
+
+ALTER TABLE wave_pick_breakdown
+    DROP CONSTRAINT IF EXISTS wave_pick_breakdown_so_line_id_fkey,
+    ADD CONSTRAINT wave_pick_breakdown_so_line_id_fkey
+        FOREIGN KEY (so_line_id) REFERENCES sales_order_lines(so_line_id)
+        ON DELETE SET NULL;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -332,11 +332,17 @@ CREATE TABLE wave_pick_orders (
 CREATE INDEX ix_wave_pick_orders_batch ON wave_pick_orders(batch_id);
 
 -- Wave picking: per-SO breakdown for combined pick tasks
+--
+-- mig 059 dropped NOT NULL on so_line_id and switched the FK to
+-- ON DELETE SET NULL (mirrors mig 058's pick_tasks treatment). The
+-- breakdown survives as a free-standing wave-audit row when its SO
+-- line is later deleted, keeping
+-- quantity / quantity_picked / short_quantity intact.
 CREATE TABLE wave_pick_breakdown (
     id SERIAL PRIMARY KEY,
     pick_task_id INTEGER NOT NULL REFERENCES pick_tasks(pick_task_id),
     so_id INTEGER NOT NULL REFERENCES sales_orders(so_id),
-    so_line_id INTEGER NOT NULL REFERENCES sales_order_lines(so_line_id),
+    so_line_id INTEGER REFERENCES sales_order_lines(so_line_id) ON DELETE SET NULL,
     quantity INTEGER NOT NULL,
     quantity_picked INTEGER DEFAULT 0,
     short_quantity INTEGER DEFAULT 0

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -298,7 +298,14 @@ CREATE TABLE pick_tasks (
     pick_task_id SERIAL PRIMARY KEY,
     batch_id INT NOT NULL REFERENCES pick_batches(batch_id),
     so_id INT NOT NULL REFERENCES sales_orders(so_id),
-    so_line_id INT NOT NULL REFERENCES sales_order_lines(so_line_id),
+    -- mig 049 dropped NOT NULL when transfer-order picks were added
+    -- (so_line_id / to_line_id are XOR via pick_tasks_target_xor).
+    -- mig 058 added ON DELETE SET NULL so pick_tasks survive as
+    -- free-standing audit rows when a sales_order_line is deleted
+    -- (partial-fulfill shrink-to-zero, line removal, etc.). The
+    -- audit kernel (item, bin, qty, picked_by/at, status) stays
+    -- intact; only the line pointer goes NULL.
+    so_line_id INT REFERENCES sales_order_lines(so_line_id) ON DELETE SET NULL,
     item_id INT NOT NULL REFERENCES items(item_id),
     bin_id INT NOT NULL REFERENCES bins(bin_id),
     quantity_to_pick INT NOT NULL,
@@ -1868,9 +1875,13 @@ ALTER TABLE pick_tasks
     ALTER COLUMN so_id DROP NOT NULL,
     ALTER COLUMN so_line_id DROP NOT NULL;
 
+-- to_line_id mirrors so_line_id's ON DELETE SET NULL (mig 058) so a
+-- transfer-order line deletion does not block on historical
+-- pick_tasks. The pick_task audit survives; only the line pointer
+-- goes NULL.
 ALTER TABLE pick_tasks
     ADD COLUMN to_id      INT REFERENCES transfer_orders(to_id),
-    ADD COLUMN to_line_id INT REFERENCES transfer_order_lines(to_line_id);
+    ADD COLUMN to_line_id INT REFERENCES transfer_order_lines(to_line_id) ON DELETE SET NULL;
 
 CREATE INDEX ix_pick_tasks_to      ON pick_tasks(to_id);
 CREATE INDEX ix_pick_tasks_to_line ON pick_tasks(to_line_id);


### PR DESCRIPTION
## Summary

Two FK migrations moving line-level pick bookkeeping off default-RESTRICT, so a future DELETE on sales_order_lines cannot be blocked by historical pick records:

- `110e013` -- pick_tasks.{so_line_id, to_line_id} -> ON DELETE SET NULL (migration 058). pick_tasks are durable audit records of physical events; the audit kernel survives line deletion with only the line pointer going NULL. so_id / to_id / bin_id / item_id stay RESTRICT. schema.sql also realigned with the post-mig-049 nullable column state.
- `14b7e39` -- wave_pick_breakdown.so_line_id likewise (migration 059); same shape, same audit semantics, same SET-NULL-over-CASCADE trade.

Neither migration touches rows.

## Mobile

Zero mobile/ diffs.

## Pre-merge gate

- [x] Picking/wave suites green locally against the migrated schema
- [ ] CI green
