### PR TITLE
chore(release): v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Sentry WMS will be documented in this file.
 
+## [v1.10.3] - 2026-06-12
+
+Patch release. Two floor-operations fixes from production: PickableStaging bins become valid put-away sources (matching the receive screen), and receipt cancel gains a cross-PO guard after a single Cancel tap was observed reversing 564 receipts across 17 POs.
+
+**Mobile.** The put-away fix has a handheld half: PutAwayScreen accepts both staging bin types on bin-scan and item-scan. Mobile version moves to 1.10.3 (versionCode 7); update to the v1.10.3 APK to pick up the handheld-side fix, or stay on v1.9.0 if you do not put away from PickableStaging bins. APK build attaches to the release separately.
+
+### Fixed
+
+- **PickableStaging bins are valid put-away sources** (#343): the pending-putaway queue filtered bins to bin_type = 'Staging' while the receive screen already accepts both 'Staging' and 'PickableStaging' -- items received into PickableStaging tray bins (which stay sales-pickable for concurrency) were invisible to the handheld put-away flow. `pending_putaway()` extends the filter to IN ('Staging','PickableStaging'); the handheld bin-scan handler and item-scan staging detector accept both. Existing Staging bins surface unchanged; server change is backward-compatible with the v1.9.0 handheld.
+- **Receipt cancel refuses cross-PO sweeps** (#344): the mobile receive screen accumulates receipt_ids across every PO loaded in a session, so one Cancel tap could reverse receipts on POs the operator never intended to touch (observed: 564 receipts across 17 POs from a single tap on a PO with zero receipts of its own). `po_id` is now required on the cancel request, and a pre-flight check refuses the cancel with the list of mismatched receipt_ids -- before any inventory, PO line, or receipt row is touched -- when any visible receipt belongs to a different PO. Legitimate single-PO cancels are unchanged; out-of-warehouse receipts remain silently skipped per the existing scope clause (V-026).
+
+### Migrations
+
+None on this release.
+
 ## [v1.10.2] - 2026-06-12
 
 Patch release. Security catch-up across all three dependency trees plus two data-integrity fixes from production: the audit-log hash chain now survives multi-line memo content, and line-level pick bookkeeping moves to ON DELETE SET NULL so line deletion cannot strand historical pick records.

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "license": "Apache-2.0",
       "dependencies": {
         "react": "^19.2.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin",
   "private": true,
-  "version": "1.10.2",
+  "version": "1.10.3",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -384,7 +384,7 @@ export default function Settings() {
       <div className="settings-section">
         <h3>About</h3>
         <div className="detail-grid">
-          <span className="detail-label">Version</span><span className="mono">1.10.2</span>
+          <span className="detail-label">Version</span><span className="mono">1.10.3</span>
           <span className="detail-label">Repository</span><span><a href="https://github.com/hightower-systems/sentry-wms" target="_blank" rel="noopener noreferrer">github.com/hightower-systems/sentry-wms</a></span>
         </div>
       </div>

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Sentry WMS",
     "slug": "sentry-wms",
-    "version": "1.9.0",
+    "version": "1.10.3",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -22,7 +22,7 @@
         "backgroundColor": "#000000"
       },
       "package": "com.hightowersystems.sentrywms",
-      "versionCode": 6,
+      "versionCode": 7,
       "usesCleartextTraffic": true,
       "permissions": [
         "INTERNET",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sentry-wms-mobile",
-  "version": "1.9.0",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sentry-wms-mobile",
-      "version": "1.9.0",
+      "version": "1.10.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@0no-co/graphql.web": "^1.2.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-wms-mobile",
-  "version": "1.9.0",
+  "version": "1.10.3",
   "license": "Apache-2.0",
   "description": "Sentry WMS - Mobile Scanner App",
   "main": "expo/AppEntry.js",


### PR DESCRIPTION
## Summary

Release branch for v1.10.3: CHANGELOG entry covering #343 / #344, admin version bumps, and mobile version bumps (package.json + lockfile + app.json versionCode 6 -> 7) since the put-away fix has a handheld half.

## Mobile

Version metadata only on this branch; the PutAwayScreen change itself landed via #343. APK build attaches to the release separately.

## Pre-merge gate

- [x] CI green expected (CHANGELOG + version strings + lockfile version fields only)
