### PR TITLE
feat(admin-orders): SO edit expansion + company-local Shipped Date

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,3 +171,9 @@ SENTRY_ALLOW_INTERNAL_WEBHOOKS=false
 # starting in v1.5.1. If the combination is intentional (network-level
 # protection applied elsewhere, e.g. a cloud VPC lock-down), acknowledge
 # the risk by setting SENTRY_ALLOW_OPEN_BIND=1. Use sparingly.
+
+# Company-local timezone for operator-facing calendar dates (e.g. the
+# Shipped Date on the admin SO modal). IANA zone name. Timestamps are
+# stored in UTC; this zone converts them to the calendar date operators
+# reason about. Defaults to UTC when unset.
+SENTRY_COMPANY_TIMEZONE=UTC

--- a/admin/src/components/TopBar.jsx
+++ b/admin/src/components/TopBar.jsx
@@ -41,9 +41,29 @@ export default function TopBar({ forced = false }) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchHighlight, setSearchHighlight] = useState(-1);
+  const [serverVersion, setServerVersion] = useState(null);
   const menuRef = useRef(null);
   const whRef = useRef(null);
   const searchRef = useRef(null);
+
+  useEffect(() => {
+    // Fetch the running api version once after login so the operator can
+    // tell at a glance whether a deploy landed. /api/admin/system-info is
+    // admin-gated, so no fingerprinting concern. Silent on failure -- the
+    // version label is informational, not load-bearing.
+    if (forced || !user) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await api.get('/admin/system-info');
+        if (res?.ok && !cancelled) {
+          const data = await res.json();
+          setServerVersion(data?.version || null);
+        }
+      } catch (_) { /* ignore */ }
+    })();
+    return () => { cancelled = true; };
+  }, [forced, user]);
 
   const initials = user?.full_name
     ? user.full_name.split(' ').map(n => n[0]).join('').toUpperCase()
@@ -142,6 +162,21 @@ export default function TopBar({ forced = false }) {
           <line x1="19" y1="20" x2="23.5" y2="20" stroke="#FCF4E3" strokeWidth="1" opacity="0.4"/>
         </svg>
         Sentry WMS
+        {serverVersion && (
+          <span
+            className="topbar-version"
+            title={`API version ${serverVersion}`}
+            style={{
+              marginLeft: 8,
+              fontSize: 11,
+              fontWeight: 400,
+              opacity: 0.55,
+              letterSpacing: 0.2,
+            }}
+          >
+            v{serverVersion}
+          </span>
+        )}
       </div>
       {!forced && <div className="topbar-breadcrumb" ref={whRef} style={{ position: 'relative' }}>
         <span

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -102,6 +102,9 @@ export default function SalesOrders() {
       ship_method: so.ship_method || '',
       ship_by_date: so.ship_by_date ? so.ship_by_date.slice(0, 10) : '',
       memo: so.memo || '',
+      // Server-computed company-local Shipped Date (YYYY-MM-DD). Seeds
+      // the date picker directly so it matches the read-only view.
+      shipped_at: so.shipped_date_local || '',
     });
     setEditError('');
   }
@@ -117,6 +120,15 @@ export default function SalesOrders() {
       ship_by_date: editForm.ship_by_date || null,
       memo: editForm.memo || null,
     };
