### PR TITLE
feat(permissions): per-page web-admin grants (mig 061)

### DIFF
--- a/admin/src/api.js
+++ b/admin/src/api.js
@@ -9,13 +9,19 @@ async function apiFetch(path, options = {}) {
   const method = (options.method || 'GET').toUpperCase();
   const needsCsrf = method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS';
   const csrfToken = needsCsrf ? getCsrfToken() : null;
+  // avid-overhaul-mk1 P6.1: callers can pass silentPermissionDenied:true
+  // to opt OUT of the global Permissions Error popup for background
+  // fetches (sidebar badges, navshell settings probes). Without it
+  // every USER landing on Dashboard would see the modal fire on
+  // page mount before they did anything explicit.
+  const { silentPermissionDenied = false, ...fetchOptions } = options;
   const headers = {
     'Content-Type': 'application/json',
     ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
-    ...options.headers,
+    ...fetchOptions.headers,
   };
   const res = await fetch(`${API_BASE}${path}`, {
-    ...options,
+    ...fetchOptions,
     headers,
     credentials: 'include',
   });
@@ -23,13 +29,29 @@ async function apiFetch(path, options = {}) {
     window.location.href = '/login';
     return;
   }
+  // P6.1: surface page-permission rejections via a window event so
+  // Layout can render a "Permissions Error" modal wherever the user
+  // is. Response shape comes from @require_admin_or_page_permission
+  // ({error: "Permission denied", page_key: "..."}). Peek at the body
+  // without consuming the stream (clone first) so the caller can
+  // still .json() the response.
+  if (res.status === 403 && !silentPermissionDenied) {
+    try {
+      const peek = await res.clone().json();
+      if (peek?.error === 'Permission denied' && peek?.page_key) {
+        window.dispatchEvent(new CustomEvent('sentry:permission-denied', {
+          detail: { page_key: peek.page_key, path },
+        }));
+      }
+    } catch (_) { /* non-JSON 403 (legacy / unrelated) */ }
+  }
   return res;
 }
 
 export const api = {
-  get: (path) => apiFetch(path),
-  post: (path, body) => apiFetch(path, { method: 'POST', body: JSON.stringify(body) }),
-  put: (path, body) => apiFetch(path, { method: 'PUT', body: JSON.stringify(body) }),
-  patch: (path, body) => apiFetch(path, { method: 'PATCH', body: JSON.stringify(body) }),
-  delete: (path) => apiFetch(path, { method: 'DELETE' }),
+  get: (path, opts) => apiFetch(path, { ...(opts || {}) }),
+  post: (path, body, opts) => apiFetch(path, { method: 'POST', body: JSON.stringify(body), ...(opts || {}) }),
+  put: (path, body, opts) => apiFetch(path, { method: 'PUT', body: JSON.stringify(body), ...(opts || {}) }),
+  patch: (path, body, opts) => apiFetch(path, { method: 'PATCH', body: JSON.stringify(body), ...(opts || {}) }),
+  delete: (path, opts) => apiFetch(path, { method: 'DELETE', ...(opts || {}) }),
 };

