### PR TITLE
fix(pos): cash-tender accepts external_txn_ref=None

### DIFF
--- a/api/schemas/pos.py
+++ b/api/schemas/pos.py
@@ -181,7 +181,15 @@ class CheckoutBody(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     idempotency_key:   UUID4
-    external_txn_ref:  str             = Field(..., min_length=1, max_length=_EXTERNAL_TXN_REF_MAX)
+    # Was required with min_length=1. Cash payments
+    # legitimately have no external processor reference (no card-processor
+    # session, no marketplace_txn_id), so accept None. The dedup
+    # contract is carried by idempotency_key (UUID4), not external_
+    # txn_ref. sales_orders.external_txn_ref is already nullable in
+    # schema (line 265, partial index at line 739 filters on IS NOT
+    # NULL), and the INSERT/SELECT paths all bind-param straight
+    # through, so NULL flows end-to-end without NPE.
+    external_txn_ref:  Optional[str]   = Field(None, max_length=_EXTERNAL_TXN_REF_MAX)
     cashier_id:        str             = Field(..., min_length=1, max_length=_CASHIER_ID_MAX)
     terminal_id:       str             = Field(..., min_length=1, max_length=_TERMINAL_ID_MAX)
     completed_at:      datetime


### PR DESCRIPTION
## Summary

- `00c510b` -- the POS cash-tender flow was broken at the schema boundary: `external_txn_ref` required a non-empty string, but cash payments legitimately carry no external processor reference (no card-processor session, no marketplace_txn_id). A cash checkout failed Pydantic validation with 422 invalid_body and surfaced at the register as an error popup after Pay. Now `Optional[str] = Field(None, ...)`. Safe by construction: the DB column is already nullable, the partial unique index already filters IS NOT NULL, and the dedup contract is idempotency_key, not external_txn_ref. Card tenders are unaffected.

## Mobile

Zero mobile/ diffs.

## Pre-merge gate

- [x] POS checkout + validate-cart suites green locally (43 tests)
- [ ] CI green