+    // Shipped Date: send only when the operator actually changed it,
+    // comparing against the server-computed company-local date. The
+    // backend anchors the picked date at noon in the company timezone,
+    // so a precise ship instant is never clobbered by a routine save.
+    // Empty clears to NULL.
+    const shippedDate = (editForm.shipped_at || '').trim();
+    if (shippedDate !== (editing.shipped_date_local || '')) {
+      body.shipped_at = shippedDate || null;
+    }
     const res = await api.put(`/admin/sales-orders/${editing.so_id}`, body);
     if (res?.ok) {
       setEditing(null);
@@ -422,6 +434,10 @@ export default function SalesOrders() {
             <div className="form-group">
               <label>Ship By</label>
               <input className="form-input" type="date" value={editForm.ship_by_date} onChange={(e) => setEditForm({ ...editForm, ship_by_date: e.target.value })} />
+            </div>
+            <div className="form-group">
+              <label className="form-label">Shipped Date</label>
+              <input className="form-input" type="date" value={editForm.shipped_at} onChange={(e) => setEditForm({ ...editForm, shipped_at: e.target.value })} />
             </div>
           </div>
           <div className="form-group">

--- a/api/app.py
+++ b/api/app.py
@@ -530,11 +530,13 @@ def create_app():
     @_require_auth
     @_require_role("ADMIN")
     def system_info():
+        from version import __version__ as _code_version
         return _jsonify(
             {
                 "proxy_fix_active": app.config.get(
                     "PROXY_FIX_ACTIVE", False
                 ),
+                "version": _code_version,
             }
         )
 

--- a/api/constants.py
+++ b/api/constants.py
@@ -2,6 +2,8 @@
 Status constants used across the Sentry WMS API.
 """
 
+import os
+
 # Purchase Order statuses
 PO_OPEN = "OPEN"
 PO_PARTIAL = "PARTIAL"
@@ -19,6 +21,14 @@ SO_PICKED = "PICKED"
 SO_PACKED = "PACKED"
 SO_SHIPPED = "SHIPPED"
 SO_CANCELLED = "CANCELLED"
+# Company-wide timezone for operator-facing calendar dates (e.g. the
+# Shipped Date on the SO modal). Timestamps are stored in UTC; this is
+# the single zone used to convert them to the local calendar date
+# operators reason about, and to anchor manually-entered dates.
+# Deployment-configurable; defaults to UTC. Single-zone assumption;
+# switch to per-row warehouses.timezone if that ever changes.
+COMPANY_TIMEZONE = os.environ.get("SENTRY_COMPANY_TIMEZONE", "UTC")
+
 
 # Pick Batch statuses
 BATCH_OPEN = "OPEN"

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -475,7 +475,20 @@ def update_sales_order(so_id, validated):
     if not so:
         return jsonify({"error": "Sales order not found"}), 404
 
-    ALLOWED_FIELDS = {"so_number", "so_barcode", "customer_name", "customer_phone", "customer_address", "ship_method", "ship_address", "ship_by_date", "priority", "memo"}
+    ALLOWED_FIELDS = {
+        "so_number", "so_barcode",
+        "customer_name", "customer_phone", "customer_address",
+        "ship_method", "ship_address", "ship_by_date",
+        "priority", "memo",
+        # Shipment-state edits for backfill of orders shipped via
+        # external systems (e.g. a retiring shipping bridge) so the warehouse view
+        # reflects the right status without going through the dockd
+        # PICKED -> PACKED -> SHIPPED chain. Direct UPDATE -- does NOT
+        # write inventory_movements or outbox events; for one-off data
+        # corrections only. Routine fulfillment still flows through
+        # /api/v1/dockd/orders/<so_number>/ship.
+        "status", "carrier", "tracking_number", "shipped_at",
+    }
     fields, params = [], {"sid": so_id}
     for col in ALLOWED_FIELDS:
         if col in data:

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -460,13 +460,20 @@ def create_sales_order(validated):
 @validate_body(UpdateSalesOrderRequest)
 @with_db
 def update_sales_order(so_id, validated):
+    """Admin edit of SO non-line fields.
+
+    Status policy: admin can edit at any status. Real-world use case is
+    customer callbacks requesting address / ship-method / memo corrections
+    after picking has started. Mirrors the looser status policy on the
+    /address PATCH endpoint below (admin bypasses the OPEN-only gate there).
+    Endpoint remains @require_role("ADMIN") so non-admin roles cannot
+    invoke it regardless of SO status.
+    """
     data = validated.model_dump(exclude_unset=True)
 
     so = g.db.execute(text("SELECT so_id, status FROM sales_orders WHERE so_id = :sid"), {"sid": so_id}).fetchone()
     if not so:
         return jsonify({"error": "Sales order not found"}), 404
-    if so.status != SO_OPEN:
-        return jsonify({"error": f"Can only update SOs with OPEN status. Current: {so.status}"}), 400
 
     ALLOWED_FIELDS = {"so_number", "so_barcode", "customer_name", "customer_phone", "customer_address", "ship_method", "ship_address", "ship_by_date", "priority", "memo"}
     fields, params = [], {"sid": so_id}

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -2,6 +2,8 @@
 
 import math
 import uuid
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from flask import g, jsonify, request
 from sqlalchemy import text
@@ -9,6 +11,7 @@ from sqlalchemy import text
 from constants import (
     PO_OPEN, PO_CLOSED, SO_OPEN, SO_PICKED, SO_PACKED, SO_CANCELLED,
     TASK_PENDING, ADJ_PENDING,
+    COMPANY_TIMEZONE,
     ACTION_PICK,
     ACTION_SO_ADDRESS_EDITED,
     ROLE_ADMIN,
@@ -297,10 +300,12 @@ def list_sales_orders():
             SELECT so_id, so_number, so_barcode, customer_name, customer_phone, customer_address,
                    status, priority, warehouse_id,
                    ship_method, ship_address, order_date, ship_by_date, created_at, created_by,
-                   carrier, tracking_number, shipped_at, memo
+                   carrier, tracking_number, shipped_at,
+                   (shipped_at AT TIME ZONE :company_tz)::date AS shipped_date_local,
+                   memo
             FROM sales_orders {where_sql} ORDER BY so_id DESC LIMIT :limit OFFSET :offset
         """),
-        params,
+        {**params, "company_tz": COMPANY_TIMEZONE},
     ).fetchall()
 
     return jsonify({
@@ -314,6 +319,7 @@ def list_sales_orders():
              "created_at": r.created_at.isoformat() if r.created_at else None, "created_by": r.created_by,
              "carrier": r.carrier, "tracking_number": r.tracking_number,
              "shipped_at": r.shipped_at.isoformat() if r.shipped_at else None,
+             "shipped_date_local": r.shipped_date_local.isoformat() if r.shipped_date_local else None,
              "memo": r.memo}
             for r in rows
         ],
