### PR TITLE
fix(db): validate pooled connections before use

### DIFF
--- a/api/models/database.py
+++ b/api/models/database.py
@@ -11,7 +11,13 @@ DATABASE_URL = os.getenv(
     "DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry"
 )
 
-engine = create_engine(DATABASE_URL)
+# pool_pre_ping validates a pooled connection with a lightweight ping before
+# handing it out, transparently replacing one the server has dropped. Without
+# it, a connection closed during idle (Postgres idle timeout, container/network
+# recycling) surfaces as "server closed the connection unexpectedly" -> 500 on
+# the first request after idle. pool_recycle proactively retires connections
+# older than 30 min so they never reach that state.
+engine = create_engine(DATABASE_URL, pool_pre_ping=True, pool_recycle=1800)
 SessionLocal = sessionmaker(bind=engine)
 Base = declarative_base()
 


### PR DESCRIPTION
## Summary

- `51195e1` -- adds `pool_pre_ping` so SQLAlchemy replaces a connection the server has already dropped, and `pool_recycle` so connections retire before the Postgres idle timeout. Without this, the first request after an idle period failed with "server closed the connection unexpectedly" and a 500, surfacing as intermittent errors on the first hit after quiet periods.

## Mobile

Zero mobile/ diffs.

## Pre-merge gate

- [x] Full api suite green locally on this branch
- [ ] CI green
