### PR TITLE
fix(receiving): refuse cross-PO cancel; require po_id on cancel request

### DIFF
--- a/api/routes/receiving.py
+++ b/api/routes/receiving.py
@@ -351,10 +351,42 @@ def cancel_receiving(validated):
 
     # Collect PO IDs before deleting receipts
     po_ids = set()
-    if validated.po_id:
-        po_ids.add(validated.po_id)
+    po_ids.add(validated.po_id)
 
     scope_clause, scope_params = warehouse_scope_clause("warehouse_id")
+
+    # Pre-flight cross-PO guard. The mobile receive screen accumulates
+    # receipt_ids across every PO loaded in a session (sessionReceiptIds
+    # is never reset between POs), so a single Cancel tap can sweep
+    # receipts belonging to POs the operator never intended to touch.
+    # Reject the whole call if any visible receipt belongs to a different
+    # po_id; refuse before any state mutation so a partial reversal is
+    # not possible. Receipts in another warehouse are filtered out by
+    # scope_clause (V-026) and are not considered mismatched here, which
+    # preserves the existing silent-skip behaviour for cross-warehouse
+    # IDs in the loop below.
+    mismatched = g.db.execute(
+        text(
+            f"""
+            SELECT receipt_id, po_id FROM item_receipts
+             WHERE receipt_id = ANY(:rids)
+               AND po_id != :po_id
+               {scope_clause}
+             LIMIT 20
+            """
+        ),
+        {"rids": receipt_ids, "po_id": validated.po_id, **scope_params},
+    ).fetchall()
+    if mismatched:
+        return jsonify({
+            "error": (
+                "receipt_ids span multiple purchase orders; refusing to "
+                "cross-cancel. Cancel one PO at a time."
+            ),
+            "po_id": validated.po_id,
+            "mismatched_receipt_ids": [r.receipt_id for r in mismatched],
+        }), 400
+
     # V-025: derive audit warehouse_id from the receipt rows themselves,
     # never from the attacker-controlled request body. Track per-
     # warehouse reversals so each audit row has a trustworthy

--- a/api/schemas/receiving.py
+++ b/api/schemas/receiving.py
@@ -20,6 +20,11 @@ class ReceiveItemsRequest(BaseModel):
 
 
 class CancelReceivingRequest(BaseModel):
+    # po_id is required so the route can refuse a cancel whose
+    # receipt_ids span multiple POs. The mobile receive screen accumulates
+    # receipt_ids across every PO loaded in a session, so a single Cancel
+    # tap can otherwise reach receipts the operator never intended to
+    # reverse. See routes/receiving.py:cancel_receiving for the guard.
+    po_id: int = Field(..., gt=0)
     receipt_ids: List[int] = Field(default_factory=list)
-    po_id: Optional[int] = Field(None, gt=0)
     warehouse_id: Optional[int] = Field(None, gt=0)

--- a/api/tests/test_receiving.py
+++ b/api/tests/test_receiving.py
@@ -216,6 +216,15 @@ class TestCancelReceiving:
     def test_cancel_empty_list(self, client, auth_headers):
         """Cancelling with no receipt_ids should return 200."""
         resp = client.post("/api/receiving/cancel", json={
+            "po_id": 1,
             "receipt_ids": [],
         }, headers=auth_headers)
         assert resp.status_code == 200
+
+    def test_cancel_requires_po_id(self, client, auth_headers):
+        """The route must refuse a cancel without po_id so the cross-PO
+        guard always has a target to validate against."""
+        resp = client.post("/api/receiving/cancel", json={
+            "receipt_ids": [1, 2, 3],
+        }, headers=auth_headers)
+        assert resp.status_code in (400, 422)

--- a/api/tests/test_validation.py
+++ b/api/tests/test_validation.py
@@ -106,10 +106,17 @@ class TestReceivingSchemas:
         with pytest.raises(ValidationError):
             ReceiveItemsRequest(po_id=-1, items=[{"item_id": 1, "quantity": 1, "bin_id": 1}])
 
-    def test_cancel_defaults(self):
-        req = CancelReceivingRequest()
+    def test_cancel_requires_po_id(self):
+        # po_id is required so the route can refuse cross-PO cancels.
+        with pytest.raises(ValidationError):
+            CancelReceivingRequest()
+        with pytest.raises(ValidationError):
+            CancelReceivingRequest(receipt_ids=[1, 2, 3])
+
+    def test_cancel_defaults_with_po_id(self):
+        req = CancelReceivingRequest(po_id=1)
         assert req.receipt_ids == []
-        assert req.po_id is None
+        assert req.po_id == 1
 
 
 class TestPutawaySchemas:


### PR DESCRIPTION
## Summary

- `e0989ee` -- the mobile receive screen accumulates receipt_ids across every PO loaded in a session (sessionReceiptIds is never reset between POs), so a single Cancel tap could reverse receipts belonging to POs the operator never intended to touch -- in one observed case, 564 receipts across 17 POs from a tap on a PO with zero receipts of its own. Server-side guard until the mobile screen is rebuilt: `po_id` is now required on CancelReceivingRequest, and a pre-flight check refuses the cancel with the list of mismatched receipt_ids -- before any inventory, PO line, or receipt row is touched -- when any visible receipt belongs to a different PO. A legitimate single-PO cancel still succeeds. Request schema change: `po_id` is a new required field on the cancel body.

## Mobile

Zero mobile/ diffs. The mobile-side session-reset rebuild is tracked separately; this guard makes the failure impossible server-side regardless of client state.

## Pre-merge gate

- [x] Receiving + validation suites green locally (94 tests)
- [ ] CI green