--- a/admin/src/api.js
+++ b/admin/src/api.js
@@ -9,7 +9,7 @@ async function apiFetch(path, options = {}) {
   const method = (options.method || 'GET').toUpperCase();
   const needsCsrf = method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS';
   const csrfToken = needsCsrf ? getCsrfToken() : null;
-  // avid-overhaul-mk1 P6.1: callers can pass silentPermissionDenied:true
+  // Page permissions (mig 061): callers can pass silentPermissionDenied:true
   // to opt OUT of the global Permissions Error popup for background
   // fetches (sidebar badges, navshell settings probes). Without it
   // every USER landing on Dashboard would see the modal fire on

--- a/admin/src/auth.jsx
+++ b/admin/src/auth.jsx
@@ -12,14 +12,17 @@ export function AuthProvider({ children }) {
     // V-045: session lives in an HttpOnly cookie; there is no token in
     // localStorage to read. Ask the API who we are. If the cookie is
     // missing or expired, /auth/me returns 401 and we stay unauthenticated.
+    //
+    // Page permissions (mig 061): USER role is now a first-class web-admin
+    // identity (gated per page via user_page_permissions). The previous
+    // role === 'ADMIN' guard would silently drop a valid USER session
+    // and force them back to the login screen.
     let cancelled = false;
     api.get('/auth/me').then(async (res) => {
       if (cancelled) return;
       if (res && res.ok) {
         const data = await res.json();
-        if (data.role === 'ADMIN') {
-          setUser(data);
-        }
+        setUser(data);
       }
       setLoading(false);
     }).catch(() => {
@@ -49,11 +52,10 @@ export function AuthProvider({ children }) {
       throw new Error(friendlyError(data, 'Login failed. Please try again.'));
     }
     const data = await res.json();
-    if (data.user.role !== 'ADMIN') {
-      // Not an admin -- ask the server to clear the cookies we just got.
-      await api.post('/auth/logout', {});
-      throw new Error('Not authorized');
-    }
+    // Page permissions (mig 061): USERs are allowed into the admin shell.
+    // Per-page permissions decide what they can actually do; the
+    // sidebar hides ungranted pages and the api gate returns 403 for
+    // direct URL hits. Any user with valid credentials proceeds.
     setUser(data.user);
     return data.user;
   }

--- a/admin/src/components/Layout.jsx
+++ b/admin/src/components/Layout.jsx
@@ -1,10 +1,25 @@
+import { useEffect, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import TopBar from './TopBar.jsx';
 import Sidebar from './Sidebar.jsx';
+import Modal from './Modal.jsx';
 import { useAuth } from '../auth.jsx';
 
 export default function Layout() {
   const { user } = useAuth();
+  // Page permissions (mig 061): catch global permission-denied events from
+  // api.js and surface a "Permissions Error" modal. Lives on Layout so
+  // it covers every page reached through the admin shell.
+  const [permError, setPermError] = useState(null);
+
+  useEffect(() => {
+    function onPermDenied(evt) {
+      setPermError(evt.detail || { page_key: null });
+    }
+    window.addEventListener('sentry:permission-denied', onPermDenied);
+    return () => window.removeEventListener('sentry:permission-denied', onPermDenied);
+  }, []);
+
   // When the user is stuck in a forced-change flow the only available
   // actions are the change-password form and logout, so drop the sidebar
   // entirely and widen the main column.
@@ -16,6 +31,29 @@ export default function Layout() {
       <main className="content">
         <Outlet />
       </main>
+      {permError && (
+        <Modal
+          title="Permissions Error"
+          onClose={() => setPermError(null)}
+          footer={
+            <button className="btn btn-primary" onClick={() => setPermError(null)}>
+              OK
+            </button>
+          }
+        >
+          <p style={{ fontSize: 14, marginBottom: 12 }}>
+            You do not have permission to access this resource.
+          </p>
+          {permError.page_key && (
+            <p style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
+              Page: <span className="mono">{permError.page_key}</span>
+            </p>
+          )}
+          <p style={{ fontSize: 13 }}>
+            Contact an administrator if you need access.
+          </p>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/admin/src/components/Layout.jsx
+++ b/admin/src/components/Layout.jsx
@@ -1,24 +1,45 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import TopBar from './TopBar.jsx';
 import Sidebar from './Sidebar.jsx';
 import Modal from './Modal.jsx';
 import { useAuth } from '../auth.jsx';
 
+const PERM_POPUP_COOLDOWN_MS = 5000;
+
 export default function Layout() {
   const { user } = useAuth();
   // Page permissions (mig 061): catch global permission-denied events from
   // api.js and surface a "Permissions Error" modal. Lives on Layout so
   // it covers every page reached through the admin shell.
+  //
+  // Two debouncers keep the modal from spamming a USER browsing pages
+  // they have partial access to:
+  //   1. Don't replace an already-open modal - the operator dismisses
+  //      one at a time; piling new ones underneath is confusing.
+  //   2. After dismiss, suppress further popups for COOLDOWN_MS so a
+  //      page that fires several permission_denied calls during mount
+  //      shows the modal once total, not once per call.
   const [permError, setPermError] = useState(null);
+  const dismissedAt = useRef(0);
 
   useEffect(() => {
     function onPermDenied(evt) {
-      setPermError(evt.detail || { page_key: null });
+      const now = Date.now();
+      if (now - dismissedAt.current < PERM_POPUP_COOLDOWN_MS) return;
+      // Functional setter so we read the latest state without listing
+      // permError as a deps dependency (which would re-bind the listener
+      // every render).
+      setPermError((current) => current || (evt.detail || { page_key: null }));
     }
     window.addEventListener('sentry:permission-denied', onPermDenied);
     return () => window.removeEventListener('sentry:permission-denied', onPermDenied);
   }, []);
+
+  function dismissPermError() {
+    dismissedAt.current = Date.now();
+    setPermError(null);
+  }
 
   // When the user is stuck in a forced-change flow the only available
   // actions are the change-password form and logout, so drop the sidebar
@@ -34,9 +55,9 @@ export default function Layout() {
       {permError && (
         <Modal
           title="Permissions Error"
-          onClose={() => setPermError(null)}
+          onClose={dismissPermError}
           footer={
-            <button className="btn btn-primary" onClick={() => setPermError(null)}>
+            <button className="btn btn-primary" onClick={dismissPermError}>
               OK
             </button>
           }

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -71,6 +71,21 @@ export default function Sidebar() {
   const { user } = useAuth();
   const { warehouseId } = useWarehouse();
   const [counts, setCounts] = useState({});
+  // Mirrors the require_packing_before_shipping system setting. When
+  // packing is disabled, the Packing nav entry is hidden so operators
+  // do not navigate to a screen that no longer corresponds to any
+  // active workflow. Default true matches Settings.jsx fallback.
+  const [packingEnabled, setPackingEnabled] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.get('/admin/settings/require_packing_before_shipping').then(async (res) => {
+      if (!res?.ok || cancelled) return;
+      const data = await res.json();
+      setPackingEnabled(data?.value !== 'false');
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     if (!warehouseId) return;
@@ -99,11 +114,17 @@ export default function Sidebar() {
     });
   }, [location.pathname, warehouseId]);
 
+  const navGroups = packingEnabled
+    ? NAV
+    : NAV.map((group) => ({
+        ...group,
+        items: group.items.filter((item) => item.to !== '/packing'),
+      }));
 
   return (
     <nav className="sidebar">
       <div className="sidebar-wordmark">SENTRY</div>
-      {NAV.map((group) => (
+      {navGroups.map((group) => (
         <div key={group.label} className="sidebar-card">
           <div className="sidebar-group-label">{group.label}</div>
           {group.items.map((item) => (

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -1,72 +1,87 @@
 import { NavLink, useLocation } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { api } from '../api.js';
+import { useAuth } from '../auth.jsx';
 import { useWarehouse } from '../warehouse.jsx';
 
+// Each NAV item carries a page_key matching api/constants.py
+// ALL_PAGE_KEYS. Sidebar filters by the user's allowed_pages so a
+// USER without the grant never sees the link (and the backend
+// rejects direct URL hits via @require_admin_or_page_permission).
+// Dashboard intentionally has no page_key: it is reachable by any
+// authenticated user so the badges below populate.
 const NAV = [
   {
     label: 'Floor',
     items: [
-      { to: '/', label: 'Dashboard' },
-      { to: '/inventory', label: 'Inventory' },
-      { to: '/cycle-counts', label: 'Counts' },
-      { to: '/count-approvals', label: 'Approvals' },
+      { to: '/', label: 'Dashboard', pageKey: 'dashboard' },
+      { to: '/inventory', label: 'Inventory', pageKey: 'inventory' },
+      { to: '/cycle-counts', label: 'Counts', pageKey: 'cycle-counts' },
+      { to: '/count-approvals', label: 'Approvals', pageKey: 'count-approvals' },
     ],
   },
   {
     label: 'Inbound',
     items: [
-      { to: '/purchase-orders', label: 'Purchase Orders' },
-      { to: '/receiving', label: 'Receiving' },
-      { to: '/putaway', label: 'Put-away' },
+      { to: '/purchase-orders', label: 'Purchase Orders', pageKey: 'purchase-orders' },
+      { to: '/receiving', label: 'Receiving', pageKey: 'receiving' },
+      { to: '/putaway', label: 'Put-away', pageKey: 'putaway' },
     ],
   },
   {
     label: 'Outbound',
     items: [
-      { to: '/sales-orders', label: 'Sales Orders' },
-      { to: '/picking', label: 'Picking' },
-      { to: '/packing', label: 'Packing' },
-      { to: '/shipping', label: 'Shipping' },
+      { to: '/sales-orders', label: 'Sales Orders', pageKey: 'sales-orders' },
+      { to: '/picking', label: 'Picking', pageKey: 'picking' },
+      { to: '/packing', label: 'Packing', pageKey: 'packing' },
+      { to: '/shipping', label: 'Shipping', pageKey: 'shipping' },
     ],
   },
   {
     label: 'Warehouse',
     items: [
-      { to: '/warehouses', label: 'Warehouses' },
-      { to: '/bins', label: 'Bins' },
-      { to: '/zones', label: 'Zones' },
-      { to: '/items', label: 'Items' },
-      { to: '/preferred-bins', label: 'Preferred Bins' },
-      { to: '/adjustments', label: 'Adjustments' },
-      { to: '/transfer-orders', label: 'Transfer Orders' },
-      { to: '/inter-warehouse-transfers', label: 'Bin Transfers' },
+      { to: '/warehouses', label: 'Warehouses', pageKey: 'warehouses' },
+      { to: '/bins', label: 'Bins', pageKey: 'bins' },
+      { to: '/zones', label: 'Zones', pageKey: 'zones' },
+      { to: '/items', label: 'Items', pageKey: 'items' },
+      { to: '/preferred-bins', label: 'Preferred Bins', pageKey: 'preferred-bins' },
+      { to: '/adjustments', label: 'Adjustments', pageKey: 'adjustments' },
+      { to: '/transfer-orders', label: 'Transfer Orders', pageKey: 'transfer-orders' },
+      { to: '/inter-warehouse-transfers', label: 'Bin Transfers', pageKey: 'inter-warehouse-transfers' },
     ],
   },
   {
     label: 'System',
     items: [
-      { to: '/users', label: 'Users' },
-      { to: '/api-tokens', label: 'API tokens' },
-      { to: '/inbound', label: 'Inbound activity' },
-      { to: '/consumer-groups', label: 'Consumer groups' },
-      { to: '/webhooks', label: 'Webhooks' },
-      { to: '/audit-log', label: 'Audit log' },
-      { to: '/imports', label: 'Import' },
-      { to: '/integrations', label: 'Integrations' },
-      { to: '/settings', label: 'Settings' },
+      { to: '/users', label: 'Users', pageKey: 'users' },
+      { to: '/api-tokens', label: 'API tokens', pageKey: 'api-tokens' },
+      { to: '/inbound', label: 'Inbound activity', pageKey: 'inbound' },
+      { to: '/consumer-groups', label: 'Consumer groups', pageKey: 'consumer-groups' },
+      { to: '/webhooks', label: 'Webhooks', pageKey: 'webhooks' },
+      { to: '/audit-log', label: 'Audit log', pageKey: 'audit-log' },
+      { to: '/imports', label: 'Import', pageKey: 'imports' },
+      { to: '/integrations', label: 'Integrations', pageKey: 'integrations' },
+      { to: '/settings', label: 'Settings', pageKey: 'settings' },
     ],
   },
 ];
 
 export default function Sidebar() {
   const location = useLocation();
+  const { user } = useAuth();
   const { warehouseId } = useWarehouse();
   const [counts, setCounts] = useState({});
 
   useEffect(() => {
     if (!warehouseId) return;
-    api.get(`/admin/dashboard?warehouse_id=${warehouseId}`).then(async (res) => {
+    // Same silent treatment for the dashboard counts (sidebar badges).
+    // /admin/dashboard is intentionally any-auth so this typically
+    // succeeds, but a future tightening should not blow up the UI
+    // with a modal on every page load.
+    api.get(
+      `/admin/dashboard?warehouse_id=${warehouseId}`,
+      { silentPermissionDenied: true },
+    ).then(async (res) => {
       if (!res || !res.ok) return;
       const data = await res.json();
       setCounts({
@@ -83,6 +98,7 @@ export default function Sidebar() {
       });
     });
   }, [location.pathname, warehouseId]);
+
 
   return (
     <nav className="sidebar">

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -79,7 +79,15 @@ export default function Sidebar() {
 
   useEffect(() => {
     let cancelled = false;
-    api.get('/admin/settings/require_packing_before_shipping').then(async (res) => {
+    // Background fetch - the Sidebar uses this to filter the Packing
+    // entry but a USER who lacks the settings grant should not see
+    // the global Permissions Error popup over it. silentPermissionDenied
+    // suppresses the popup; the call still resolves and we fall back
+    // to packingEnabled=true (default UI state).
+    api.get(
+      '/admin/settings/require_packing_before_shipping',
+      { silentPermissionDenied: true },
+    ).then(async (res) => {
       if (!res?.ok || cancelled) return;
       const data = await res.json();
       setPackingEnabled(data?.value !== 'false');

--- a/admin/src/pages/Dashboard.jsx
+++ b/admin/src/pages/Dashboard.jsx
@@ -205,9 +205,17 @@ export default function Dashboard() {
     const qp = new URLSearchParams({
       start: range.start, end: range.end, warehouse_id: String(warehouseId),
     });
-    const res = await api.get(`/v1/dashboard/productivity?${qp}`);
+    // P6.1: productivity is ADMIN-only upstream; a USER hitting the
+    // home page should not see "Forbidden" inline. Silent the popup
+    // and on 403 just clear the payload so the widget shows nothing.
+    const res = await api.get(
+      `/v1/dashboard/productivity?${qp}`,
+      { silentPermissionDenied: true },
+    );
     if (res?.ok) {
       setPayload(await res.json());
+    } else if (res?.status === 403) {
+      setPayload(null);
     } else {
       const data = await res?.json();
       setPayload(null);

--- a/admin/src/pages/InterWarehouseTransfers.jsx
+++ b/admin/src/pages/InterWarehouseTransfers.jsx
@@ -49,7 +49,7 @@ export default function InterWarehouseTransfers() {
   }, [form.destination_warehouse_id]);
 
   async function loadWarehouses() {
-    const res = await api.get('/admin/warehouses');
+    const res = await api.get('/admin/warehouses', { silentPermissionDenied: true });
     if (res?.ok) {
       const data = await res.json();
       setWarehouses(data.warehouses || []);

--- a/admin/src/pages/Packing.jsx
+++ b/admin/src/pages/Packing.jsx
@@ -15,7 +15,7 @@ export default function Packing() {
 
   useEffect(() => {
     if (!warehouseId) return;
-    api.get('/admin/settings/require_packing_before_shipping').then(async (res) => {
+    api.get('/admin/settings/require_packing_before_shipping', { silentPermissionDenied: true }).then(async (res) => {
       if (!res?.ok) return;
       const data = await res.json();
       const enabled = data.value !== 'false' && data.value !== false;

--- a/admin/src/pages/Picking.jsx
+++ b/admin/src/pages/Picking.jsx
@@ -40,8 +40,8 @@ export default function Picking() {
     setError('');
     // Load items and warehouses for dropdowns
     const [itemRes, whRes] = await Promise.all([
-      api.get('/admin/items?per_page=500&active=true'),
-      api.get('/admin/warehouses'),
+      api.get('/admin/items?per_page=500&active=true', { silentPermissionDenied: true }),
+      api.get('/admin/warehouses', { silentPermissionDenied: true }),
     ]);
     if (itemRes?.ok) {
       const data = await itemRes.json();

--- a/admin/src/pages/PreferredBins.jsx
+++ b/admin/src/pages/PreferredBins.jsx
@@ -31,7 +31,7 @@ export default function PreferredBins() {
 
   async function openAdd() {
     const [itemRes, binRes] = await Promise.all([
-      api.get('/admin/items?per_page=200'),
+      api.get('/admin/items?per_page=200', { silentPermissionDenied: true }),
       api.get(`/admin/bins?warehouse_id=${warehouseId}`),
     ]);
     if (itemRes?.ok) setItems((await itemRes.json()).items || []);

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -118,7 +118,7 @@ export default function Settings() {
   // modal opens so Settings' first paint does not fetch /admin/items.
   async function ensureItemsLoaded() {
     if (itemsLoaded) return;
-    const res = await api.get('/admin/items?per_page=1000&active=true');
+    const res = await api.get('/admin/items?per_page=1000&active=true', { silentPermissionDenied: true });
     if (res?.ok) {
       const data = await res.json();
       const map = new Map();

--- a/admin/src/pages/Shipping.jsx
+++ b/admin/src/pages/Shipping.jsx
@@ -17,7 +17,7 @@ export default function Shipping() {
     async function load() {
       let requirePacking = true;
       try {
-        const settingRes = await api.get('/admin/settings/require_packing_before_shipping');
+        const settingRes = await api.get('/admin/settings/require_packing_before_shipping', { silentPermissionDenied: true });
         if (settingRes?.ok) {
           const data = await settingRes.json();
           requirePacking = data.value !== 'false' && data.value !== false;

--- a/admin/src/pages/Tokens.jsx
+++ b/admin/src/pages/Tokens.jsx
@@ -167,7 +167,7 @@ export default function Tokens() {
     // empty list in the respective checkbox component.
     const [catalogRes, warehousesRes] = await Promise.all([
       api.get('/admin/scope-catalog'),
-      api.get('/admin/warehouses'),
+      api.get('/admin/warehouses', { silentPermissionDenied: true }),
     ]);
     if (catalogRes?.ok) {
       const data = await catalogRes.json();

--- a/admin/src/pages/TransferOrders.jsx
+++ b/admin/src/pages/TransferOrders.jsx
@@ -100,7 +100,7 @@ export default function TransferOrders() {
   useEffect(() => { loadWarehouses(); }, []);
 
   async function loadWarehouses() {
-    const res = await api.get('/admin/warehouses');
+    const res = await api.get('/admin/warehouses', { silentPermissionDenied: true });
     if (res?.ok) {
       const data = await res.json();
       setWarehouses(data.warehouses || data || []);

--- a/admin/src/pages/Users.jsx
+++ b/admin/src/pages/Users.jsx
@@ -17,6 +17,68 @@ const ALL_FUNCTIONS = [
   { key: 'transfer', label: 'Transfer' },
 ];
 
+// Web-admin page grants (mig 061). Mirrors the sidebar
+// groups so the create / edit modal feels familiar; keys match
+// api/constants.py ALL_PAGE_KEYS exactly. ADMIN users bypass the
+// permission table server-side, so checking these for an ADMIN is
+// purely cosmetic - the PUT endpoint no-ops for ADMIN targets.
+const PAGE_GROUPS = [
+  {
+    label: 'Floor',
+    pages: [
+      { key: 'inventory', label: 'Inventory' },
+      { key: 'cycle-counts', label: 'Cycle Counts' },
+      { key: 'count-approvals', label: 'Count Approvals' },
+    ],
+  },
+  {
+    label: 'Inbound',
+    pages: [
+      { key: 'purchase-orders', label: 'Purchase Orders' },
+      { key: 'receiving', label: 'Receiving' },
+      { key: 'putaway', label: 'Put-away' },
+    ],
+  },
+  {
+    label: 'Outbound',
+    pages: [
+      { key: 'sales-orders', label: 'Sales Orders' },
+      { key: 'picking', label: 'Picking' },
+      { key: 'packing', label: 'Packing' },
+      { key: 'shipping', label: 'Shipping' },
+    ],
+  },
+  {
+    label: 'Warehouse',
+    pages: [
+      { key: 'items', label: 'Items' },
+      { key: 'adjustments', label: 'Inventory Adjustments' },
+      { key: 'inter-warehouse-transfers', label: 'Inventory Transfers' },
+      { key: 'transfer-orders', label: 'Transfer Orders' },
+      { key: 'warehouses', label: 'Warehouses' },
+      { key: 'bins', label: 'Bins' },
+      { key: 'zones', label: 'Zones' },
+      { key: 'preferred-bins', label: 'Preferred Bins' },
+    ],
+  },
+  {
+    label: 'System',
+    pages: [
+      { key: 'users', label: 'Users' },
+      { key: 'api-tokens', label: 'API Tokens' },
+      { key: 'inbound', label: 'Inbound Activity' },
+      { key: 'consumer-groups', label: 'Consumer Groups' },
+      { key: 'webhooks', label: 'Webhooks' },
+      { key: 'audit-log', label: 'Audit Log' },
+      { key: 'imports', label: 'Imports' },
+      { key: 'integrations', label: 'Integrations' },
+      { key: 'settings', label: 'Settings' },
+    ],
+  },
+];
+
+const ALL_PAGE_KEYS = PAGE_GROUPS.flatMap((g) => g.pages.map((p) => p.key));
+
 export default function Users() {
   const { user: currentUser } = useAuth();
   const [users, setUsers] = useState([]);
@@ -25,6 +87,10 @@ export default function Users() {
   const [editId, setEditId] = useState(null);
   const [form, setForm] = useState({});
   const [error, setError] = useState('');
+  // mig 061: per-page web-admin grants. Edited inline alongside
+  // the rest of the user form and saved via a follow-up PUT once the
+  // user record itself lands.
+  const [pagePermissions, setPagePermissions] = useState([]);
 
   useEffect(() => {
     loadUsers();
@@ -50,11 +116,12 @@ export default function Users() {
   function openCreate() {
     setEditId(null);
     setForm({ role: 'USER', warehouse_ids: [], allowed_functions: [], is_active: true });
+    setPagePermissions([]);
     setError('');
     setShowModal(true);
   }
 
-  function openEdit(user) {
+  async function openEdit(user) {
     setEditId(user.user_id);
     setForm({
       ...user,
@@ -64,6 +131,45 @@ export default function Users() {
     });
     setError('');
     setShowModal(true);
+    // Fetch the user's existing per-page grants so the modal can
+    // populate the checkboxes. ADMINs return is_full_access=true
+    // with the entire catalog, which we surface as "all checked".
+    const res = await api.get(`/admin/users/${user.user_id}/permissions`);
+    if (res?.ok) {
+      const data = await res.json();
+      setPagePermissions(data.page_keys || []);
+    } else {
+      setPagePermissions([]);
+    }
+  }
+
+  function togglePagePermission(pageKey) {
+    setPagePermissions((prev) => (
+      prev.includes(pageKey)
+        ? prev.filter((k) => k !== pageKey)
+        : [...prev, pageKey]
+    ));
+  }
+
+  function selectAllPagesInGroup(group) {
+    setPagePermissions((prev) => {
+      const next = new Set(prev);
+      group.pages.forEach((p) => next.add(p.key));
+      return Array.from(next);
+    });
+  }
+
+  function clearPagesInGroup(group) {
+    const groupKeys = new Set(group.pages.map((p) => p.key));
+    setPagePermissions((prev) => prev.filter((k) => !groupKeys.has(k)));
+  }
+
+  function selectAllPages() {
+    setPagePermissions([...ALL_PAGE_KEYS]);
+  }
+
+  function clearAllPages() {
+    setPagePermissions([]);
   }
 
   async function save() {
@@ -86,13 +192,32 @@ export default function Users() {
     const res = editId
       ? await api.put(`/admin/users/${editId}`, body)
       : await api.post('/admin/users', body);
-    if (res?.ok) {
-      setShowModal(false);
-      loadUsers();
-    } else {
+    if (!res?.ok) {
       const data = await res?.json();
       setError(data?.error || 'Failed to save');
+      return;
     }
+    // Persist per-page grants in a follow-up PUT. The endpoint is a
+    // no-op for ADMIN targets (server bypasses the table), so calling
+    // it unconditionally is safe. Resolve the user_id from the
+    // create response when we just minted a new row.
+    const userPayload = await res.json().catch(() => null);
+    const savedUserId = editId || userPayload?.user_id;
+    if (savedUserId) {
+      const permRes = await api.put(
+        `/admin/users/${savedUserId}/permissions`,
+        { page_keys: pagePermissions },
+      );
+      if (!permRes?.ok) {
+        const permData = await permRes?.json();
+        setError(
+          permData?.error || 'User saved, but failed to save page permissions',
+        );
+        return;
+      }
+    }
+    setShowModal(false);
+    loadUsers();
   }
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(null);
@@ -166,6 +291,7 @@ export default function Users() {
 
       {showModal && (
         <Modal title={editId ? 'Edit User' : 'New User'} onClose={() => setShowModal(false)}
+          size="wide"
           footer={
             <>
               <button className="btn" onClick={() => setShowModal(false)}>Cancel</button>
@@ -225,6 +351,85 @@ export default function Users() {
                 </label>
               ))}
             </div>
+          </div>
+
+          <div className="form-group">
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <label>Web Admin Page Access</label>
+              <span style={{ fontSize: 12 }}>
+                <button
+                  type="button"
+                  onClick={selectAllPages}
+                  style={{ background: 'none', border: 'none', color: 'var(--accent)', cursor: 'pointer', padding: 0, fontSize: 12 }}
+                >
+                  Select all
+                </button>
+                <span style={{ color: 'var(--text-tertiary)', margin: '0 6px' }}>/</span>
+                <button
+                  type="button"
+                  onClick={clearAllPages}
+                  style={{ background: 'none', border: 'none', color: 'var(--accent)', cursor: 'pointer', padding: 0, fontSize: 12 }}
+                >
+                  Clear
+                </button>
+              </span>
+            </div>
+            {form.role === 'ADMIN' ? (
+              <p style={{ fontSize: 12, color: 'var(--text-secondary)', padding: '8px 0' }}>
+                ADMIN role bypasses page permissions - full access to every web admin page.
+              </p>
+            ) : (
+              <div style={{
+                display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+                gap: 12, padding: '8px 0',
+              }}>
+                {PAGE_GROUPS.map((group) => {
+                  const groupKeys = new Set(group.pages.map((p) => p.key));
+                  const grantedCount = pagePermissions.filter((k) => groupKeys.has(k)).length;
+                  return (
+                    <div key={group.label} className="card" style={{ padding: 10 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+                        <strong style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                          {group.label}
+                        </strong>
+                        <span style={{ fontSize: 11 }}>
+                          <button
+                            type="button"
+                            onClick={() => selectAllPagesInGroup(group)}
+                            style={{ background: 'none', border: 'none', color: 'var(--accent)', cursor: 'pointer', padding: 0, fontSize: 11 }}
+                          >
+                            All
+                          </button>
+                          <span style={{ color: 'var(--text-tertiary)', margin: '0 4px' }}>/</span>
+                          <button
+                            type="button"
+                            onClick={() => clearPagesInGroup(group)}
+                            style={{ background: 'none', border: 'none', color: 'var(--accent)', cursor: 'pointer', padding: 0, fontSize: 11 }}
+                          >
+                            None
+                          </button>
+                        </span>
+                      </div>
+                      {group.pages.map((p) => (
+                        <label key={p.key} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '2px 0', cursor: 'pointer', fontSize: 13 }}>
+                          <input
+                            type="checkbox"
+                            checked={pagePermissions.includes(p.key)}
+                            onChange={() => togglePagePermission(p.key)}
+                          />
+                          {p.label}
+                        </label>
+                      ))}
+                      {grantedCount > 0 && grantedCount < group.pages.length && (
+                        <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginTop: 4 }}>
+                          {grantedCount} / {group.pages.length}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
         </Modal>
       )}

--- a/admin/src/pages/Users.jsx
+++ b/admin/src/pages/Users.jsx
@@ -257,6 +257,28 @@ export default function Users() {
     }
   }
 
+  function selectAllWarehouses() {
+    setForm({
+      ...form,
+      warehouse_ids: warehouses.map((wh) => wh.warehouse_id),
+    });
+  }
+
+  function clearWarehouses() {
+    setForm({ ...form, warehouse_ids: [] });
+  }
+
+  function selectAllFunctions() {
+    setForm({
+      ...form,
+      allowed_functions: ALL_FUNCTIONS.map((fn) => fn.key),
+    });
+  }
+
+  function clearFunctions() {
+    setForm({ ...form, allowed_functions: [] });
+  }
+
   function warehouseCodes(warehouseIds) {
     if (!warehouseIds || warehouseIds.length === 0) return '-';
     return warehouseIds
@@ -321,7 +343,28 @@ export default function Users() {
             </select>
           </div>
           <div className="form-group">
-            <label>Warehouses</label>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <label>Warehouses</label>
+              {warehouses.length > 0 && (
+                <span style={{ fontSize: 12 }}>
+                  <button
+                    type="button"
+                    onClick={selectAllWarehouses}
+                    style={{ background: 'none', border: 'none', color: 'var(--accent)', cursor: 'pointer', padding: 0, fontSize: 12 }}
+                  >
+                    Select all
+                  </button>
+                  <span style={{ color: 'var(--text-tertiary)', margin: '0 6px' }}>/</span>
+                  <button
+                    type="button"
+                    onClick={clearWarehouses}
+                    style={{ background: 'none', border: 'none', color: 'var(--accent)', cursor: 'pointer', padding: 0, fontSize: 12 }}
+                  >
+                    Clear
+                  </button>
+                </span>
+              )}
+            </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '8px 0' }}>
               {warehouses.map((wh) => (
                 <label key={wh.warehouse_id} style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
@@ -338,7 +381,26 @@ export default function Users() {
             </div>
           </div>
           <div className="form-group">
-            <label>Mobile Module Access</label>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <label>Mobile Module Access</label>
+              <span style={{ fontSize: 12 }}>
+                <button
+                  type="button"
+                  onClick={selectAllFunctions}
+                  style={{ background: 'none', border: 'none', color: 'var(--accent)', cursor: 'pointer', padding: 0, fontSize: 12 }}
+                >
+                  Select all
+                </button>
+                <span style={{ color: 'var(--text-tertiary)', margin: '0 6px' }}>/</span>
+                <button
+                  type="button"
+                  onClick={clearFunctions}
+                  style={{ background: 'none', border: 'none', color: 'var(--accent)', cursor: 'pointer', padding: 0, fontSize: 12 }}
+                >
+                  Clear
+                </button>
+              </span>
+            </div>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, padding: '8px 0' }}>
               {ALL_FUNCTIONS.map((fn) => (
                 <label key={fn.key} style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', minWidth: 100 }}>

--- a/admin/src/pages/Users.jsx
+++ b/admin/src/pages/Users.jsx
@@ -106,7 +106,7 @@ export default function Users() {
   }
 
   async function loadWarehouses() {
-    const res = await api.get('/admin/warehouses');
+    const res = await api.get('/admin/warehouses', { silentPermissionDenied: true });
     if (res?.ok) {
       const data = await res.json();
       setWarehouses(data.warehouses || []);

--- a/admin/src/pages/Webhooks.jsx
+++ b/admin/src/pages/Webhooks.jsx
@@ -882,7 +882,7 @@ export default function Webhooks() {
     const [connRes, catalogRes, whRes] = await Promise.all([
       api.get('/admin/connector-registry'),
       api.get('/admin/scope-catalog'),
-      api.get('/admin/warehouses'),
+      api.get('/admin/warehouses', { silentPermissionDenied: true }),
     ]);
     if (connRes?.ok) {
       const data = await connRes.json();
@@ -999,7 +999,7 @@ export default function Webhooks() {
     if (scopeCatalog.event_types.length === 0 || warehouses.length === 0) {
       const [catalogRes, whRes] = await Promise.all([
         api.get('/admin/scope-catalog'),
-        api.get('/admin/warehouses'),
+        api.get('/admin/warehouses', { silentPermissionDenied: true }),
       ]);
       if (catalogRes?.ok) {
         const data = await catalogRes.json();

--- a/admin/src/test/tokens-scope-checkboxes.test.jsx
+++ b/admin/src/test/tokens-scope-checkboxes.test.jsx
@@ -120,7 +120,7 @@ describe('Tokens create-modal checkbox scope pickers (#159)', () => {
     // Scope-catalog + warehouses fire on modal open.
     await waitFor(() => {
       expect(apiGetMock).toHaveBeenCalledWith('/admin/scope-catalog');
-      expect(apiGetMock).toHaveBeenCalledWith('/admin/warehouses');
+      expect(apiGetMock).toHaveBeenCalledWith('/admin/warehouses', { silentPermissionDenied: true });
     });
   }
 

--- a/admin/src/warehouse.jsx
+++ b/admin/src/warehouse.jsx
@@ -14,7 +14,11 @@ export function WarehouseProvider({ children }) {
 
   useEffect(() => {
     if (!user) return;
-    api.get('/admin/warehouses').then(async (res) => {
+    // P6.1: topbar warehouse picker needs this list but a USER without
+    // the "warehouses" page grant should not see the global modal.
+    // The picker just goes empty (the warehouse_id sessionStorage
+    // value can still drive every other call).
+    api.get('/admin/warehouses', { silentPermissionDenied: true }).then(async (res) => {
       if (!res?.ok) return;
       const data = await res.json();
       const list = data.warehouses || [];

--- a/api/constants.py
+++ b/api/constants.py
@@ -153,3 +153,21 @@ BIN_PICKABLE = "Pickable"
 # User roles
 ROLE_ADMIN = "ADMIN"
 ROLE_USER = "USER"
+
+# mig 061: source of truth for the per-page web-admin
+# permission grid. Keys MATCH the React admin URL slugs so the sidebar
+# filter and the @require_admin_or_page_permission decorator can both
+# read straight off this list. Adding a new admin page is a two-step
+# change: append the key here and grant it to any users who need it.
+ALL_PAGE_KEYS = (
+    "dashboard",
+    "inventory", "cycle-counts", "count-approvals",
+    "purchase-orders", "receiving", "putaway",
+    "sales-orders",
+    "picking", "packing", "shipping",
+    "items",
+    "adjustments", "inter-warehouse-transfers", "transfer-orders",
+    "warehouses", "bins", "zones", "preferred-bins",
+    "users", "api-tokens", "inbound", "consumer-groups",
+    "webhooks", "audit-log", "imports", "integrations", "settings",
+)

--- a/api/middleware/auth_middleware.py
+++ b/api/middleware/auth_middleware.py
@@ -71,6 +71,10 @@ def require_auth(f):
         # Verify the user is still active and refresh role/warehouse_ids from DB.
         # This ensures that deactivated accounts and role/warehouse changes take
         # effect immediately rather than waiting for the JWT to expire.
+        # Page permissions (mig 061): same session also fetches the user's
+        # per-page web-admin grants (USER role only). Stashed on payload
+        # so the @require_admin_or_page_permission decorator stays a
+        # pure list lookup; ADMIN bypasses with allowed_pages=None.
         import models.database as _db
         db = _db.SessionLocal()
         try:
@@ -82,6 +86,16 @@ def require_auth(f):
                 ),
                 {"uid": payload["user_id"]},
             ).fetchone()
+            allowed_pages = None
+            if row and row.is_active and row.role != "ADMIN":
+                page_rows = db.execute(
+                    text(
+                        "SELECT page_key FROM user_page_permissions "
+                        "WHERE user_id = :uid"
+                    ),
+                    {"uid": payload["user_id"]},
+                ).fetchall()
+                allowed_pages = [r.page_key for r in page_rows]
         finally:
             db.close()
 
@@ -98,6 +112,7 @@ def require_auth(f):
         # checks always reflect the current state.
         payload["role"] = row.role
         payload["warehouse_ids"] = list(row.warehouse_ids) if row.warehouse_ids else []
+        payload["allowed_pages"] = allowed_pages  # None for ADMIN, list for USER
 
         g.current_user = payload
 
@@ -222,37 +237,30 @@ def require_role(*roles):
 def require_admin_or_page_permission(page_key):
     """Web-admin permission gate (mig 061).
 
-    ADMIN bypasses the check (full access by definition). Any other
-    role must carry an explicit row in user_page_permissions for
-    this page_key, otherwise the request is rejected with 403 +
-    {error: "Permission denied", page_key: "..."} so the frontend
-    can surface a clean "Permissions Error" popup.
+    ADMIN bypasses the check (g.current_user["allowed_pages"] is None).
+    Any other role must carry the page_key in their allowed_pages
+    list (populated at auth time from user_page_permissions),
+    otherwise the request is rejected with 403 + {error:
+    "Permission denied", page_key: "..."} so the frontend can
+    surface a clean "Permissions Error" popup.
 
-    Must be applied AFTER @with_db so g.db is available for the
-    permission lookup. The query is a single PK probe on
-    user_page_permissions(user_id, page_key) so the overhead is
-    bounded even on hot endpoints.
+    Drop-in replacement for @require_role("ADMIN") - applied in the
+    same decorator slot (after @require_auth, before @validate_body
+    / @with_db).
     """
     def decorator(f):
         @wraps(f)
         def decorated(*args, **kwargs):
             user = g.current_user
-            if user.get("role") == "ADMIN":
+            allowed = user.get("allowed_pages")
+            # ADMIN: allowed is None (sentinel) -> pass.
+            # USER:  allowed is a list; page_key must be in it.
+            if allowed is None or page_key in allowed:
                 return f(*args, **kwargs)
-            user_id = user.get("user_id")
-            row = g.db.execute(
-                text(
-                    "SELECT 1 FROM user_page_permissions "
-                    "WHERE user_id = :uid AND page_key = :pk LIMIT 1"
-                ),
-                {"uid": user_id, "pk": page_key},
-            ).fetchone()
-            if not row:
-                return jsonify({
-                    "error": "Permission denied",
-                    "page_key": page_key,
-                }), 403
-            return f(*args, **kwargs)
+            return jsonify({
+                "error": "Permission denied",
+                "page_key": page_key,
+            }), 403
 
         return decorated
 

--- a/api/middleware/auth_middleware.py
+++ b/api/middleware/auth_middleware.py
@@ -219,6 +219,46 @@ def require_role(*roles):
     return decorator
 
 
+def require_admin_or_page_permission(page_key):
+    """Web-admin permission gate (mig 061).
+
+    ADMIN bypasses the check (full access by definition). Any other
+    role must carry an explicit row in user_page_permissions for
+    this page_key, otherwise the request is rejected with 403 +
+    {error: "Permission denied", page_key: "..."} so the frontend
+    can surface a clean "Permissions Error" popup.
+
+    Must be applied AFTER @with_db so g.db is available for the
+    permission lookup. The query is a single PK probe on
+    user_page_permissions(user_id, page_key) so the overhead is
+    bounded even on hot endpoints.
+    """
+    def decorator(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            user = g.current_user
+            if user.get("role") == "ADMIN":
+                return f(*args, **kwargs)
+            user_id = user.get("user_id")
+            row = g.db.execute(
+                text(
+                    "SELECT 1 FROM user_page_permissions "
+                    "WHERE user_id = :uid AND page_key = :pk LIMIT 1"
+                ),
+                {"uid": user_id, "pk": page_key},
+            ).fetchone()
+            if not row:
+                return jsonify({
+                    "error": "Permission denied",
+                    "page_key": page_key,
+                }), 403
+            return f(*args, **kwargs)
+
+        return decorated
+
+    return decorator
+
+
 # v1.5.1 V-201 (#142): the v1.5.0 guard rejected only unset / empty
 # pepper values; a 1-byte pepper passed silently. A weak pepper
 # collapses the precomputation defense pepper exists to provide.

--- a/api/routes/admin/admin_connectors.py
+++ b/api/routes/admin/admin_connectors.py
@@ -9,7 +9,7 @@ from flask import g, jsonify
 
 from connectors import registry
 from connectors.url_guard import BlockedDestinationError
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import admin_bp
 from schemas.connectors import DeleteCredentialsRequest, SaveCredentialsRequest, TestConnectionRequest
@@ -24,7 +24,7 @@ VALID_SYNC_TYPES = ("orders", "items", "inventory", "fulfillment")
 
 @admin_bp.route("/connectors", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("integrations")
 def list_connectors():
     """List all registered connectors with their config schemas and capabilities."""
     connectors = registry.list_all()
@@ -42,7 +42,7 @@ def list_connectors():
 
 @admin_bp.route("/connectors/<connector_name>/config-schema", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("integrations")
 def get_config_schema(connector_name):
     """Get the required credential fields for a specific connector."""
     try:
@@ -60,7 +60,7 @@ def get_config_schema(connector_name):
 
 @admin_bp.route("/connectors/<connector_name>/credentials", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("integrations")
 @limiter.limit("10 per minute")
 @validate_body(SaveCredentialsRequest)
 @with_db
@@ -86,7 +86,7 @@ def save_credentials(connector_name, validated):
 
 @admin_bp.route("/connectors/<connector_name>/credentials", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("integrations")
 @with_db
 def get_credentials(connector_name):
     """List stored credential keys for a connector+warehouse. Values are masked."""
@@ -126,7 +126,7 @@ def get_credentials(connector_name):
 
 @admin_bp.route("/connectors/<connector_name>/test", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("integrations")
 @limiter.limit("10 per minute")
 @validate_body(TestConnectionRequest)
 @with_db
@@ -165,7 +165,7 @@ def test_connection(connector_name, validated):
 
 @admin_bp.route("/connectors/<connector_name>/credentials", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("integrations")
 @validate_body(DeleteCredentialsRequest)
 @with_db
 def remove_credentials(connector_name, validated):
@@ -192,7 +192,7 @@ def remove_credentials(connector_name, validated):
 
 @admin_bp.route("/connectors/<connector_name>/sync-status", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("integrations")
 @with_db
 def get_sync_status(connector_name):
     """Return sync state for all sync types for this connector+warehouse.
@@ -219,7 +219,7 @@ def get_sync_status(connector_name):
 
 @admin_bp.route("/connectors/<connector_name>/sync-reset", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("integrations")
 @limiter.limit("10 per minute")
 @with_db
 def reset_sync_state(connector_name):
@@ -283,7 +283,7 @@ def reset_sync_state(connector_name):
 
 @admin_bp.route("/connectors/<connector_name>/sync/<sync_type>", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("integrations")
 @limiter.limit("20 per minute")
 @with_db
 def trigger_sync(connector_name, sync_type):

--- a/api/routes/admin/admin_consumer_groups.py
+++ b/api/routes/admin/admin_consumer_groups.py
@@ -32,7 +32,7 @@ from constants import (
     ACTION_CONSUMER_GROUP_UPDATE,
     ACTION_CONSUMER_GROUP_DELETE,
 )
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import admin_bp
 from schemas.consumer_groups import (
@@ -74,7 +74,7 @@ def _row_to_group(row) -> dict:
 
 @admin_bp.route("/connector-registry", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("consumer-groups")
 @validate_body(ConnectorCreateRequest)
 @with_db
 def create_registered_connector(validated):
@@ -111,7 +111,7 @@ def create_registered_connector(validated):
 
 @admin_bp.route("/connector-registry", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("consumer-groups")
 @with_db
 def list_registered_connectors():
     rows = g.db.execute(
@@ -125,7 +125,7 @@ def list_registered_connectors():
 
 @admin_bp.route("/connector-registry/<connector_id>", methods=["PATCH"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("consumer-groups")
 @validate_body(ConnectorUpdateRequest)
 @with_db
 def update_registered_connector(validated, connector_id):
@@ -185,7 +185,7 @@ def update_registered_connector(validated, connector_id):
 
 @admin_bp.route("/connector-registry/<connector_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("consumer-groups")
 @with_db
 def delete_registered_connector(connector_id):
     """Delete a connector when no consumer_groups or
@@ -266,7 +266,7 @@ def delete_registered_connector(connector_id):
 
 @admin_bp.route("/consumer-groups", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("consumer-groups")
 @validate_body(ConsumerGroupCreateRequest)
 @with_db
 def create_consumer_group(validated):
@@ -379,7 +379,7 @@ def create_consumer_group(validated):
 
 @admin_bp.route("/consumer-groups", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("consumer-groups")
 @with_db
 def list_consumer_groups():
     rows = g.db.execute(
@@ -395,7 +395,7 @@ def list_consumer_groups():
 
 @admin_bp.route("/consumer-groups/<consumer_group_id>", methods=["PATCH"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("consumer-groups")
 @validate_body(ConsumerGroupUpdateRequest)
 @with_db
 def update_consumer_group(validated, consumer_group_id):
@@ -445,7 +445,7 @@ def update_consumer_group(validated, consumer_group_id):
 
 @admin_bp.route("/consumer-groups/<consumer_group_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("consumer-groups")
 @with_db
 def delete_consumer_group(consumer_group_id):
     # v1.5.1 V-207 (#148): RETURNING the connector_id + last_cursor so

--- a/api/routes/admin/admin_inbound.py
+++ b/api/routes/admin/admin_inbound.py
@@ -25,7 +25,7 @@ Endpoints:
 
 from flask import jsonify, request, g
 
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import admin_bp
 from sqlalchemy import text
@@ -76,7 +76,7 @@ def _activity_union_sql(filter_resource: str | None) -> str:
 
 @admin_bp.route("/inbound/activity", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("inbound")
 @with_db
 def list_inbound_activity():
     """Recent inbound activity across all five resources.
@@ -166,7 +166,7 @@ def list_inbound_activity():
     "/inbound/activity/<resource>/<int:inbound_id>", methods=["GET"]
 )
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("inbound")
 @with_db
 def get_inbound_row(resource: str, inbound_id: int):
     """Detail view: source_payload + canonical_payload + ingest metadata.

--- a/api/routes/admin/admin_items.py
+++ b/api/routes/admin/admin_items.py
@@ -8,7 +8,7 @@ from sqlalchemy import text
 
 from pydantic import ValidationError
 
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import admin_bp
 from datetime import timezone
@@ -32,7 +32,7 @@ from utils.validation import validate_body
 
 @admin_bp.route("/items", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("items")
 @with_db
 def list_items():
     page = request.args.get("page", 1, type=int)
@@ -90,7 +90,7 @@ def list_items():
 
 @admin_bp.route("/items/<int:item_id>", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("items")
 @with_db
 def get_item(item_id):
     item = g.db.execute(
@@ -147,7 +147,7 @@ def get_item(item_id):
 
 @admin_bp.route("/items", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("items")
 @validate_body(CreateItemRequest)
 @with_db
 def create_item(validated):
@@ -189,7 +189,7 @@ def create_item(validated):
 
 @admin_bp.route("/items/<int:item_id>", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("items")
 @validate_body(UpdateItemRequest)
 @with_db
 def update_item(item_id, validated):
@@ -228,7 +228,7 @@ def update_item(item_id, validated):
 
 @admin_bp.route("/items/<int:item_id>/archive", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("items")
 @with_db
 def archive_item(item_id):
     existing = g.db.execute(text("SELECT item_id, is_active FROM items WHERE item_id = :iid"), {"iid": item_id}).fetchone()
@@ -243,7 +243,7 @@ def archive_item(item_id):
 
 @admin_bp.route("/items/<int:item_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("items")
 @with_db
 def delete_item(item_id):
     existing = g.db.execute(text("SELECT item_id FROM items WHERE item_id = :iid"), {"iid": item_id}).fetchone()
@@ -286,7 +286,7 @@ def delete_item(item_id):
 
 @admin_bp.route("/inventory", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("inventory")
 @with_db
 def list_inventory():
     page = request.args.get("page", 1, type=int)
@@ -395,7 +395,7 @@ def _validate_row(entity_type, rec):
 
 @admin_bp.route("/import/<entity_type>", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("imports")
 @with_db
 def csv_import(entity_type):
     if entity_type not in _IMPORT_ROW_SCHEMAS:
@@ -770,7 +770,7 @@ def _import_inventory_adjustment(db, row: InventoryAdjustmentImportRow):
 
 @admin_bp.route("/preferred-bins", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("preferred-bins")
 @with_db
 def list_preferred_bins():
     item_id = request.args.get("item_id", type=int)
@@ -828,7 +828,7 @@ def list_preferred_bins():
 
 @admin_bp.route("/preferred-bins", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("preferred-bins")
 @validate_body(CreatePreferredBinRequest)
 @with_db
 def create_preferred_bin(validated):
@@ -852,7 +852,7 @@ def create_preferred_bin(validated):
 
 @admin_bp.route("/preferred-bins/<int:preferred_bin_id>", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("preferred-bins")
 @validate_body(UpdatePreferredBinRequest)
 @with_db
 def update_preferred_bin(preferred_bin_id, validated):
@@ -868,7 +868,7 @@ def update_preferred_bin(preferred_bin_id, validated):
 
 @admin_bp.route("/preferred-bins/<int:preferred_bin_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("preferred-bins")
 @with_db
 def delete_preferred_bin(preferred_bin_id):
     g.db.execute(

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -13,7 +13,7 @@ from constants import (
     ACTION_SO_ADDRESS_EDITED,
     ROLE_ADMIN,
 )
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import admin_bp
 from schemas.purchase_orders import CreatePurchaseOrderRequest, UpdatePurchaseOrderRequest
@@ -35,7 +35,7 @@ from utils.validation import validate_body
 
 @admin_bp.route("/purchase-orders", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("purchase-orders")
 @with_db
 def list_purchase_orders():
     page = request.args.get("page", 1, type=int)
@@ -87,7 +87,7 @@ def list_purchase_orders():
 
 @admin_bp.route("/purchase-orders/<int:po_id>", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("purchase-orders")
 @with_db
 def get_purchase_order(po_id):
     po = g.db.execute(
@@ -127,7 +127,7 @@ def get_purchase_order(po_id):
 
 @admin_bp.route("/purchase-orders", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("purchase-orders")
 @validate_body(CreatePurchaseOrderRequest)
 @with_db
 def create_purchase_order(validated):
@@ -178,7 +178,7 @@ def create_purchase_order(validated):
 
 @admin_bp.route("/purchase-orders/<int:po_id>", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("purchase-orders")
 @validate_body(UpdatePurchaseOrderRequest)
 @with_db
 def update_purchase_order(po_id, validated):
@@ -218,7 +218,7 @@ def update_purchase_order(po_id, validated):
 
 @admin_bp.route("/purchase-orders/<int:po_id>/close", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("purchase-orders")
 @with_db
 def close_purchase_order(po_id):
     po = g.db.execute(
@@ -240,7 +240,7 @@ def close_purchase_order(po_id):
 
 @admin_bp.route("/purchase-orders/<int:po_id>/reopen", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("purchase-orders")
 @with_db
 def reopen_purchase_order(po_id):
     po = g.db.execute(
@@ -266,7 +266,7 @@ def reopen_purchase_order(po_id):
 
 @admin_bp.route("/sales-orders", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("sales-orders")
 @with_db
 def list_sales_orders():
     page = request.args.get("page", 1, type=int)
@@ -323,7 +323,7 @@ def list_sales_orders():
 
 @admin_bp.route("/sales-orders/<int:so_id>", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("sales-orders")
 @with_db
 def get_sales_order(so_id):
     so = g.db.execute(
@@ -403,7 +403,7 @@ def get_sales_order(so_id):
 
 @admin_bp.route("/sales-orders", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("sales-orders")
 @validate_body(CreateSalesOrderRequest)
 @with_db
 def create_sales_order(validated):
@@ -456,7 +456,7 @@ def create_sales_order(validated):
 
 @admin_bp.route("/sales-orders/<int:so_id>", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("sales-orders")
 @validate_body(UpdateSalesOrderRequest)
 @with_db
 def update_sales_order(so_id, validated):
@@ -570,7 +570,7 @@ def update_sales_order_address(so_id, validated):
 
 @admin_bp.route("/sales-orders/<int:so_id>/cancel", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("sales-orders")
 @with_db
 def cancel_sales_order(so_id):
     """Operator-initiated cancel. Delegates to the shared
@@ -600,7 +600,7 @@ def cancel_sales_order(so_id):
 
 @admin_bp.route("/short-picks", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("sales-orders")
 @with_db
 def get_short_picks():
     """Return recent short pick events from the audit log."""

--- a/api/routes/admin/admin_search.py
+++ b/api/routes/admin/admin_search.py
@@ -12,7 +12,7 @@ since there is no customers table.
 from flask import g, jsonify, request
 from sqlalchemy import text
 
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_auth
 from middleware.db import with_db
 from routes.admin import admin_bp
 
@@ -188,7 +188,12 @@ def _search_customers(pattern: str, warehouse_id: int | None) -> list[dict]:
 
 @admin_bp.route("/search", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+# Page permissions (mig 061): reachable by any authenticated user so the
+# topbar typeahead works for USER roles. Results across items / bins /
+# POs / SOs are bounded by the warehouse_scope check inside
+# require_auth (USERs cannot pass a warehouse_id outside their grants),
+# so a USER without specific page permissions can still see search
+# hits but their click-through lands on a 403 from the gated endpoint.
 @with_db
 def global_search():
     raw_q = (request.args.get("q") or "").strip()

--- a/api/routes/admin/admin_tokens.py
+++ b/api/routes/admin/admin_tokens.py
@@ -31,8 +31,8 @@ from constants import (
 )
 from middleware.auth_middleware import (
     V150_ENDPOINT_SLUGS,
+    require_admin_or_page_permission,
     require_auth,
-    require_role,
     validate_pepper_config,
 )
 from middleware.db import with_db
@@ -158,7 +158,7 @@ def _row_to_listing(row) -> dict:
 
 @admin_bp.route("/scope-catalog", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("api-tokens")
 @with_db
 def scope_catalog():
     """Serve the admin UI's token-create modal its authoritative
@@ -249,7 +249,7 @@ def scope_catalog():
 
 @admin_bp.route("/tokens", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("api-tokens")
 @validate_body(CreateTokenRequest)
 @with_db
 def create_token(validated):
@@ -436,7 +436,7 @@ def create_token(validated):
 
 @admin_bp.route("/tokens", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("api-tokens")
 @with_db
 def list_tokens():
     """Return every wms_tokens row with its rotation-age status. No plaintext."""
@@ -458,7 +458,7 @@ def list_tokens():
 
 @admin_bp.route("/tokens/<int:token_id>/rotate", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("api-tokens")
 @with_db
 def rotate_token(token_id):
     """Issue a new plaintext, replace the hash, bump rotated_at. Plaintext once."""
@@ -532,7 +532,7 @@ def rotate_token(token_id):
 
 @admin_bp.route("/tokens/<int:token_id>/revoke", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("api-tokens")
 @with_db
 def revoke_token(token_id):
     """Flip status to revoked + stamp revoked_at. The cache TTL means
@@ -575,7 +575,7 @@ def revoke_token(token_id):
 
 @admin_bp.route("/tokens/<int:token_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("api-tokens")
 @with_db
 def delete_token(token_id):
     """Hard delete a token row. The decorator already rejects the hash

--- a/api/routes/admin/admin_transfer_orders.py
+++ b/api/routes/admin/admin_transfer_orders.py
@@ -32,7 +32,7 @@ from constants import (
     ACTION_TO_REJECTED,
     ACTION_TO_SUBMITTED,
 )
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import admin_bp
 from schemas.csv_import import TransferOrderImportRow
@@ -137,7 +137,7 @@ def _serialise_to_approval(row) -> dict:
 
 @admin_bp.route("/transfer-orders", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def list_transfer_orders():
     page = request.args.get("page", 1, type=int)
@@ -192,7 +192,7 @@ def list_transfer_orders():
 
 @admin_bp.route("/transfer-orders/<int:to_id>", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def get_transfer_order(to_id):
     header = g.db.execute(
@@ -319,7 +319,7 @@ def _release_inventory_allocation(
 
 @admin_bp.route("/transfer-orders/<int:to_id>/cancel", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def cancel_transfer_order(to_id):
     header = g.db.execute(
@@ -385,7 +385,7 @@ def cancel_transfer_order(to_id):
 
 @admin_bp.route("/transfer-orders/<int:to_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def delete_transfer_order(to_id):
     header = g.db.execute(
@@ -458,7 +458,7 @@ def delete_transfer_order(to_id):
     methods=["POST"],
 )
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def short_close_to_line(to_id, line_id):
     line = g.db.execute(
@@ -548,7 +548,7 @@ def _resolve_warehouse_id(db, code: str) -> Optional[int]:
 
 @admin_bp.route("/transfer-orders/import", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def import_transfer_order():
     """Build a single TO from a list of (sku, quantity) records.
@@ -789,7 +789,7 @@ def import_transfer_order():
     "/transfer-orders/<int:to_id>/start-picking", methods=["POST"],
 )
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def start_to_picking(to_id):
     """Create a pick_batch + pick_tasks for the TO so the picker can
@@ -1236,7 +1236,7 @@ def _credit_destination_inventory(
     methods=["POST"],
 )
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def approve_transfer_order_approval(to_id, approval_id):
     approval = g.db.execute(
@@ -1425,7 +1425,7 @@ def approve_transfer_order_approval(to_id, approval_id):
     methods=["POST"],
 )
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def reject_transfer_order_approval(to_id, approval_id):
     body = request.get_json() or {}

--- a/api/routes/admin/admin_users.py
+++ b/api/routes/admin/admin_users.py
@@ -15,7 +15,7 @@ from constants import (
     BIN_STAGING, ACTION_ADJUST,
     ALL_PAGE_KEYS,
 )
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import VALID_ROLES, admin_bp
 from schemas.inventory_adjustments import DirectAdjustmentRequest, ReviewAdjustmentsRequest
@@ -36,7 +36,7 @@ from utils.validation import validate_body
 
 @admin_bp.route("/users", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("users")
 @with_db
 def list_users():
     page = request.args.get("page", 1, type=int)
@@ -66,7 +66,7 @@ def list_users():
 
 @admin_bp.route("/users", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("users")
 @validate_body(CreateUserRequest)
 @with_db
 def create_user(validated):
@@ -109,7 +109,7 @@ def create_user(validated):
 
 @admin_bp.route("/users/<int:user_id>", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("users")
 @validate_body(UpdateUserRequest)
 @with_db
 def update_user(user_id, validated):
@@ -198,7 +198,7 @@ def update_user(user_id, validated):
 
 @admin_bp.route("/users/<int:user_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("users")
 @with_db
 def delete_user(user_id):
     existing = g.db.execute(text("SELECT user_id FROM users WHERE user_id = :uid"), {"uid": user_id}).fetchone()
@@ -234,7 +234,7 @@ def delete_user(user_id):
 
 @admin_bp.route("/users/<int:user_id>/permissions", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("users")
 @with_db
 def get_user_permissions(user_id):
     """Return the list of page_keys explicitly granted to a USER.
@@ -272,7 +272,7 @@ def get_user_permissions(user_id):
 
 @admin_bp.route("/users/<int:user_id>/permissions", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("users")
 @validate_body(UpdateUserPagePermissionsRequest)
 @with_db
 def replace_user_permissions(user_id, validated):
@@ -343,7 +343,7 @@ def replace_user_permissions(user_id, validated):
 
 @admin_bp.route("/audit-log", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("audit-log")
 @with_db
 def list_audit_log():
     page = request.args.get("page", 1, type=int)
@@ -477,7 +477,7 @@ def list_audit_log():
 
 @admin_bp.route("/dashboard", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+# /dashboard is reachable by any authenticated user so the sidebar can show badges; the response shape is non-sensitive (just counts).
 @with_db
 def dashboard():
     warehouse_id = request.args.get("warehouse_id", type=int)
@@ -629,7 +629,7 @@ def dashboard():
 
 @admin_bp.route("/settings", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("settings")
 @with_db
 def get_settings():
     rows = g.db.execute(text("SELECT id, key, value, updated_at FROM app_settings ORDER BY key")).fetchall()
@@ -644,7 +644,7 @@ def get_settings():
 
 @admin_bp.route("/settings/<setting_key>", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("settings")
 @with_db
 def get_setting(setting_key):
     row = g.db.execute(
@@ -658,7 +658,7 @@ def get_setting(setting_key):
 
 @admin_bp.route("/settings", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("settings")
 @validate_body(UpdateSettingsRequest)
 @with_db
 def update_settings(validated):
@@ -694,7 +694,7 @@ def update_settings(validated):
 
 @admin_bp.route("/cycle-counts", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("cycle-counts")
 @with_db
 def list_cycle_counts():
     rows = g.db.execute(
@@ -755,7 +755,7 @@ def list_cycle_counts():
 
 @admin_bp.route("/adjustments/pending", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("adjustments")
 @with_db
 def list_pending_adjustments():
     """Return pending inventory adjustments grouped by cycle count."""
@@ -799,7 +799,7 @@ def list_pending_adjustments():
 
 @admin_bp.route("/adjustments/review", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("adjustments")
 @validate_body(ReviewAdjustmentsRequest)
 @with_db
 def review_adjustments(validated):
@@ -974,7 +974,7 @@ def review_adjustments(validated):
 
 @admin_bp.route("/adjustments/direct", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("adjustments")
 @validate_body(DirectAdjustmentRequest)
 @with_db
 def direct_adjustment(validated):
@@ -1104,7 +1104,7 @@ def direct_adjustment(validated):
 
 @admin_bp.route("/adjustments/list", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("adjustments")
 @with_db
 def list_adjustments():
     """Return recent inventory adjustments with item and bin details."""

--- a/api/routes/admin/admin_users.py
+++ b/api/routes/admin/admin_users.py
@@ -319,12 +319,16 @@ def replace_user_permissions(user_id, validated):
         {"uid": user_id},
     )
     if requested:
+        # Pass a list of dicts so SQLAlchemy issues an executemany.
+        # Avoids the :keys::text[] form which collides with SQLAlchemy's
+        # named-parameter parser (the `::` cast is read as the start of
+        # another parameter).
         g.db.execute(
             text(
                 "INSERT INTO user_page_permissions (user_id, page_key, granted_by) "
-                "SELECT :uid, k, :gb FROM unnest(:keys::text[]) AS k"
+                "VALUES (:uid, :pk, :gb)"
             ),
-            {"uid": user_id, "keys": requested, "gb": granted_by},
+            [{"uid": user_id, "pk": pk, "gb": granted_by} for pk in requested],
         )
     g.db.commit()
     return jsonify({

--- a/api/routes/admin/admin_users.py
+++ b/api/routes/admin/admin_users.py
@@ -13,13 +13,18 @@ from constants import (
     BATCH_OPEN, BATCH_IN_PROGRESS,
     ADJ_PENDING, ADJ_APPROVED, ADJ_REJECTED,
     BIN_STAGING, ACTION_ADJUST,
+    ALL_PAGE_KEYS,
 )
 from middleware.auth_middleware import require_auth, require_role
 from middleware.db import with_db
 from routes.admin import VALID_ROLES, admin_bp
 from schemas.inventory_adjustments import DirectAdjustmentRequest, ReviewAdjustmentsRequest
 from schemas.settings import UpdateSettingsRequest
-from schemas.users import CreateUserRequest, UpdateUserRequest
+from schemas.users import (
+    CreateUserRequest,
+    UpdateUserPagePermissionsRequest,
+    UpdateUserRequest,
+)
 from services.audit_service import write_audit_log
 from services.events_service import emit_event, get_user_external_id
 from services.auth_service import validate_password
@@ -223,6 +228,111 @@ def delete_user(user_id):
     g.db.execute(text("DELETE FROM users WHERE user_id = :uid"), {"uid": user_id})
     g.db.commit()
     return jsonify({"message": "User deleted"})
+
+
+# ── Per-page web-admin permission grants (P6.1) ──────────────────────────────
+
+@admin_bp.route("/users/<int:user_id>/permissions", methods=["GET"])
+@require_auth
+@require_role("ADMIN")
+@with_db
+def get_user_permissions(user_id):
+    """Return the list of page_keys explicitly granted to a USER.
+    ADMIN role users return the full ALL_PAGE_KEYS catalog so the UI
+    can mark every checkbox without a separate role check."""
+    user = g.db.execute(
+        text("SELECT user_id, role FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    if user.role == "ADMIN":
+        return jsonify({
+            "user_id": user_id,
+            "role": "ADMIN",
+            "page_keys": list(ALL_PAGE_KEYS),
+            "is_full_access": True,
+        })
+
+    rows = g.db.execute(
+        text(
+            "SELECT page_key FROM user_page_permissions "
+            "WHERE user_id = :uid ORDER BY page_key"
+        ),
+        {"uid": user_id},
+    ).fetchall()
+    return jsonify({
+        "user_id": user_id,
+        "role": user.role,
+        "page_keys": [r.page_key for r in rows],
+        "is_full_access": False,
+    })
+
+
+@admin_bp.route("/users/<int:user_id>/permissions", methods=["PUT"])
+@require_auth
+@require_role("ADMIN")
+@validate_body(UpdateUserPagePermissionsRequest)
+@with_db
+def replace_user_permissions(user_id, validated):
+    """Replace a user's full per-page grant set in one transaction.
+
+    Unknown page_keys land as 400 so a typo cannot quietly persist a
+    grant the sidebar will never honor. The replace-all semantics mean
+    the caller does not have to diff and DELETE the old set; whatever
+    page_keys arrive in the body become the new authoritative set.
+
+    Granting permissions to an ADMIN is a no-op: ADMINs bypass the
+    table entirely so the rows do nothing useful. The handler still
+    accepts the request without writing rows so the frontend's
+    "Save permissions" button does not have to special-case roles.
+    """
+    user = g.db.execute(
+        text("SELECT user_id, role FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    requested = list(dict.fromkeys(validated.page_keys))  # de-dup, preserve order
+    unknown = [k for k in requested if k not in ALL_PAGE_KEYS]
+    if unknown:
+        return jsonify({
+            "error": "Unknown page_key(s)",
+            "unknown": unknown,
+        }), 400
+
+    if user.role == "ADMIN":
+        # ADMINs always have full access; rows are inert. Skip the
+        # write so we do not pollute the table with redundant data.
+        return jsonify({
+            "user_id": user_id,
+            "role": "ADMIN",
+            "page_keys": list(ALL_PAGE_KEYS),
+            "is_full_access": True,
+        })
+
+    granted_by = g.current_user["user_id"]
+    g.db.execute(
+        text("DELETE FROM user_page_permissions WHERE user_id = :uid"),
+        {"uid": user_id},
+    )
+    if requested:
+        g.db.execute(
+            text(
+                "INSERT INTO user_page_permissions (user_id, page_key, granted_by) "
+                "SELECT :uid, k, :gb FROM unnest(:keys::text[]) AS k"
+            ),
+            {"uid": user_id, "keys": requested, "gb": granted_by},
+        )
+    g.db.commit()
+    return jsonify({
+        "user_id": user_id,
+        "role": user.role,
+        "page_keys": requested,
+        "is_full_access": False,
+    })
 
 
 # ── Audit Log ─────────────────────────────────────────────────────────────────

--- a/api/routes/admin/admin_warehouse.py
+++ b/api/routes/admin/admin_warehouse.py
@@ -7,7 +7,7 @@ from flask import g, jsonify, request
 from sqlalchemy import text
 
 from constants import ACTION_TRANSFER
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import VALID_BIN_TYPES, VALID_ZONE_TYPES, admin_bp
 from schemas.bins import CreateBinRequest, UpdateBinRequest
@@ -22,7 +22,7 @@ from utils.validation import validate_body
 
 @admin_bp.route("/warehouses", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("warehouses")
 @with_db
 def list_warehouses():
     page = request.args.get("page", 1, type=int)
@@ -47,7 +47,7 @@ def list_warehouses():
 
 @admin_bp.route("/warehouses/<int:warehouse_id>", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("warehouses")
 @with_db
 def get_warehouse(warehouse_id):
     wh = g.db.execute(
@@ -72,7 +72,7 @@ def get_warehouse(warehouse_id):
 
 @admin_bp.route("/warehouses", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("warehouses")
 @validate_body(CreateWarehouseRequest)
 @with_db
 def create_warehouse(validated):
@@ -96,7 +96,7 @@ def create_warehouse(validated):
 
 @admin_bp.route("/warehouses/<int:warehouse_id>", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("warehouses")
 @validate_body(UpdateWarehouseRequest)
 @with_db
 def update_warehouse(warehouse_id, validated):
@@ -131,7 +131,7 @@ def update_warehouse(warehouse_id, validated):
 
 @admin_bp.route("/warehouses/<int:warehouse_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("warehouses")
 @with_db
 def delete_warehouse(warehouse_id):
     wh = g.db.execute(text("SELECT warehouse_id FROM warehouses WHERE warehouse_id = :wid"), {"wid": warehouse_id}).fetchone()
@@ -172,7 +172,7 @@ def delete_warehouse(warehouse_id):
 
 @admin_bp.route("/zones", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("zones")
 @with_db
 def list_zones():
     page = request.args.get("page", 1, type=int)
@@ -205,7 +205,7 @@ def list_zones():
 
 @admin_bp.route("/zones", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("zones")
 @validate_body(CreateZoneRequest)
 @with_db
 def create_zone(validated):
@@ -230,7 +230,7 @@ def create_zone(validated):
 
 @admin_bp.route("/zones/<int:zone_id>", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("zones")
 @validate_body(UpdateZoneRequest)
 @with_db
 def update_zone(zone_id, validated):
@@ -263,7 +263,7 @@ def update_zone(zone_id, validated):
 
 @admin_bp.route("/zones/<int:zone_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("zones")
 @with_db
 def delete_zone(zone_id):
     existing = g.db.execute(
@@ -292,7 +292,7 @@ def delete_zone(zone_id):
 
 @admin_bp.route("/bins", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("bins")
 @with_db
 def list_bins():
     page = request.args.get("page", 1, type=int)
@@ -352,7 +352,7 @@ def list_bins():
 
 @admin_bp.route("/bins/<int:bin_id>", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("bins")
 @with_db
 def get_bin(bin_id):
     b = g.db.execute(
@@ -388,7 +388,7 @@ def get_bin(bin_id):
 
 @admin_bp.route("/bins", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("bins")
 @validate_body(CreateBinRequest)
 @with_db
 def create_bin(validated):
@@ -428,7 +428,7 @@ def create_bin(validated):
 
 @admin_bp.route("/bins/<int:bin_id>", methods=["PUT"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("bins")
 @validate_body(UpdateBinRequest)
 @with_db
 def update_bin(bin_id, validated):
@@ -470,7 +470,7 @@ def update_bin(bin_id, validated):
 
 @admin_bp.route("/bins/<int:bin_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("bins")
 @with_db
 def delete_bin(bin_id):
     existing = g.db.execute(text("SELECT bin_id, bin_code FROM bins WHERE bin_id = :bid"), {"bid": bin_id}).fetchone()
@@ -507,7 +507,7 @@ def delete_bin(bin_id):
 
 @admin_bp.route("/inter-warehouse-transfer", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @validate_body(InterWarehouseTransferRequest)
 @with_db
 def create_inter_warehouse_transfer(validated):
@@ -623,7 +623,7 @@ def create_inter_warehouse_transfer(validated):
 
 @admin_bp.route("/inter-warehouse-transfers", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("transfer-orders")
 @with_db
 def list_inter_warehouse_transfers():
     """Return recent inter-warehouse transfers with item, bin, and warehouse details."""

--- a/api/routes/admin/admin_webhooks.py
+++ b/api/routes/admin/admin_webhooks.py
@@ -40,7 +40,7 @@ from constants import (
     ACTION_WEBHOOK_SUBSCRIPTION_DELETE_SOFT,
     ACTION_WEBHOOK_SUBSCRIPTION_UPDATE,
 )
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import admin_bp
 from schemas.webhooks import (
@@ -239,7 +239,7 @@ def _check_url_tombstone(canonical_url: str, acknowledge_url_reuse: bool):
 
 @admin_bp.route("/webhooks", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @limiter.limit("60 per minute")
 @validate_body(CreateWebhookRequest)
 @with_db
@@ -463,7 +463,7 @@ def create_webhook(validated):
 
 @admin_bp.route("/webhooks", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @with_db
 def list_webhooks():
     """List every webhook subscription with a 24h stats rollup."""
@@ -488,7 +488,7 @@ def list_webhooks():
 
 @admin_bp.route("/webhooks/<subscription_id>", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @with_db
 def get_webhook(subscription_id):
     """Detail view for a single webhook subscription."""
@@ -514,7 +514,7 @@ def get_webhook(subscription_id):
 
 @admin_bp.route("/webhooks/<subscription_id>", methods=["PATCH"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @limiter.limit("60 per minute")
 @validate_body(UpdateWebhookRequest)
 @with_db
@@ -861,7 +861,7 @@ def update_webhook(validated, subscription_id):
 
 @admin_bp.route("/webhooks/<subscription_id>/rotate-secret", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @limiter.limit("60 per minute")
 @with_db
 def rotate_webhook_secret(subscription_id):
@@ -981,7 +981,7 @@ def rotate_webhook_secret(subscription_id):
 
 @admin_bp.route("/webhooks/<subscription_id>", methods=["DELETE"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @limiter.limit("60 per minute")
 @with_db
 def delete_webhook(subscription_id):
@@ -1185,7 +1185,7 @@ _DLQ_LIMIT_DEFAULT = 50
 
 @admin_bp.route("/webhooks/<subscription_id>/dlq", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @with_db
 def list_dlq(subscription_id):
     """Paginated DLQ viewer. Returns the dead-letter delivery
@@ -1313,7 +1313,7 @@ def list_dlq(subscription_id):
     "/webhooks/<subscription_id>/replay/<int:delivery_id>", methods=["POST"]
 )
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @limiter.limit("60 per minute")
 @with_db
 def replay_single(subscription_id, delivery_id):
@@ -1513,7 +1513,7 @@ def _replay_filter_clauses(f) -> tuple[str, dict, str]:
 
 @admin_bp.route("/webhooks/<subscription_id>/replay-batch", methods=["POST"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @limiter.limit("60 per minute")
 @validate_body(ReplayBatchRequest)
 @with_db
@@ -1900,7 +1900,7 @@ def _compute_lag(subscription_row) -> int | None:
 
 @admin_bp.route("/webhooks/<subscription_id>/stats", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @with_db
 def webhook_stats(subscription_id):
     """Per-subscription stats with a 30s in-process cache.
@@ -2046,7 +2046,7 @@ _WEBHOOK_ERRORS_LIMIT_DEFAULT = 50
 
 @admin_bp.route("/webhook-errors", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("webhooks")
 @with_db
 def list_webhook_errors():
     """Cross-subscription error log. Returns delivery rows in

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -211,6 +211,20 @@ def me():
     if not require_packing:
         functions = [f for f in functions if f != "pack"]
 
+    # Web-admin page grants (mig 061). ADMIN sees every
+    # registered page; USER sees only their explicit grants. Returned
+    # alongside the existing mobile allowed_functions so the React
+    # admin's sidebar can filter NAV in one shot.
+    from constants import ALL_PAGE_KEYS
+    if row.role == "ADMIN":
+        allowed_pages = list(ALL_PAGE_KEYS)
+    else:
+        page_rows = g.db.execute(
+            text("SELECT page_key FROM user_page_permissions WHERE user_id = :uid"),
+            {"uid": user_id},
+        ).fetchall()
+        allowed_pages = [r.page_key for r in page_rows]
+
     return jsonify({
         "user_id": row.user_id,
         "username": row.username,
@@ -218,6 +232,7 @@ def me():
         "role": row.role,
         "warehouse_id": row.warehouse_id,
         "allowed_functions": functions,
+        "allowed_pages": allowed_pages,
         "require_packing": require_packing,
         "must_change_password": bool(row.must_change_password),
     })

--- a/api/schemas/users.py
+++ b/api/schemas/users.py
@@ -7,6 +7,15 @@ from pydantic import BaseModel, Field, field_validator
 VALID_ROLES = ("ADMIN", "USER")
 
 
+class UpdateUserPagePermissionsRequest(BaseModel):
+    """Replaces a user's full per-page grant
+    set in one PUT. The handler validates each key against
+    constants.ALL_PAGE_KEYS so a typo lands as a clean 400 rather
+    than a silent grant that the sidebar will never honor."""
+
+    page_keys: List[str] = Field(default_factory=list, max_length=200)
+
+
 class CreateUserRequest(BaseModel):
     username: str = Field(..., min_length=1, max_length=150)
     password: str = Field(..., min_length=1, max_length=256)

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -35,14 +35,23 @@ def _picker_headers(client):
 def _web_user_with_pages(client, page_keys, username="webuser1"):
     """Create a USER role with the given web-admin page grants and
     return auth headers. Used by P6.1 tests to drive the permission
-    decorator and the /auth/me allowed_pages payload."""
+    decorator and the /auth/me allowed_pages payload.
+
+    warehouse_ids is populated alongside the legacy warehouse_id so
+    require_auth's warehouse-scope check passes when a test endpoint
+    is called with warehouse_id=1 - otherwise the middleware would
+    reject the request with 403 before the page-permission gate runs
+    and the test would not actually be exercising what it claims to.
+    """
     conn = get_raw_connection()
     cur = conn.cursor()
     import bcrypt
     pw_hash = bcrypt.hashpw(b"webuser123", bcrypt.gensalt()).decode("utf-8")
     cur.execute(
-        "INSERT INTO users (username, password_hash, full_name, role, warehouse_id, external_id) "
-        "VALUES (%s, %s, 'Web User', 'USER', 1, gen_random_uuid()) RETURNING user_id",
+        "INSERT INTO users (username, password_hash, full_name, role, "
+        "warehouse_id, warehouse_ids, external_id) "
+        "VALUES (%s, %s, 'Web User', 'USER', 1, ARRAY[1], gen_random_uuid()) "
+        "RETURNING user_id",
         (username, pw_hash),
     )
     user_id = cur.fetchone()[0]

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -32,6 +32,32 @@ def _picker_headers(client):
     return {"Authorization": f"Bearer {token}"}
 
 
+def _web_user_with_pages(client, page_keys, username="webuser1"):
+    """Create a USER role with the given web-admin page grants and
+    return auth headers. Used by P6.1 tests to drive the permission
+    decorator and the /auth/me allowed_pages payload."""
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    import bcrypt
+    pw_hash = bcrypt.hashpw(b"webuser123", bcrypt.gensalt()).decode("utf-8")
+    cur.execute(
+        "INSERT INTO users (username, password_hash, full_name, role, warehouse_id, external_id) "
+        "VALUES (%s, %s, 'Web User', 'USER', 1, gen_random_uuid()) RETURNING user_id",
+        (username, pw_hash),
+    )
+    user_id = cur.fetchone()[0]
+    for pk in page_keys:
+        cur.execute(
+            "INSERT INTO user_page_permissions (user_id, page_key) VALUES (%s, %s)",
+            (user_id, pk),
+        )
+    cur.close()
+
+    resp = client.post("/api/auth/login", json={"username": username, "password": "webuser123"})
+    token = resp.get_json()["token"]
+    return user_id, {"Authorization": f"Bearer {token}"}
+
+
 # ── Warehouses ────────────────────────────────────────────────────────────────
 
 class TestWarehouses:

--- a/db/migrations/061_user_page_permissions.sql
+++ b/db/migrations/061_user_page_permissions.sql
@@ -1,0 +1,25 @@
+-- 061: granular per-page permissions for web-admin
+-- USERs. The existing role model has just ADMIN and USER; USER could
+-- never reach the admin surface (every admin endpoint required ADMIN).
+-- The new junction table lets an ADMIN grant a USER access to a
+-- specific subset of pages.
+--
+-- Page keys are URL slugs from the React admin (e.g. 'items',
+-- 'purchase-orders'). They live in api/constants.py as ALL_PAGE_KEYS
+-- and the column has no CHECK constraint here so adding a new page
+-- only requires a constants.py update plus a row insert; no schema
+-- migration for routine page additions.
+--
+-- ADMIN role bypasses this table entirely - admins have full access
+-- by definition. Only USER role rows look up here.
+
+CREATE TABLE IF NOT EXISTS user_page_permissions (
+    user_id     INT          NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    page_key    VARCHAR(64)  NOT NULL,
+    granted_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    granted_by  INT          REFERENCES users(user_id) ON DELETE SET NULL,
+    PRIMARY KEY (user_id, page_key)
+);
+
+CREATE INDEX IF NOT EXISTS ix_user_page_permissions_user
+    ON user_page_permissions(user_id);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1951,3 +1951,18 @@ CREATE TABLE dockd_idempotency (
 );
 
 CREATE INDEX dockd_idempotency_prune ON dockd_idempotency(created_at);
+
+-- mig 061: per-page permission grants for web-admin
+-- USERs. ADMIN bypasses this table; USER must have an explicit row
+-- per page_key to reach the matching admin endpoint. Existing
+-- deploys pick this up via db/migrations/061_user_page_permissions.sql.
+CREATE TABLE IF NOT EXISTS user_page_permissions (
+    user_id     INT          NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    page_key    VARCHAR(64)  NOT NULL,
+    granted_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    granted_by  INT          REFERENCES users(user_id) ON DELETE SET NULL,
+    PRIMARY KEY (user_id, page_key)
+);
+
+CREATE INDEX IF NOT EXISTS ix_user_page_permissions_user
+    ON user_page_permissions(user_id);


### PR DESCRIPTION
## Summary

Per-page permission grants for web-admin USERs, in eight commits:

- `user_page_permissions` table (migration 061) + replace-set CRUD on the user endpoints + `/auth/me` returns `allowed_pages` (None for ADMIN, list for USER). The auth middleware fetches grants in the same session it already uses for the role/active refresh, so the new `@require_admin_or_page_permission` decorator stays a pure list lookup at request time.
- The decorator replaces `@require_role("ADMIN")` across every admin endpoint, keyed to the page each endpoint serves (ALL_PAGE_KEYS in constants.py is the single source the sidebar filter and the decorator both read).
- Sidebar filters nav to granted pages; the Users form gains a permission grid with Select all / Clear; a denied navigation surfaces one clean Permissions Error popup.
- Background fetches (sidebar badges, settings probes, modal catalogs) pass `silentPermissionDenied` so a USER never sees the popup fire over a page they did not visit; the tokens-modal test updated to match the call shape.
- Packing nav entry hides when packing is disabled in settings.

## Mobile

Zero mobile/ diffs.

## Pre-merge gate

- [x] Full api suite green locally (2351 passed); admin vitest 74/74
- [ ] CI green
