### PR TITLE
chore(release): v1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Sentry WMS will be documented in this file.
 
+## [v1.10.4] - 2026-06-12
+
+Patch release. Three API-reliability fixes from production: cash tenders no longer fail POS checkout validation, pooled DB connections are validated before use so the first request after an idle period stops 500ing, and the SO detail endpoint returns the customer phone and address it already accepted on PUT.
+
+**Mobile.** Zero mobile/ diffs on this branch. v1.10.3 APK (versionCode 7) remains the working baseline; no new APK build for v1.10.4.
+
+### Fixed
+
+- **POS cash tender accepts a null processor reference** (#346): `external_txn_ref` required a non-empty string, but cash payments legitimately carry no external processor reference (no card-processor session, no marketplace_txn_id) -- a cash checkout failed Pydantic validation with 422 invalid_body and surfaced at the register as an error popup after Pay. Now `Optional[str] = Field(None, ...)`. Safe by construction: the DB column is already nullable, the partial unique index already filters IS NOT NULL, and the dedup contract is `idempotency_key`, not `external_txn_ref`. Card tenders are unaffected.
+- **Pooled DB connections validated before use** (#347): `pool_pre_ping` replaces connections the server has already dropped and `pool_recycle` retires connections before the Postgres idle timeout. Without this, the first request after an idle period failed with "server closed the connection unexpectedly" and a 500.
+- **SO detail returns customer_phone + customer_address** (#348): the PUT path accepted both and the write landed, but the detail SELECT omitted them, so the edit modal came back blank after Save and operators assumed the save had failed. Both fields now ride the SELECT and the response payload.
+
+### Migrations
+
+None on this release.
+
 ## [v1.10.3] - 2026-06-12
 
 Patch release. Two floor-operations fixes from production: PickableStaging bins become valid put-away sources (matching the receive screen), and receipt cancel gains a cross-PO guard after a single Cancel tap was observed reversing 564 receipts across 17 POs.

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "license": "Apache-2.0",
       "dependencies": {
         "react": "^19.2.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin",
   "private": true,
-  "version": "1.10.3",
+  "version": "1.10.4",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -384,7 +384,7 @@ export default function Settings() {
       <div className="settings-section">
         <h3>About</h3>
         <div className="detail-grid">
-          <span className="detail-label">Version</span><span className="mono">1.10.3</span>
+          <span className="detail-label">Version</span><span className="mono">1.10.4</span>
           <span className="detail-label">Repository</span><span><a href="https://github.com/hightower-systems/sentry-wms" target="_blank" rel="noopener noreferrer">github.com/hightower-systems/sentry-wms</a></span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Release branch for v1.10.4: CHANGELOG entry covering #346 / #347 / #348, admin version bumps (package.json + lockfile top-level and self-reference), and the Settings About-card.

## Mobile

Zero mobile/ diffs since the v1.10.3 tag. v1.10.3 APK (versionCode 7) remains the working baseline.

## Pre-merge gate

- [x] CI green expected (CHANGELOG + version strings + lockfile version fields only)
