### PR TITLE
chore(release): v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Sentry WMS will be documented in this file.
 
+## [v1.11.0] - 2026-06-12
+
+"Status simplification" release. The sales_orders lifecycle drops three statuses that production showed were dead weight: PACKING was never set by application code, ALLOCATED was a comment-only value, and PICKING merely mirrored "this SO sits inside an active pick batch," state already carried by `pick_batch_orders` + `pick_batches`. The lifecycle is now **OPEN -> PICKED -> PACKED -> SHIPPED**, with CANCELLED as the off-ramp. Picking concurrency is unchanged: row locks and the pick_batches aggregate still serialize batch creation and completion.
+
+**Mobile.** Zero mobile/ diffs on this release; no new APK build for v1.11.0.
+
+### Breaking changes
+
+- **PICKING, PACKING, ALLOCATED retired from the SO lifecycle** (#351): `sales_orders.status` never returns PICKING or PACKING; `sales_order_lines.status` never returns ALLOCATED. Status filters using retired values match nothing (no error). External automation keying on the retired statuses must move to the derived signal: an SO is "in picking" when it has a `pick_batch_orders` row whose batch is OPEN or IN_PROGRESS. Migration 060 **runs a backfill**: live orders in retired statuses fold to OPEN, ALLOCATED lines fold to PENDING (no-op on databases that never held them). If folded orders belonged to open pick batches, cancel or complete those batches before re-enabling pick traffic; `create_pick_batch` now refuses an OPEN SO that already sits in an active batch.
+
+### Changed
+
+- `cancel_sales_order` folds the former PICKING branch into OPEN: an OPEN SO with allocated quantity is the release-allocation-on-cancel path. Dashboard `in_picking` is derived via the batch join; `ready_to_pick` is open SOs minus in-picking, so the tiles stay disjoint.
+
+### Migrations
+
+- **060** (#351) -- retire statuses, executed backfill, column comments updated.
+
 ## [v1.10.4] - 2026-06-12
 
 Patch release. Three API-reliability fixes from production: cash tenders no longer fail POS checkout validation, pooled DB connections are validated before use so the first request after an idle period stops 500ing, and the SO detail endpoint returns the customer phone and address it already accepted on PUT.

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "1.10.4",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react": "^19.2.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin",
   "private": true,
-  "version": "1.10.4",
+  "version": "1.11.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -384,7 +384,7 @@ export default function Settings() {
       <div className="settings-section">
         <h3>About</h3>
         <div className="detail-grid">
-          <span className="detail-label">Version</span><span className="mono">1.10.4</span>
+          <span className="detail-label">Version</span><span className="mono">1.11.0</span>
           <span className="detail-label">Repository</span><span><a href="https://github.com/hightower-systems/sentry-wms" target="_blank" rel="noopener noreferrer">github.com/hightower-systems/sentry-wms</a></span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Release branch for v1.11.0: CHANGELOG entry covering #351 (breaking-change guidance + executed backfill), admin version bumps, and the Settings About-card. Supersedes #352.

## Mobile

Zero mobile/ diffs since the v1.10.4 tag.

## Pre-merge gate

- [x] CI green expected (CHANGELOG + version strings + lockfile version fields only)
