### PR TITLE
fix(putaway): accept PickableStaging bins as putaway sources

### DIFF
--- a/api/routes/putaway.py
+++ b/api/routes/putaway.py
@@ -13,7 +13,7 @@ from middleware.db import with_db
 from schemas.putaway import ConfirmPutawayRequest, UpdatePreferredRequest
 from services.audit_service import write_audit_log
 from services.inventory_service import move_inventory
-from constants import ACTION_PUTAWAY, BIN_STAGING
+from constants import ACTION_PUTAWAY, BIN_STAGING, BIN_PICKABLE_STAGING
 from utils.validation import validate_body
 
 putaway_bp = Blueprint("putaway", __name__)
@@ -27,6 +27,10 @@ def pending_putaway(warehouse_id):
     if not ok:
         return denied
 
+    # Putaway sources include both pure Staging bins and PickableStaging
+    # bins -- the latter serve receive flows that stage trays before
+    # putaway while remaining Pickable for sales-pick concurrency.
+    # Mirrors the receive screen's set in mobile/src/screens/ReceiveScreen.js.
     rows = g.db.execute(
         text(
             """
@@ -36,12 +40,16 @@ def pending_putaway(warehouse_id):
             FROM inventory inv
             JOIN items i ON i.item_id = inv.item_id
             JOIN bins b ON b.bin_id = inv.bin_id
-            WHERE b.bin_type = :bin_staging
+            WHERE b.bin_type IN (:bin_staging, :bin_pickable_staging)
               AND inv.quantity_on_hand > 0
               AND inv.warehouse_id = :warehouse_id
             """
         ),
-        {"warehouse_id": warehouse_id, "bin_staging": BIN_STAGING},
+        {
+            "warehouse_id": warehouse_id,
+            "bin_staging": BIN_STAGING,
+            "bin_pickable_staging": BIN_PICKABLE_STAGING,
+        },
     ).fetchall()
 
     return jsonify({

--- a/mobile/src/screens/PutAwayScreen.js
+++ b/mobile/src/screens/PutAwayScreen.js
@@ -42,12 +42,14 @@ export default function PutAwayScreen({ navigation }) {
   // --- Load Phase ---
 
   const handleScanItem = async (barcode) => {
-    // Check for staging bin scan first
+    // Check for staging bin scan first.
+    // Both 'Staging' and 'PickableStaging' bin types are valid putaway
+    // sources -- mirrors ReceiveScreen.js which accepts the same set.
     try {
       const binResp = await client.get(`/api/lookup/bin/${encodeURIComponent(barcode)}`);
       if (binResp.data?.bin) {
         const bin = binResp.data.bin;
-        if (bin.bin_type === 'Staging') {
+        if (bin.bin_type === 'Staging' || bin.bin_type === 'PickableStaging') {
           // Load all items from this staging bin
           const items = binResp.data.items || [];
           if (items.length === 0) {
@@ -89,7 +91,7 @@ export default function PutAwayScreen({ navigation }) {
       const scannedItem = itemResp.data.item;
       const locations = itemResp.data.locations || [];
       const stagingLoc = locations.find(
-        (l) => l.bin_type === 'Staging'
+        (l) => l.bin_type === 'Staging' || l.bin_type === 'PickableStaging'
       );
 
       if (!stagingLoc) {


### PR DESCRIPTION
## Summary

- `cae51d0` -- the put-away pending queue and the handheld put-away screen only accepted 'Staging' bins as sources, while the receive screen already accepts both 'Staging' and 'PickableStaging'. Items received into PickableStaging bins (tray-staging flows that stay sales-pickable) were invisible to the handheld put-away flow. `pending_putaway()` extends its bin_type filter to IN ('Staging','PickableStaging'); the mobile bin-scan handler and item-scan staging detector accept both. Server change is backward-compatible: existing Staging bins surface unchanged.

## Mobile

`mobile/src/screens/PutAwayScreen.js` carries the handheld half of the fix. APK rebuild required to ship it; release-level APK guidance rides with the v1.10.3 release notes.

## Pre-merge gate

- [x] Putaway suite green locally (20 tests)
- [ ] CI green
