### PR TITLE
chore(git): ignore local .env backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ site/
 # Proxy
 proxy/certs/
 proxy/certs/*.pem
+
+# Local .env backups (never commit; see also .env above)
+.env.backup*
+*.env.backup*


### PR DESCRIPTION
## Summary

- Adds `.env.backup*` / `*.env.backup*` to .gitignore. The existing `.env` ignore does not cover suffixed backup copies; this closes that gap so a local backup can never be staged.

## Mobile

Zero mobile/ diffs.

## Pre-merge gate

- [x] CI green expected (gitignore only)