@@ -334,6 +340,7 @@ def get_sales_order(so_id):
                    warehouse_id, ship_method, ship_address,
                    order_date, ship_by_date, created_at, picked_at, packed_at,
                    shipped_at, created_by,
+                   (shipped_at AT TIME ZONE :company_tz)::date AS shipped_date_local,
                    order_total, customer_shipping_paid, memo,
                    billing_address_name, billing_address_line1, billing_address_line2,
                    billing_address_city, billing_address_state,
@@ -345,7 +352,7 @@ def get_sales_order(so_id):
                    shipping_address_phone
               FROM sales_orders WHERE so_id = :sid
         """),
-        {"sid": so_id},
+        {"sid": so_id, "company_tz": COMPANY_TIMEZONE},
     ).fetchone()
     if not so:
         return jsonify({"error": "Sales order not found"}), 404
@@ -387,6 +394,13 @@ def get_sales_order(so_id):
             ),
             # v1.9.0: free-text operator-facing note (mig 055).
             "memo": so.memo,
+            # Shipped date as the company-local calendar date (UTC
+            # shipped_at converted via COMPANY_TIMEZONE in SQL). The admin
+            # modal displays and edits this single value so the read-only
+            # view and the date picker can never disagree.
+            "shipped_date_local": (
+                so.shipped_date_local.isoformat() if so.shipped_date_local else None
+            ),
             # v1.8.0 (#288): structured billing/shipping address fields.
             **{name: getattr(so, name) for name in ADDRESS_FIELD_NAMES},
         },
@@ -471,7 +485,7 @@ def update_sales_order(so_id, validated):
     """
     data = validated.model_dump(exclude_unset=True)
 
-    so = g.db.execute(text("SELECT so_id, status FROM sales_orders WHERE so_id = :sid"), {"sid": so_id}).fetchone()
+    so = g.db.execute(text("SELECT so_id, status, shipped_at FROM sales_orders WHERE so_id = :sid"), {"sid": so_id}).fetchone()
     if not so:
         return jsonify({"error": "Sales order not found"}), 404
 
@@ -491,9 +505,41 @@ def update_sales_order(so_id, validated):
     }
     fields, params = [], {"sid": so_id}
     for col in ALLOWED_FIELDS:
-        if col in data:
-            fields.append(f"{col} = :{col}")
-            params[col] = data[col]
+        if col not in data:
+            continue
+        # shipped_at is handled separately below: it is a calendar date
+        # anchored at noon in the company timezone, not a raw passthrough.
+        if col == "shipped_at":
+            continue
+        fields.append(f"{col} = :{col}")
+        params[col] = data[col]
+
+    # shipped_at: operator-entered Shipped Date. The wire value is a
+    # calendar date (YYYY-MM-DD); anchor it at noon in COMPANY_TIMEZONE
+    # so the stored UTC instant always reads back as that same date
+    # regardless of DST. Empty string clears to NULL. dockd ship writes
+    # the precise NOW() instant directly and is unaffected. Change
+    # detection compares company-local dates so a no-op re-save writes no
+    # audit row.
+    if "shipped_at" in data:
+        raw = (data["shipped_at"] or "").strip()
+        old_local = (
+            so.shipped_at.astimezone(ZoneInfo(COMPANY_TIMEZONE)).date().isoformat()
+            if so.shipped_at else ""
+        )
+        if raw != old_local:
+            if raw:
+                # CAST(... AS date), not :shipped_date::date -- SQLAlchemy
+                # text() mis-parses a :param immediately followed by the ::
+                # cast operator and leaves the bind unsubstituted.
+                fields.append(
+                    "shipped_at = (CAST(:shipped_date AS date) + time '12:00') "
+                    "AT TIME ZONE :company_tz"
+                )
+                params["shipped_date"] = raw
+                params["company_tz"] = COMPANY_TIMEZONE
+            else:
+                fields.append("shipped_at = NULL")
 
     if not fields:
         return jsonify({"error": "No valid fields provided"}), 400

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -54,6 +54,16 @@ class UpdateSalesOrderRequest(BaseModel):
     ship_by_date: Optional[str] = Field(None, max_length=32)
     priority: Optional[int] = Field(None, ge=0, le=10)
     memo: Optional[str] = Field(None, max_length=4096)
+    # Shipment-state fields editable by ADMIN. Used to backfill SOs
+    # that shipped via a retiring external system so the warehouse
+    # view reflects accurate status. Status is
+    # one of the canonical SO statuses; carrier/tracking_number/shipped_at
+    # are the same values the dockd ship endpoint writes through the
+    # service layer. Free-text NotificationOrigin column unchanged.
+    status: Optional[str] = Field(None, max_length=32)
+    carrier: Optional[str] = Field(None, max_length=64)
+    tracking_number: Optional[str] = Field(None, max_length=128)
+    shipped_at: Optional[str] = Field(None, max_length=64)
 
 
 class UpdateSalesOrderAddressRequest(BaseModel):

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -63,6 +63,9 @@ class UpdateSalesOrderRequest(BaseModel):
     status: Optional[str] = Field(None, max_length=32)
     carrier: Optional[str] = Field(None, max_length=64)
     tracking_number: Optional[str] = Field(None, max_length=128)
+    # shipped_at is a calendar date (YYYY-MM-DD): the operator-facing
+    # Shipped Date. The route anchors it at noon in COMPANY_TIMEZONE
+    # before storing. Empty string clears to NULL.
     shipped_at: Optional[str] = Field(None, max_length=64)
 
 

--- a/api/tests/test_so_shipped_date.py
+++ b/api/tests/test_so_shipped_date.py
@@ -1,0 +1,257 @@
+"""Shipped Date on the admin SO modal.
+
+shipped_at is stored as a UTC TIMESTAMPTZ (dockd ship writes NOW()).
+The admin modal surfaces it as a single company-local calendar date so
+the read-only view and the editable date picker can never disagree:
+
+- GET detail returns shipped_date_local: (shipped_at AT TIME ZONE
+  COMPANY_TIMEZONE)::date as YYYY-MM-DD, independent of the server's
+  UTC offset.
+- PUT shipped_at takes a calendar date and anchors it at noon in
+  COMPANY_TIMEZONE, so the stored instant always reads back as that
+  same date through DST. Empty string clears to NULL. A no-op re-save
+  writes no audit row.
+
+COMPANY_TIMEZONE is env-driven (default UTC); these tests pin
+America/Denver to assert across both
+the MDT (UTC-6, summer) and MST (UTC-7, winter) offsets.
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from sqlalchemy import text as sa_text
+
+
+@pytest.fixture(autouse=True)
+def _pin_company_timezone(monkeypatch):
+    """COMPANY_TIMEZONE defaults to UTC and is deployment-configurable.
+    These tests assert DST behaviour, so pin a DST-observing zone on
+    every module that imported the constant at boot."""
+    import constants as _c
+    import routes.admin.admin_orders as _ao
+    monkeypatch.setattr(_c, "COMPANY_TIMEZONE", "America/Denver")
+    monkeypatch.setattr(_ao, "COMPANY_TIMEZONE", "America/Denver")
+
+
+
+def _create_so(client, auth_headers):
+    sn = f"SO-SHIP-{uuid.uuid4().hex[:8]}"
+    resp = client.post(
+        "/api/admin/sales-orders",
+        json={
+            "so_number": sn,
+            "warehouse_id": 1,
+            "lines": [{"item_id": 1, "quantity_ordered": 1}],
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code in (200, 201), resp.get_json()
+    return resp.get_json()["sales_order"]["so_id"]
+
+
+# ----------------------------------------------------------------------
+# Pydantic schema surface
+# ----------------------------------------------------------------------
+
+
+class TestPydanticSchemas:
+    def test_update_request_accepts_shipped_at_date(self):
+        from schemas.sales_orders import UpdateSalesOrderRequest
+        req = UpdateSalesOrderRequest(shipped_at="2025-07-14")
+        assert req.shipped_at == "2025-07-14"
+
+    def test_update_request_accepts_empty_string_for_clear(self):
+        from schemas.sales_orders import UpdateSalesOrderRequest
+        req = UpdateSalesOrderRequest(shipped_at="")
+        assert req.shipped_at == ""
+
+    def test_update_request_rejects_over_64_chars(self):
+        from pydantic import ValidationError
+        from schemas.sales_orders import UpdateSalesOrderRequest
+        with pytest.raises(ValidationError) as exc:
+            UpdateSalesOrderRequest(shipped_at="x" * 65)
+        errors = exc.value.errors()
+        assert any(e["loc"] == ("shipped_at",) for e in errors)
+
+
+# ----------------------------------------------------------------------
+# GET detail surface
+# ----------------------------------------------------------------------
+
+
+class TestGetDetail:
+    def test_detail_returns_shipped_date_local_key(self, client, auth_headers):
+        """The key must always be present so the controlled date input
+        never sees undefined."""
+        get_resp = client.get("/api/admin/sales-orders/1", headers=auth_headers)
+        assert get_resp.status_code == 200
+        assert "shipped_date_local" in get_resp.get_json()["sales_order"]
+
+    def test_unshipped_order_has_null_shipped_date_local(self, client, auth_headers):
+        so_id = _create_so(client, auth_headers)
+        body = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        ).get_json()["sales_order"]
+        assert body["shipped_date_local"] is None
+
+
+# ----------------------------------------------------------------------
+# Timezone correctness: UTC instant -> company-local date
+# ----------------------------------------------------------------------
+
+
+class TestUtcToLocalDate:
+    def test_utc_instant_maps_to_local_date_summer(
+        self, client, auth_headers, _db_transaction,
+    ):
+        """An order shipped 21:00 Mountain on 2025-07-14 is the instant
+        2025-07-15T03:00Z. A naive UTC slice would show 2025-07-15; the
+        company-local date is 2025-07-14."""
+        so_id = _create_so(client, auth_headers)
+        _db_transaction.execute(
+            sa_text(
+                "UPDATE sales_orders SET shipped_at = "
+                "'2025-07-15T03:00:00+00'::timestamptz WHERE so_id = :s"
+            ),
+            {"s": so_id},
+        )
+        body = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        ).get_json()["sales_order"]
+        assert body["shipped_date_local"] == "2025-07-14"
+
+    def test_utc_instant_maps_to_local_date_winter(
+        self, client, auth_headers, _db_transaction,
+    ):
+        """Same boundary in January (MST, UTC-7): 20:00 Mountain on
+        2025-01-14 is 2025-01-15T03:00Z; local date is 2025-01-14."""
+        so_id = _create_so(client, auth_headers)
+        _db_transaction.execute(
+            sa_text(
+                "UPDATE sales_orders SET shipped_at = "
+                "'2025-01-15T03:00:00+00'::timestamptz WHERE so_id = :s"
+            ),
+            {"s": so_id},
+        )
+        body = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        ).get_json()["sales_order"]
+        assert body["shipped_date_local"] == "2025-01-14"
+
+
+# ----------------------------------------------------------------------
+# PUT round-trip: pick a date, read back the same date; noon anchor
+# ----------------------------------------------------------------------
+
+
+class TestPutRoundTrip:
+    def _local_ts(self, db, so_id):
+        return db.execute(
+            sa_text(
+                "SELECT (shipped_at AT TIME ZONE 'America/Denver') AS lts "
+                "  FROM sales_orders WHERE so_id = :s"
+            ),
+            {"s": so_id},
+        ).fetchone().lts
+
+    def test_put_date_round_trips_summer(
+        self, client, auth_headers, _db_transaction,
+    ):
+        so_id = _create_so(client, auth_headers)
+        put = client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            json={"shipped_at": "2025-07-14"},
+            headers=auth_headers,
+        )
+        assert put.status_code == 200, put.get_json()
+        # Reads back as the same calendar date.
+        body = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        ).get_json()["sales_order"]
+        assert body["shipped_date_local"] == "2025-07-14"
+        # Stored anchored at noon company-local (boundary-proof).
+        lts = self._local_ts(_db_transaction, so_id)
+        assert lts.date().isoformat() == "2025-07-14"
+        assert lts.hour == 12
+
+    def test_put_date_round_trips_winter(
+        self, client, auth_headers, _db_transaction,
+    ):
+        so_id = _create_so(client, auth_headers)
+        client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            json={"shipped_at": "2025-01-14"},
+            headers=auth_headers,
+        )
+        body = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        ).get_json()["sales_order"]
+        assert body["shipped_date_local"] == "2025-01-14"
+        lts = self._local_ts(_db_transaction, so_id)
+        assert lts.date().isoformat() == "2025-01-14"
+        assert lts.hour == 12
+
+    def test_put_empty_string_clears_to_null(
+        self, client, auth_headers, _db_transaction,
+    ):
+        so_id = _create_so(client, auth_headers)
+        client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            json={"shipped_at": "2025-07-14"},
+            headers=auth_headers,
+        )
+        client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            json={"shipped_at": ""},
+            headers=auth_headers,
+        )
+        val = _db_transaction.execute(
+            sa_text("SELECT shipped_at FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone().shipped_at
+        assert val is None
+        body = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        ).get_json()["sales_order"]
+        assert body["shipped_date_local"] is None
+
+
+# ----------------------------------------------------------------------
+# Audit / idempotency
+# ----------------------------------------------------------------------
+
+
+class TestAudit:
+    def test_noop_resave_returns_no_valid_fields(
+        self, client, auth_headers, _db_transaction,
+    ):
+        """Re-sending the same company-local date is change-detected
+        server-side: the shipped_at field is skipped, and a PUT carrying
+        nothing else returns the endpoint's empty-update contract (400
+        "No valid fields provided") instead of touching the row.
+        Edit-audit assertions ride with the salesorderedit.completed
+        event work."""
+        so_id = _create_so(client, auth_headers)
+        resp = client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            headers=auth_headers,
+            json={"shipped_at": "2025-07-14"},
+        )
+        assert resp.status_code == 200
+        resp2 = client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            headers=auth_headers,
+            json={"shipped_at": "2025-07-14"},
+        )
+        assert resp2.status_code == 400
+        assert "No valid fields" in resp2.get_json()["error"]

--- a/api/version.py
+++ b/api/version.py
@@ -1,3 +1,3 @@
 """Sentry WMS version."""
 
-__version__ = "1.5.0"
+__version__ = "1.10.4"


### PR DESCRIPTION
## Summary

Admin SO editing expansion, four commits:

- SO header edits allowed at any status (ADMIN; the endpoint stays admin-gated, so operators below ADMIN keep the OPEN-only gate).
- PUT ALLOWED_FIELDS gains status / carrier / tracking_number / shipped_at for one-off backfill of orders shipped through external systems. Direct UPDATE -- no inventory_movements or outbox events; routine fulfillment still flows through dockd.
- Admin topbar surfaces the running api version via /api/admin/system-info.
- Shipped Date on the SO edit modal, company-local: the API computes `shipped_date_local` from the stored UTC instant via the new `SENTRY_COMPANY_TIMEZONE` env (IANA zone, defaults to UTC; documented in .env.example), and a manually-picked date anchors at noon in that zone so it reads back as the same calendar date across DST. Change detection compares company-local dates, so a routine re-save never clobbers a precise dockd ship instant. Tests pin a DST-observing zone to cover both transitions.

## Mobile

Zero mobile/ diffs.

## Pre-merge gate

- [x] Full api suite green locally (2362 passed); admin vitest 74/74
- [ ] CI green
