### PR TITLE
feat(orders): SO line CRUD + so-full-edit override + source_system (mig 062)

### DIFF
--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -1,12 +1,33 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { api } from '../api.js';
+import { useAuth } from '../auth.jsx';
 import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 import Modal from '../components/Modal.jsx';
 import StatusTag from '../components/StatusTag.jsx';
 
 const STATUS_OPTIONS = ['All', 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED'];
+const EDITABLE_STATUS_OPTIONS = ['OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED'];
+// Lines are terminal once the SO has shipped or cancelled. Header edits
+// remain ADMIN-only for SHIPPED (external-system backfill); for CANCELLED
+// the operator should reopen via the cancel-undo workflow, not edit.
+const LINE_TERMINAL_STATUSES = new Set(['SHIPPED', 'CANCELLED']);
+
+// Matches PurchaseOrders.formatApiError: surfaces field-level details
+// from the @validate_body decorator instead of the bare "validation_error".
+function formatApiError(data, fallback) {
+  if (!data) return fallback;
+  if (Array.isArray(data.details) && data.details.length > 0) {
+    return data.details
+      .map((d) => {
+        const field = Array.isArray(d.loc) && d.loc.length ? d.loc.join('.') : 'request';
+        return `${field}: ${d.msg}`;
+      })
+      .join('; ');
+  }
+  return data.error || fallback;
+}
 
 // v1.8.0 (#268) per-component billing/shipping address fields. Order
 // must match the canonical column ordering for round-trip consistency.
@@ -48,6 +69,10 @@ function NullableValue({ value }) {
 }
 
 export default function SalesOrders() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'ADMIN';
+  const hasSOFullEdit = isAdmin || (user?.allowed_overrides || []).includes('so-full-edit');
+
   const [searchParams] = useSearchParams();
   const [search, setSearch] = useState(searchParams.get('q') || '');
   const [orders, setOrders] = useState([]);
@@ -68,8 +93,67 @@ export default function SalesOrders() {
   const [addressEditing, setAddressEditing] = useState(null);
   const [addressForm, setAddressForm] = useState({});
   const [addressError, setAddressError] = useState('');
+  // SO line CRUD inside the edit modal (mig 062). State
+  // mirrors PurchaseOrders.jsx: editLines is the working copy, optimistic
+  // PATCH/POST/DELETE update it without refetching; lineErrors keep
+  // the inline rejection visible per row.
+  const [editLines, setEditLines] = useState([]);
+  const [lineErrors, setLineErrors] = useState({});
+  const [newLineSku, setNewLineSku] = useState('');
+  const [newLineQty, setNewLineQty] = useState('');
+  const [newLineError, setNewLineError] = useState('');
+  const [addingLine, setAddingLine] = useState(false);
+  const [skuSuggestions, setSkuSuggestions] = useState([]);
+  const [resolvedItem, setResolvedItem] = useState(null);
+  // Allocation-release confirm: shows what will happen before the
+  // PATCH/DELETE leaves the browser so the operator can back out.
+  // intent === 'shrink' carries a target qty; 'delete' just removes.
+  const [releaseConfirm, setReleaseConfirm] = useState(null);
+  // Canonical source_system tag list for the source_system dropdown.
+  // Fetched once; ADMIN + so-full-edit-override roles can repoint.
+  const [sourceSystems, setSourceSystems] = useState([]);
 
   useEffect(() => { loadOrders(); }, [page, statusFilter, search]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    api.get('/admin/source-systems', { silentPermissionDenied: true }).then(async (res) => {
+      if (!res?.ok) return;
+      const data = await res.json();
+      setSourceSystems(data.source_systems || []);
+    });
+  }, []);
+
+  // Debounced SKU typeahead matching the PO edit modal. Quiet when the
+  // edit modal is closed; minimum 2 characters to avoid spamming the
+  // items endpoint on every keystroke.
+  useEffect(() => {
+    if (!editing) return;
+    const sku = newLineSku.trim();
+    if (sku.length < 2) {
+      setSkuSuggestions([]);
+      setResolvedItem(null);
+      return;
+    }
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/items?q=${encodeURIComponent(sku)}&per_page=10&active=true`,
+        { silentPermissionDenied: true },
+      );
+      if (!res?.ok) {
+        setSkuSuggestions([]);
+        setResolvedItem(null);
+        return;
+      }
+      const data = await res.json();
+      const items = data.items || [];
+      setSkuSuggestions(items);
+      const exact = items.find(
+        (i) => String(i.sku || '').trim().toLowerCase() === sku.toLowerCase(),
+      ) || null;
+      setResolvedItem(exact);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [newLineSku, editing]);
 
   async function loadOrders() {
     const qp = new URLSearchParams({ page: String(page), per_page: '50' });
@@ -92,21 +176,53 @@ export default function SalesOrders() {
     }
   }
 
-  function openEdit(so) {
-    setEditing(so);
+  async function openEdit(so) {
+    // Fetch the full SO with its lines so the modal can drive line
+    // CRUD without a second round-trip. Falls back to the row-level
+    // values if the detail call fails so the operator at least sees
+    // the basic edit form.
+    const res = await api.get(`/admin/sales-orders/${so.so_id}`);
+    let full = so;
+    let lines = [];
+    if (res?.ok) {
+      const data = await res.json();
+      full = data.sales_order || so;
+      lines = data.lines || [];
+    }
+    setEditing(full);
     setEditForm({
-      so_number: so.so_number || '',
-      customer_name: so.customer_name || '',
-      customer_phone: so.customer_phone || '',
-      ship_address: so.ship_address || '',
-      ship_method: so.ship_method || '',
-      ship_by_date: so.ship_by_date ? so.ship_by_date.slice(0, 10) : '',
-      memo: so.memo || '',
+      so_number: full.so_number || '',
+      customer_name: full.customer_name || '',
+      customer_phone: full.customer_phone || '',
+      ship_address: full.ship_address || '',
+      ship_method: full.ship_method || '',
+      ship_by_date: full.ship_by_date ? full.ship_by_date.slice(0, 10) : '',
+      memo: full.memo || '',
+      status: full.status || 'OPEN',
+      source_system: full.source_system || '',
       // Server-computed company-local Shipped Date (YYYY-MM-DD). Seeds
       // the date picker directly so it matches the read-only view.
-      shipped_at: so.shipped_date_local || '',
+      shipped_at: full.shipped_date_local || '',
     });
+    setEditLines(lines);
+    setLineErrors({});
+    setNewLineSku('');
+    setNewLineQty('');
+    setNewLineError('');
+    setReleaseConfirm(null);
     setEditError('');
+  }
+
+  function closeEdit() {
+    setEditing(null);
+    setEditLines([]);
+    setLineErrors({});
+    setNewLineSku('');
+    setNewLineQty('');
+    setNewLineError('');
+    setReleaseConfirm(null);
+    setEditError('');
+    setConfirmCancel(false);
   }
 
   async function saveEdit() {
@@ -120,6 +236,17 @@ export default function SalesOrders() {
       ship_by_date: editForm.ship_by_date || null,
       memo: editForm.memo || null,
     };
+    // Status edits are only sent when the operator changed the value.
+    // Sending the current status would still 200 but it noises the
+    // audit log with a self-transition row.
+    if (editForm.status && editForm.status !== editing.status) {
+      body.status = editForm.status;
+    }
+    // source_system reassignment: ADMIN-or-override gated server-side.
+    // Send only when it changed; "" tells the backend to clear to NULL.
+    if (hasSOFullEdit && editForm.source_system !== (editing.source_system || '')) {
+      body.source_system = editForm.source_system || '';
+    }
     // Shipped Date: send only when the operator actually changed it,
     // comparing against the server-computed company-local date. The
     // backend anchors the picked date at noon in the company timezone,
@@ -131,12 +258,139 @@ export default function SalesOrders() {
     }
     const res = await api.put(`/admin/sales-orders/${editing.so_id}`, body);
     if (res?.ok) {
-      setEditing(null);
+      closeEdit();
       loadOrders();
     } else {
-      const data = await res?.json();
-      setEditError(data?.error || 'Failed to save');
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
+      setEditError(formatApiError(data, 'Failed to save'));
     }
+  }
+
+  // ── line CRUD ─────────────────────────────────────────────────────────────
+
+  async function resolveSku(sku) {
+    const key = String(sku || '').trim().toLowerCase();
+    if (!key) return null;
+    const res = await api.get(
+      `/admin/items?q=${encodeURIComponent(sku)}&per_page=10&active=true`,
+      { silentPermissionDenied: true },
+    );
+    if (!res?.ok) return null;
+    const data = await res.json();
+    return (data.items || []).find(
+      (i) => String(i.sku || '').trim().toLowerCase() === key,
+    ) || null;
+  }
+
+  async function addLine() {
+    setNewLineError('');
+    const sku = newLineSku.trim();
+    const qty = parseInt(newLineQty, 10);
+    if (!sku) { setNewLineError('Enter a SKU'); return; }
+    if (isNaN(qty) || qty <= 0) { setNewLineError('Enter a positive quantity'); return; }
+    setAddingLine(true);
+    try {
+      let item = resolvedItem;
+      if (!item || String(item.sku).toLowerCase() !== sku.toLowerCase()) {
+        item = await resolveSku(sku);
+      }
+      if (!item) { setNewLineError(`Unknown SKU: ${sku}`); return; }
+      const res = await api.post(
+        `/admin/sales-orders/${editing.so_id}/lines`,
+        { item_id: item.item_id, quantity_ordered: qty },
+      );
+      if (res?.ok) {
+        const created = await res.json();
+        setEditLines((ls) => [
+          ...ls,
+          { ...created, item_name: item.item_name, upc: item.upc },
+        ]);
+        setNewLineSku('');
+        setNewLineQty('');
+        setResolvedItem(null);
+        setSkuSuggestions([]);
+      } else {
+        let data = null;
+        try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
+        setNewLineError(formatApiError(data, 'Failed to add line'));
+      }
+    } finally {
+      setAddingLine(false);
+    }
+  }
+
+  // Commits a quantity_ordered edit. If new qty crosses below
+  // quantity_allocated, we route through the release-confirm modal so
+  // the operator explicitly acknowledges that pick-batch allocations
+  // will be unwound.
+  function requestLineQtyEdit(line, newQty) {
+    if (newQty < (line.quantity_allocated || 0) && (line.quantity_allocated || 0) > 0) {
+      setReleaseConfirm({ intent: 'shrink', line, newQty });
+      return;
+    }
+    return commitLineQtyEdit(line, newQty);
+  }
+
+  async function commitLineQtyEdit(line, newQty) {
+    setLineErrors((e) => ({ ...e, [line.so_line_id]: '' }));
+    const res = await api.patch(
+      `/admin/sales-orders/${editing.so_id}/lines/${line.so_line_id}`,
+      { quantity_ordered: newQty },
+    );
+    if (res?.ok) {
+      const data = await res.json();
+      setEditLines((ls) => ls.map((l) =>
+        l.so_line_id === line.so_line_id
+          ? {
+              ...l,
+              quantity_ordered: newQty,
+              // The server zeroes quantity_allocated when it releases.
+              quantity_allocated: data.released_allocation > 0 ? 0 : l.quantity_allocated,
+            }
+          : l,
+      ));
+    } else {
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
+      setLineErrors((e) => ({
+        ...e,
+        [line.so_line_id]: formatApiError(data, 'Failed to update'),
+      }));
+    }
+  }
+
+  function requestRemoveLine(line) {
+    if ((line.quantity_allocated || 0) > 0) {
+      setReleaseConfirm({ intent: 'delete', line });
+      return;
+    }
+    return commitRemoveLine(line);
+  }
+
+  async function commitRemoveLine(line) {
+    setLineErrors((e) => ({ ...e, [line.so_line_id]: '' }));
+    const res = await api.delete(
+      `/admin/sales-orders/${editing.so_id}/lines/${line.so_line_id}`,
+    );
+    if (res?.ok) {
+      setEditLines((ls) => ls.filter((l) => l.so_line_id !== line.so_line_id));
+    } else {
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
+      setLineErrors((e) => ({
+        ...e,
+        [line.so_line_id]: formatApiError(data, 'Failed to remove'),
+      }));
+    }
+  }
+
+  async function confirmReleaseAndProceed() {
+    const c = releaseConfirm;
+    setReleaseConfirm(null);
+    if (!c) return;
+    if (c.intent === 'shrink') await commitLineQtyEdit(c.line, c.newQty);
+    else if (c.intent === 'delete') await commitRemoveLine(c.line);
   }
 
   function openAddressEdit(so) {
@@ -396,68 +650,269 @@ export default function SalesOrders() {
         </Modal>
       )}
 
-      {editing && (
+      {editing && (() => {
+        const status = editing.status;
+        const headerEditable = isAdmin || hasSOFullEdit || status === 'OPEN';
+        const lineEditable = headerEditable && !LINE_TERMINAL_STATUSES.has(status);
+        const sourceSystemEditable = hasSOFullEdit;
+        return (
+          <Modal
+            title={`Edit SO ${editing.so_number}`}
+            onClose={closeEdit}
+            size="wide"
+            footer={
+              <>
+                {status === 'OPEN' && (
+                  <button className="btn btn-danger" onClick={() => setConfirmCancel(true)}>Cancel Order</button>
+                )}
+                <button className="btn" onClick={closeEdit}>Cancel</button>
+                <button className="btn btn-primary" onClick={saveEdit} disabled={!headerEditable}>Save</button>
+              </>
+            }
+          >
+            {editError && <div className="form-error" style={{ marginBottom: 12 }}>{editError}</div>}
+            {!headerEditable && (
+              <p style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
+                Header edits are locked while the SO is {status}. Ask an
+                admin to grant the so-full-edit override if a post-OPEN
+                correction is needed.
+              </p>
+            )}
+            {headerEditable && status !== 'OPEN' && (
+              <p style={{ fontSize: 12, color: 'var(--copper)', marginBottom: 12 }}>
+                Editing past OPEN ({status}). Line changes that shrink
+                or remove allocated quantity will release pick-batch
+                allocations and require a re-pick.
+              </p>
+            )}
+            <div className="form-row">
+              <div className="form-group">
+                <label>SO Number</label>
+                <input className="form-input" disabled={!headerEditable} value={editForm.so_number} onChange={(e) => setEditForm({ ...editForm, so_number: e.target.value })} />
+              </div>
+              <div className="form-group">
+                <label>Customer</label>
+                <input className="form-input" disabled={!headerEditable} value={editForm.customer_name} onChange={(e) => setEditForm({ ...editForm, customer_name: e.target.value })} />
+              </div>
+            </div>
+            <div className="form-row">
+              <div className="form-group">
+                <label>Phone</label>
+                <input className="form-input" disabled={!headerEditable} value={editForm.customer_phone} onChange={(e) => setEditForm({ ...editForm, customer_phone: e.target.value })} />
+              </div>
+              <div className="form-group">
+                <label>Ship By</label>
+                <input className="form-input" type="date" disabled={!headerEditable} value={editForm.ship_by_date} onChange={(e) => setEditForm({ ...editForm, ship_by_date: e.target.value })} />
+              </div>
+            </div>
+            <div className="form-row">
+              <div className="form-group">
+                <label>Status</label>
+                <select
+                  className="form-select"
+                  disabled={!headerEditable}
+                  value={editForm.status}
+                  onChange={(e) => setEditForm({ ...editForm, status: e.target.value })}
+                >
+                  {EDITABLE_STATUS_OPTIONS.map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-group">
+                <label>Source System</label>
+                <select
+                  className="form-select"
+                  disabled={!sourceSystemEditable}
+                  value={editForm.source_system || ''}
+                  onChange={(e) => setEditForm({ ...editForm, source_system: e.target.value })}
+                  title={sourceSystemEditable
+                    ? 'Reassign the ERP source tag (audit-logged)'
+                    : 'ADMIN or so-full-edit override required to reassign'}
+                >
+                  <option value="">(none)</option>
+                  {sourceSystems.map((s) => (
+                    <option key={s.source_system} value={s.source_system}>
+                      {s.source_system} {s.kind ? `(${s.kind})` : ''}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="form-group">
+              <label>Ship Method</label>
+              <input className="form-input" disabled={!headerEditable} value={editForm.ship_method} onChange={(e) => setEditForm({ ...editForm, ship_method: e.target.value })} />
+            </div>
+            <div className="form-group">
+              <label>Ship Address</label>
+              <textarea className="form-input" rows={2} disabled={!headerEditable} value={editForm.ship_address} onChange={(e) => setEditForm({ ...editForm, ship_address: e.target.value })} />
+            </div>
+            <div className="form-group">
+              <label>Note (memo)</label>
+              <textarea
+                className="form-input" rows={3}
+                placeholder="Customer notes, e.g. leave at back door, fragile, double-box"
+                maxLength={4096}
+                disabled={!headerEditable}
+                value={editForm.memo}
+                onChange={(e) => setEditForm({ ...editForm, memo: e.target.value })}
+              />
+            </div>
+
+            <section className="section" style={{ marginTop: 16 }}>
+              <div className="section-title">Line Items</div>
+              {editLines.length > 0 ? (
+                <table className="lines-table">
+                  <thead>
+                    <tr>
+                      <th>SKU</th>
+                      <th>Item Name</th>
+                      <th style={{ textAlign: 'right' }}>Ordered</th>
+                      <th style={{ textAlign: 'right' }}>Allocated</th>
+                      <th style={{ textAlign: 'right' }}>Picked</th>
+                      <th style={{ textAlign: 'right' }}>Shipped</th>
+                      <th style={{ width: 40 }}></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {editLines.map((l) => {
+                      const removable = lineEditable
+                        && (l.quantity_picked || 0) === 0
+                        && (l.quantity_packed || 0) === 0
+                        && (l.quantity_shipped || 0) === 0;
+                      return (
+                        <tr key={l.so_line_id}>
+                          <td className="mono">{l.sku}</td>
+                          <td style={{ color: 'var(--text-secondary)' }}>{l.item_name}</td>
+                          <td style={{ textAlign: 'right' }}>
+                            <LineQtyInput
+                              line={l}
+                              disabled={!lineEditable}
+                              onCommit={requestLineQtyEdit}
+                            />
+                            {lineErrors[l.so_line_id] && (
+                              <div className="form-error" style={{ fontSize: 11, marginTop: 4, textAlign: 'right' }}>
+                                {lineErrors[l.so_line_id]}
+                              </div>
+                            )}
+                          </td>
+                          <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_allocated || 0}</td>
+                          <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_picked || 0}</td>
+                          <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_shipped || 0}</td>
+                          <td style={{ textAlign: 'right' }}>
+                            <button
+                              className="btn btn-sm btn-danger"
+                              onClick={() => requestRemoveLine(l)}
+                              disabled={!removable}
+                              title={!removable
+                                ? (LINE_TERMINAL_STATUSES.has(status)
+                                    ? `Lines locked while SO is ${status}`
+                                    : 'Line has picked/packed/shipped units; unwind first')
+                                : 'Remove line'}
+                              aria-label="Remove line"
+                            >&#10005;</button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              ) : (
+                <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>No line items yet.</p>
+              )}
+
+              {lineEditable && (
+                <div style={{
+                  marginTop: 12, padding: 12,
+                  background: 'var(--surface)',
+                  borderRadius: 'var(--radius)',
+                }}>
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+                    <div style={{ flex: '0 0 240px' }}>
+                      <label style={{ fontSize: 11, color: 'var(--text-secondary)', fontWeight: 500 }}>SKU</label>
+                      <input
+                        className="form-input mono"
+                        placeholder="Type SKU to search"
+                        list="so-edit-sku-suggestions"
+                        value={newLineSku}
+                        onChange={(e) => setNewLineSku(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') addLine(); }}
+                      />
+                      <datalist id="so-edit-sku-suggestions">
+                        {skuSuggestions.map((it) => (
+                          <option key={it.item_id} value={it.sku}>{it.item_name}</option>
+                        ))}
+                      </datalist>
+                    </div>
+                    <div style={{ flex: '0 0 120px' }}>
+                      <label style={{ fontSize: 11, color: 'var(--text-secondary)', fontWeight: 500 }}>Quantity</label>
+                      <input
+                        className="form-input"
+                        type="number"
+                        min={1}
+                        placeholder="0"
+                        value={newLineQty}
+                        onChange={(e) => setNewLineQty(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') addLine(); }}
+                      />
+                    </div>
+                    <div style={{ flexGrow: 1 }} />
+                    <button
+                      className="btn btn-primary"
+                      onClick={addLine}
+                      disabled={addingLine}
+                      style={{ marginTop: 16 }}
+                    >
+                      {addingLine ? 'Adding...' : 'Add Line'}
+                    </button>
+                  </div>
+                  {newLineError && (
+                    <div className="form-error" style={{ marginTop: 8, fontSize: 12 }}>
+                      {newLineError}
+                    </div>
+                  )}
+                  {!newLineError && resolvedItem && (
+                    <div style={{ marginTop: 8, fontSize: 12, color: 'var(--success)' }}>
+                      Found: <strong>{resolvedItem.sku}</strong> - {resolvedItem.item_name}
+                    </div>
+                  )}
+                  {!newLineError && !resolvedItem && newLineSku.trim().length >= 2 && skuSuggestions.length === 0 && (
+                    <div style={{ marginTop: 8, fontSize: 12, color: 'var(--text-secondary)' }}>
+                      No matches for "{newLineSku.trim()}". Click Add Line to retry the lookup.
+                    </div>
+                  )}
+                </div>
+              )}
+            </section>
+          </Modal>
+        );
+      })()}
+
+      {releaseConfirm && (
         <Modal
-          title={`Edit SO ${editing.so_number}`}
-          onClose={() => { setEditing(null); setConfirmCancel(false); }}
+          title="Release pick-batch allocation?"
+          onClose={() => setReleaseConfirm(null)}
           footer={
             <>
-              {editing.status === 'OPEN' && (
-                <button className="btn btn-danger" onClick={() => setConfirmCancel(true)}>Cancel Order</button>
-              )}
-              <button className="btn" onClick={() => setEditing(null)}>Cancel</button>
-              <button className="btn btn-primary" onClick={saveEdit} disabled={editing.status !== 'OPEN'}>Save</button>
+              <button className="btn" onClick={() => setReleaseConfirm(null)}>Back</button>
+              <button className="btn btn-danger" onClick={confirmReleaseAndProceed}>
+                {releaseConfirm.intent === 'delete' ? 'Release + Remove Line' : 'Release + Update'}
+              </button>
             </>
           }
         >
-          {editError && <div className="form-error" style={{ marginBottom: 12 }}>{editError}</div>}
-          <p style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
-            SO header fields only. Line items are fixed after SO create. Editing is
-            restricted to orders in OPEN status; once picking has started, header
-            fields are frozen to preserve the fulfillment record.
+          <p style={{ fontSize: 13, marginBottom: 8 }}>
+            Line <strong>{releaseConfirm.line.sku}</strong> currently has{' '}
+            <strong>{releaseConfirm.line.quantity_allocated}</strong> units allocated to a pick batch.
           </p>
-          <div className="form-row">
-            <div className="form-group">
-              <label>SO Number</label>
-              <input className="form-input" value={editForm.so_number} onChange={(e) => setEditForm({ ...editForm, so_number: e.target.value })} />
-            </div>
-            <div className="form-group">
-              <label>Customer</label>
-              <input className="form-input" value={editForm.customer_name} onChange={(e) => setEditForm({ ...editForm, customer_name: e.target.value })} />
-            </div>
-          </div>
-          <div className="form-row">
-            <div className="form-group">
-              <label>Phone</label>
-              <input className="form-input" value={editForm.customer_phone} onChange={(e) => setEditForm({ ...editForm, customer_phone: e.target.value })} />
-            </div>
-            <div className="form-group">
-              <label>Ship By</label>
-              <input className="form-input" type="date" value={editForm.ship_by_date} onChange={(e) => setEditForm({ ...editForm, ship_by_date: e.target.value })} />
-            </div>
-            <div className="form-group">
-              <label className="form-label">Shipped Date</label>
-              <input className="form-input" type="date" value={editForm.shipped_at} onChange={(e) => setEditForm({ ...editForm, shipped_at: e.target.value })} />
-            </div>
-          </div>
-          <div className="form-group">
-            <label>Ship Method</label>
-            <input className="form-input" value={editForm.ship_method} onChange={(e) => setEditForm({ ...editForm, ship_method: e.target.value })} />
-          </div>
-          <div className="form-group">
-            <label>Ship Address</label>
-            <textarea className="form-input" rows={2} value={editForm.ship_address} onChange={(e) => setEditForm({ ...editForm, ship_address: e.target.value })} />
-          </div>
-          <div className="form-group">
-            <label>Note (memo)</label>
-            <textarea
-              className="form-input" rows={3}
-              placeholder="Customer notes, e.g. leave at back door, fragile, double-box"
-              maxLength={4096}
-              value={editForm.memo}
-              onChange={(e) => setEditForm({ ...editForm, memo: e.target.value })}
-            />
-          </div>
+          <p style={{ fontSize: 13, marginBottom: 8 }}>
+            {releaseConfirm.intent === 'delete'
+              ? 'Removing this line will release those units back to the source bins. The line will then be deleted.'
+              : `Reducing quantity to ${releaseConfirm.newQty} (below the allocated ${releaseConfirm.line.quantity_allocated}) will release the full line allocation back to the source bins.`}
+          </p>
+          <p style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+            Released inventory becomes available for re-allocation on the next pick-batch create. The action is audit-logged.
+          </p>
         </Modal>
       )}
 
@@ -479,5 +934,43 @@ export default function SalesOrders() {
         </Modal>
       )}
     </div>
+  );
+}
+
+// Matches PurchaseOrders.LineQtyInput - inline qty input with on-blur
+// commit so an Enter or click-away triggers the PATCH. Re-syncs to
+// the parent's value after a successful update so a server-side rewrite
+// (e.g. allocation release zeroing the line) reflects immediately.
+function LineQtyInput({ line, disabled, onCommit }) {
+  const [val, setVal] = useState(String(line.quantity_ordered));
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setVal(String(line.quantity_ordered));
+  }, [line.quantity_ordered]);
+
+  async function commit() {
+    const n = parseInt(val, 10);
+    if (isNaN(n) || n <= 0 || n === line.quantity_ordered) {
+      setVal(String(line.quantity_ordered));
+      return;
+    }
+    setSaving(true);
+    await onCommit(line, n);
+    setSaving(false);
+  }
+
+  return (
+    <input
+      type="number"
+      min={1}
+      className="form-input mono"
+      style={{ width: 88, textAlign: 'right', padding: '4px 8px' }}
+      value={val}
+      disabled={disabled || saving}
+      onChange={(e) => setVal(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => { if (e.key === 'Enter') e.target.blur(); }}
+    />
   );
 }

--- a/admin/src/pages/Users.jsx
+++ b/admin/src/pages/Users.jsx
@@ -75,6 +75,20 @@ const PAGE_GROUPS = [
       { key: 'settings', label: 'Settings' },
     ],
   },
+  // Override grants (mig 062): feature-flag grants. Not pages in the
+  // sidebar; granting one lifts the OPEN-only edit gate on the
+  // matching admin surface (PO header/line edits past CLOSED+ARCHIVED;
+  // SO header/line edits past OPEN). Same storage as page grants so
+  // the multi-select reuses the existing pagePermissions array.
+  {
+    label: 'Overrides',
+    isOverride: true,
+    pages: [      {
+        key: 'so-full-edit',
+        label: 'Full SO edit (past OPEN, incl. source_system + line CRUD)',
+      },
+    ],
+  },
 ];
 
 const ALL_PAGE_KEYS = PAGE_GROUPS.flatMap((g) => g.pages.map((p) => p.key));
@@ -448,10 +462,17 @@ export default function Users() {
                 {PAGE_GROUPS.map((group) => {
                   const groupKeys = new Set(group.pages.map((p) => p.key));
                   const grantedCount = pagePermissions.filter((k) => groupKeys.has(k)).length;
+                  // The Overrides card carries an accent border so it
+                  // reads as a grant of authority, not a page-access
+                  // toggle. Granting an override is a different mental
+                  // model from picking which pages a USER can open.
+                  const cardStyle = group.isOverride
+                    ? { padding: 10, borderLeft: '3px solid var(--copper)' }
+                    : { padding: 10 };
                   return (
-                    <div key={group.label} className="card" style={{ padding: 10 }}>
+                    <div key={group.label} className="card" style={cardStyle}>
                       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
-                        <strong style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                        <strong style={{ fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: group.isOverride ? 'var(--copper)' : undefined }}>
                           {group.label}
                         </strong>
                         <span style={{ fontSize: 11 }}>

--- a/api/constants.py
+++ b/api/constants.py
@@ -181,3 +181,28 @@ ALL_PAGE_KEYS = (
     "users", "api-tokens", "inbound", "consumer-groups",
     "webhooks", "audit-log", "imports", "integrations", "settings",
 )
+
+# Override grants (mig 062): feature-flag grants that ride on the same
+# user_page_permissions table but are not pages in the sidebar. Granting
+# one lifts the status gate on SO edits so a non-admin operator can
+# repair an order past the OPEN window (e.g. fix a customer-supplied
+# typo on a CLOSED PO or repoint an SO's source_system after an ERP
+# mis-tag). ADMIN bypasses these checks; non-admins must hold the
+# override key. Kept out of ALL_PAGE_KEYS so the sidebar permission
+# grid renders them in a separate "Overrides" group.
+OVERRIDE_SO_FULL_EDIT = "so-full-edit"
+ALL_OVERRIDE_KEYS = (
+    OVERRIDE_SO_FULL_EDIT,
+)
+
+# SO mutation audit actions (mig 062). Mirror the PO line
+# CRUD coverage so the "what was on this order before it shipped"
+# question survives any post-OPEN edit. details JSONB carries the
+# before/after diff so an investigator can reconstruct the change
+# without scanning the row itself.
+ACTION_SO_LINE_ADDED = "SO_LINE_ADDED"
+ACTION_SO_LINE_UPDATED = "SO_LINE_UPDATED"
+ACTION_SO_LINE_REMOVED = "SO_LINE_REMOVED"
+ACTION_SO_HEADER_EDITED = "SO_HEADER_EDITED"
+ACTION_SO_SOURCE_SYSTEM_REASSIGNED = "SO_SOURCE_SYSTEM_REASSIGNED"
+ACTION_SO_ALLOCATION_RELEASED = "SO_ALLOCATION_RELEASED"

--- a/api/middleware/auth_middleware.py
+++ b/api/middleware/auth_middleware.py
@@ -237,10 +237,13 @@ def require_role(*roles):
 def has_override(override_key: str) -> bool:
     """Override-grant lookup (mig 062).
 
-    Returns True if the current user is ADMIN, or if their
-    allowed_pages contains override_key. Used by PO/SO route handlers
-    to lift the OPEN-only status gate when a non-admin holds the
-    matching override (po-full-edit, so-full-edit).
+    Returns True iff the user explicitly holds override_key in their
+    allowed_pages list. Unlike @require_admin_or_page_permission, an
+    ADMIN role does NOT auto-pass: the PO CLOSED/ARCHIVED gate that
+    existed pre-P7 is a deliberate safety net (an admin re-opens via
+    the status dropdown before resuming line work, preserving a clean
+    audit trail). Overrides are the new lower-bar path for non-admins
+    who need to bypass that gate; ADMIN keeps the original behavior.
 
     Read-only: does not 403 on its own. Callers branch on the
     boolean to either widen the allowed-status set or surface a
@@ -249,7 +252,9 @@ def has_override(override_key: str) -> bool:
     """
     user = g.current_user
     allowed = user.get("allowed_pages")
-    return allowed is None or override_key in allowed
+    if allowed is None:
+        return False
+    return override_key in allowed
 
 
 def require_admin_or_page_permission(page_key):

--- a/api/middleware/auth_middleware.py
+++ b/api/middleware/auth_middleware.py
@@ -234,6 +234,24 @@ def require_role(*roles):
     return decorator
 
 
+def has_override(override_key: str) -> bool:
+    """Override-grant lookup (mig 062).
+
+    Returns True if the current user is ADMIN, or if their
+    allowed_pages contains override_key. Used by PO/SO route handlers
+    to lift the OPEN-only status gate when a non-admin holds the
+    matching override (po-full-edit, so-full-edit).
+
+    Read-only: does not 403 on its own. Callers branch on the
+    boolean to either widen the allowed-status set or surface a
+    targeted 403 with their own message (preserves the existing
+    handler-controlled error responses).
+    """
+    user = g.current_user
+    allowed = user.get("allowed_pages")
+    return allowed is None or override_key in allowed
+
+
 def require_admin_or_page_permission(page_key):
     """Web-admin permission gate (mig 061).
 

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -278,6 +278,36 @@ def reopen_purchase_order(po_id):
     return jsonify({"message": "Purchase order reopened", "status": PO_OPEN})
 
 
+# ── Source Systems ────────────────────────────────────────────────────────────
+
+@admin_bp.route("/source-systems", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@with_db
+def list_source_systems():
+    """Read-only list of canonical source_system
+    tags for the SO edit modal's source_system picker.
+
+    /admin/scope-catalog already serves the same list but is gated by
+    api-tokens, which the sales-orders operator role does not get by
+    default. This focused endpoint keeps the SO edit surface usable
+    without granting the broader token permission.
+    """
+    rows = g.db.execute(
+        text(
+            "SELECT source_system, kind "
+            "  FROM inbound_source_systems_allowlist "
+            " ORDER BY source_system"
+        )
+    ).fetchall()
+    return jsonify({
+        "source_systems": [
+            {"source_system": r.source_system, "kind": r.kind}
+            for r in rows
+        ],
+    })
+
+
 # ── Sales Orders ──────────────────────────────────────────────────────────────
 
 @admin_bp.route("/sales-orders", methods=["GET"])

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -9,21 +9,34 @@ from flask import g, jsonify, request
 from sqlalchemy import text
 
 from constants import (
-    PO_OPEN, PO_CLOSED, SO_OPEN, SO_PICKED, SO_PACKED, SO_CANCELLED,
+    PO_OPEN, PO_CLOSED, SO_OPEN, SO_PICKED, SO_PACKED, SO_SHIPPED, SO_CANCELLED,
     TASK_PENDING, ADJ_PENDING,
     COMPANY_TIMEZONE,
     ACTION_PICK,
     ACTION_SO_ADDRESS_EDITED,
+    ACTION_SO_HEADER_EDITED,
+    ACTION_SO_LINE_ADDED,
+    ACTION_SO_LINE_UPDATED,
+    ACTION_SO_LINE_REMOVED,
+    ACTION_SO_SOURCE_SYSTEM_REASSIGNED,
+    ACTION_SO_ALLOCATION_RELEASED,
+    OVERRIDE_SO_FULL_EDIT,
     ROLE_ADMIN,
 )
-from middleware.auth_middleware import require_admin_or_page_permission, require_auth
+from middleware.auth_middleware import (
+    has_override,
+    require_admin_or_page_permission,
+    require_auth,
+)
 from middleware.db import with_db
 from routes.admin import admin_bp
 from schemas.purchase_orders import CreatePurchaseOrderRequest, UpdatePurchaseOrderRequest
 from schemas.sales_orders import (
     ADDRESS_FIELD_NAMES,
+    AddSalesOrderLineRequest,
     CreateSalesOrderRequest,
     UpdateSalesOrderAddressRequest,
+    UpdateSalesOrderLineRequest,
     UpdateSalesOrderRequest,
 )
 from services.audit_service import write_audit_log
@@ -342,6 +355,7 @@ def get_sales_order(so_id):
                    shipped_at, created_by,
                    (shipped_at AT TIME ZONE :company_tz)::date AS shipped_date_local,
                    order_total, customer_shipping_paid, memo,
+                   source_system,
                    billing_address_name, billing_address_line1, billing_address_line2,
                    billing_address_city, billing_address_state,
                    billing_address_postal_code, billing_address_country,
@@ -401,6 +415,9 @@ def get_sales_order(so_id):
             "shipped_date_local": (
                 so.shipped_date_local.isoformat() if so.shipped_date_local else None
             ),
+            # source_system: denormalised tag (mig 062). NULL for
+            # admin-created and POS-created SOs.
+            "source_system": so.source_system,
             # v1.8.0 (#288): structured billing/shipping address fields.
             **{name: getattr(so, name) for name in ADDRESS_FIELD_NAMES},
         },
@@ -476,24 +493,71 @@ def create_sales_order(validated):
 def update_sales_order(so_id, validated):
     """Admin edit of SO non-line fields.
 
-    Status policy: admin can edit at any status. Real-world use case is
-    customer callbacks requesting address / ship-method / memo corrections
-    after picking has started. Mirrors the looser status policy on the
-    /address PATCH endpoint below (admin bypasses the OPEN-only gate there).
-    Endpoint remains @require_role("ADMIN") so non-admin roles cannot
-    invoke it regardless of SO status.
+    Status policy:
+      * ADMIN: edit at any status (including SHIPPED, for backfill of
+        orders shipped through external systems).
+      * USER with the so-full-edit override: edit at any status except
+        SHIPPED.
+      * USER without the override: edit only when status = OPEN.
+
+    Source-system reassignment (mig 062) is gated to ADMIN or
+    so-full-edit because it changes which ERP a downstream replay
+    would target. The 16 address fields stay on /address PATCH so the
+    address-only edit path keeps its own audit shape.
+
+    Per-field audit rows mirror the address surface: one row per
+    actually-changed field carrying old/new so a post-edit forensic
+    diff does not require scanning row state.
     """
     data = validated.model_dump(exclude_unset=True)
 
-    so = g.db.execute(text("SELECT so_id, status, shipped_at FROM sales_orders WHERE so_id = :sid"), {"sid": so_id}).fetchone()
+    so = g.db.execute(
+        text(
+            "SELECT so_id, status, warehouse_id, source_system, "
+            "       so_number, so_barcode, "
+            "       customer_name, customer_phone, customer_address, "
+            "       ship_method, ship_address, ship_by_date, "
+            "       priority, memo, "
+            "       status AS cur_status, carrier, tracking_number, shipped_at "
+            "  FROM sales_orders WHERE so_id = :sid FOR UPDATE"
+        ),
+        {"sid": so_id},
+    ).fetchone()
     if not so:
         return jsonify({"error": "Sales order not found"}), 404
+
+    role = g.current_user.get("role")
+    is_admin = role == ROLE_ADMIN
+    has_so_override = has_override(OVERRIDE_SO_FULL_EDIT)
+
+    if not is_admin:
+        # Non-admin status gate. Without override: only OPEN. With
+        # override: any non-SHIPPED status.
+        if has_so_override:
+            if so.status == SO_SHIPPED:
+                return jsonify({
+                    "error": "Cannot edit a SHIPPED order; void the shipment first",
+                    "current_status": so.status,
+                }), 403
+        elif so.status != SO_OPEN:
+            return jsonify({
+                "error": "non-admin can only edit OPEN sales orders without the so-full-edit override",
+                "current_status": so.status,
+            }), 403
+
+    # source_system reassignment is the riskier knob: ADMIN-or-override.
+    # If the field was sent by a caller lacking authority, reject before
+    # the UPDATE so partial writes never land.
+    if "source_system" in data and not (is_admin or has_so_override):
+        return jsonify({
+            "error": "source_system reassignment requires ADMIN or so-full-edit override",
+        }), 403
 
     ALLOWED_FIELDS = {
         "so_number", "so_barcode",
         "customer_name", "customer_phone", "customer_address",
         "ship_method", "ship_address", "ship_by_date",
-        "priority", "memo",
+        "priority", "memo", "source_system",
         # Shipment-state edits for backfill of orders shipped via
         # external systems (e.g. a retiring shipping bridge) so the warehouse view
         # reflects the right status without going through the dockd
@@ -503,7 +567,7 @@ def update_sales_order(so_id, validated):
         # /api/v1/dockd/orders/<so_number>/ship.
         "status", "carrier", "tracking_number", "shipped_at",
     }
-    fields, params = [], {"sid": so_id}
+    fields, params, edits = [], {"sid": so_id}, []
     for col in ALLOWED_FIELDS:
         if col not in data:
             continue
@@ -511,8 +575,18 @@ def update_sales_order(so_id, validated):
         # anchored at noon in the company timezone, not a raw passthrough.
         if col == "shipped_at":
             continue
+        new_value = data[col]
+        # source_system empty string -> NULL so a CSR can clear an
+        # ERP mis-tag without picking a placeholder system. Other
+        # text fields keep their existing semantics.
+        if col == "source_system" and new_value == "":
+            new_value = None
+        old_value = getattr(so, col)
+        if old_value == new_value:
+            continue
         fields.append(f"{col} = :{col}")
-        params[col] = data[col]
+        params[col] = new_value
+        edits.append((col, old_value, new_value))
 
     # shipped_at: operator-entered Shipped Date. The wire value is a
     # calendar date (YYYY-MM-DD); anchor it at noon in COMPANY_TIMEZONE
@@ -540,22 +614,55 @@ def update_sales_order(so_id, validated):
                 params["company_tz"] = COMPANY_TIMEZONE
             else:
                 fields.append("shipped_at = NULL")
+            edits.append(("shipped_at", so.shipped_at, raw or None))
 
     if not fields:
-        return jsonify({"error": "No valid fields provided"}), 400
+        return jsonify({"unchanged": True}), 200
 
-    g.db.execute(text(f"UPDATE sales_orders SET {', '.join(fields)} WHERE so_id = :sid"), params)
+    g.db.execute(
+        text(f"UPDATE sales_orders SET {', '.join(fields)} WHERE so_id = :sid"),
+        params,
+    )
+
+    user_id = g.current_user["user_id"]
+    for field_changed, old_value, new_value in edits:
+        action = (
+            ACTION_SO_SOURCE_SYSTEM_REASSIGNED
+            if field_changed == "source_system"
+            else ACTION_SO_HEADER_EDITED
+        )
+        write_audit_log(
+            g.db,
+            action_type=action,
+            entity_type="SO",
+            entity_id=so_id,
+            user_id=user_id,
+            warehouse_id=so.warehouse_id,
+            details={
+                "field_changed": field_changed,
+                "old_value": str(old_value) if old_value is not None else None,
+                "new_value": str(new_value) if new_value is not None else None,
+            },
+        )
+
     g.db.commit()
 
     row = g.db.execute(
-        text("SELECT so_id, so_number, so_barcode, customer_name, status, warehouse_id, ship_method, ship_address, created_at FROM sales_orders WHERE so_id = :sid"),
+        text(
+            "SELECT so_id, so_number, so_barcode, customer_name, status, "
+            "       warehouse_id, ship_method, ship_address, source_system, "
+            "       created_at "
+            "  FROM sales_orders WHERE so_id = :sid"
+        ),
         {"sid": so_id},
     ).fetchone()
     return jsonify({
         "so_id": row.so_id, "so_number": row.so_number, "so_barcode": row.so_barcode,
         "customer_name": row.customer_name, "status": row.status,
         "warehouse_id": row.warehouse_id, "ship_method": row.ship_method,
-        "ship_address": row.ship_address, "created_at": row.created_at.isoformat() if row.created_at else None,
+        "ship_address": row.ship_address, "source_system": row.source_system,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "edited_fields": [e[0] for e in edits],
     })
 
 
@@ -659,6 +766,385 @@ def cancel_sales_order(so_id):
         "message": "Sales order cancelled",
         "pre_status": result["pre_status"],
         "audit_log_id": result["audit_log_id"],
+    })
+
+
+# ── Sales Order Lines (add / update / remove) ────────────────────────────────
+#
+# Mirrors the PO line surface shape but layers an
+# allocation-release pass because SO lines can have inventory committed
+# to them post-OPEN. Status gate is the same three-tier model as
+# update_sales_order: OPEN for any sales-orders user, anything else
+# requires so-full-edit override, SHIPPED + CANCELLED are terminal.
+#
+# Pick / pack / ship state on the line is treated as a hard wall:
+# quantity_picked > 0 means units have already left their source bin;
+# quantity_shipped > 0 means the load has left the building. Either
+# blocks edits even with the override because reconciling them needs
+# the unwind paths in sales_order_service, not a direct line mutation.
+
+SO_LINE_EDIT_TERMINAL_STATUSES = {SO_SHIPPED, SO_CANCELLED}
+
+
+def _so_line_edit_gate(so):
+    """Returns (allowed: bool, error_response_tuple_or_None).
+
+    Encapsulates the status-tier + override check that all SO line
+    CRUD endpoints share so the three handlers stay in lock-step.
+    """
+    if so.status in SO_LINE_EDIT_TERMINAL_STATUSES:
+        return False, (jsonify({
+            "error": f"Cannot edit lines on a {so.status} order",
+            "current_status": so.status,
+        }), 400)
+    role = g.current_user.get("role")
+    if role == ROLE_ADMIN:
+        return True, None
+    if so.status == SO_OPEN:
+        return True, None
+    if has_override(OVERRIDE_SO_FULL_EDIT):
+        return True, None
+    return False, (jsonify({
+        "error": "Line edits past OPEN require ADMIN or so-full-edit override",
+        "current_status": so.status,
+    }), 403)
+
+
+def _release_so_line_allocation(db, so_line_id: int, warehouse_id: int) -> int:
+    """Release allocations attached to a single SO line.
+
+    Walks the line's pending pick_tasks, decrements
+    inventory.quantity_allocated by each task's quantity_to_pick, zeroes
+    out sales_order_lines.quantity_allocated, then deletes the line's
+    pending pick_tasks rows. The pick_batch_orders row is left
+    untouched because it may still cover the SO's other lines.
+
+    Returns the total quantity released. Caller is responsible for
+    writing the audit row and for committing the transaction.
+
+    Mirrors the per-line subset of _unwind_allocated in
+    sales_order_service so the bin-level effect of a line shrink/delete
+    is identical to a full-SO cancel at the OPEN/PICKING boundary.
+    """
+    line = db.execute(
+        text(
+            "SELECT so_line_id, item_id, quantity_allocated "
+            "  FROM sales_order_lines WHERE so_line_id = :sol_id"
+        ),
+        {"sol_id": so_line_id},
+    ).fetchone()
+    if not line or line.quantity_allocated == 0:
+        return 0
+
+    tasks = db.execute(
+        text(
+            "SELECT bin_id, quantity_to_pick FROM pick_tasks "
+            " WHERE so_line_id = :sol_id AND status = :task_status"
+        ),
+        {"sol_id": so_line_id, "task_status": TASK_PENDING},
+    ).fetchall()
+    released_total = 0
+    for task in tasks:
+        db.execute(
+            text(
+                "UPDATE inventory "
+                "   SET quantity_allocated = GREATEST(0, quantity_allocated - :qty) "
+                " WHERE item_id = :iid AND bin_id = :bid"
+            ),
+            {"qty": task.quantity_to_pick, "iid": line.item_id, "bid": task.bin_id},
+        )
+        released_total += task.quantity_to_pick
+
+    db.execute(
+        text(
+            "DELETE FROM pick_tasks "
+            " WHERE so_line_id = :sol_id AND status = :task_status"
+        ),
+        {"sol_id": so_line_id, "task_status": TASK_PENDING},
+    )
+    db.execute(
+        text(
+            "UPDATE sales_order_lines SET quantity_allocated = 0 "
+            " WHERE so_line_id = :sol_id"
+        ),
+        {"sol_id": so_line_id},
+    )
+    return released_total
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/lines", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@validate_body(AddSalesOrderLineRequest)
+@with_db
+def add_sales_order_line(so_id, validated):
+    data = validated.model_dump()
+
+    so = g.db.execute(
+        text("SELECT so_id, status, warehouse_id FROM sales_orders WHERE so_id = :sid FOR UPDATE"),
+        {"sid": so_id},
+    ).fetchone()
+    if not so:
+        return jsonify({"error": "Sales order not found"}), 404
+
+    allowed, err = _so_line_edit_gate(so)
+    if not allowed:
+        return err
+
+    item = g.db.execute(
+        text("SELECT item_id, sku FROM items WHERE item_id = :iid"),
+        {"iid": data["item_id"]},
+    ).fetchone()
+    if not item:
+        return jsonify({"error": f"Item {data['item_id']} not found"}), 400
+
+    # Duplicate-item guard mirrors the PO surface: allocation +
+    # pick-batch creation paths fetch by (so_id, item_id) and cannot
+    # disambiguate two rows with the same item_id.
+    dup = g.db.execute(
+        text("SELECT 1 FROM sales_order_lines WHERE so_id = :sid AND item_id = :iid"),
+        {"sid": so_id, "iid": data["item_id"]},
+    ).fetchone()
+    if dup:
+        return jsonify({"error": f"Item {item.sku} is already on this SO"}), 400
+
+    next_ln = g.db.execute(
+        text("SELECT COALESCE(MAX(line_number), 0) + 1 FROM sales_order_lines WHERE so_id = :sid"),
+        {"sid": so_id},
+    ).scalar()
+
+    result = g.db.execute(
+        text(
+            """
+            INSERT INTO sales_order_lines
+                (so_id, item_id, quantity_ordered, line_number)
+            VALUES (:sid, :iid, :qty, :ln)
+            RETURNING so_line_id
+            """
+        ),
+        {
+            "sid": so_id, "iid": data["item_id"],
+            "qty": data["quantity_ordered"], "ln": next_ln,
+        },
+    )
+    so_line_id = result.fetchone()[0]
+
+    write_audit_log(
+        g.db,
+        ACTION_SO_LINE_ADDED,
+        "SO_LINE",
+        so_line_id,
+        g.current_user["user_id"],
+        so.warehouse_id,
+        details={
+            "so_id": so_id, "sku": item.sku,
+            "quantity_ordered": data["quantity_ordered"],
+        },
+    )
+    g.db.commit()
+
+    return jsonify({
+        "so_line_id": so_line_id, "so_id": so_id,
+        "item_id": data["item_id"], "sku": item.sku,
+        "quantity_ordered": data["quantity_ordered"],
+        "quantity_allocated": 0, "quantity_picked": 0,
+        "quantity_packed": 0, "quantity_shipped": 0,
+        "line_number": next_ln,
+    }), 201
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/lines/<int:so_line_id>", methods=["PATCH"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@validate_body(UpdateSalesOrderLineRequest)
+@with_db
+def update_sales_order_line(so_id, so_line_id, validated):
+    data = validated.model_dump()
+
+    so = g.db.execute(
+        text("SELECT so_id, status, warehouse_id FROM sales_orders WHERE so_id = :sid FOR UPDATE"),
+        {"sid": so_id},
+    ).fetchone()
+    if not so:
+        return jsonify({"error": "Sales order not found"}), 404
+
+    allowed, err = _so_line_edit_gate(so)
+    if not allowed:
+        return err
+
+    line = g.db.execute(
+        text(
+            """
+            SELECT sol.so_line_id, sol.quantity_ordered, sol.quantity_allocated,
+                   sol.quantity_picked, sol.quantity_packed, sol.quantity_shipped,
+                   i.sku
+              FROM sales_order_lines sol JOIN items i ON i.item_id = sol.item_id
+             WHERE sol.so_line_id = :sol_id AND sol.so_id = :sid
+            """
+        ),
+        {"sol_id": so_line_id, "sid": so_id},
+    ).fetchone()
+    if not line:
+        return jsonify({"error": "Line not found"}), 404
+
+    new_qty = data["quantity_ordered"]
+    # Picked / packed / shipped units already left their source bin or
+    # the building. Going below those numbers would orphan physical
+    # movements; require the operator to unwind via the dedicated paths
+    # (short-pick / void-ship) before shrinking the line.
+    picked_or_packed = max(line.quantity_picked, line.quantity_packed)
+    if new_qty < picked_or_packed:
+        return jsonify({
+            "error": (
+                f"quantity_ordered ({new_qty}) cannot be less than "
+                f"already-picked/packed quantity ({picked_or_packed})"
+            ),
+        }), 400
+    if new_qty < line.quantity_shipped:
+        return jsonify({
+            "error": (
+                f"quantity_ordered ({new_qty}) cannot be less than "
+                f"already-shipped quantity ({line.quantity_shipped})"
+            ),
+        }), 400
+
+    released = 0
+    # Shrinking below quantity_allocated releases the full line
+    # allocation; re-allocation happens at next pick-batch create.
+    # Going from N to a smaller N' that is still >= quantity_allocated
+    # leaves the existing allocation in place because the picker can
+    # still fulfil it.
+    if new_qty < line.quantity_allocated and line.quantity_allocated > 0:
+        released = _release_so_line_allocation(g.db, so_line_id, so.warehouse_id)
+        if released > 0:
+            write_audit_log(
+                g.db,
+                ACTION_SO_ALLOCATION_RELEASED,
+                "SO_LINE",
+                so_line_id,
+                g.current_user["user_id"],
+                so.warehouse_id,
+                details={
+                    "so_id": so_id, "sku": line.sku,
+                    "released_quantity": released,
+                    "reason": "line_quantity_reduced",
+                },
+            )
+
+    g.db.execute(
+        text(
+            "UPDATE sales_order_lines SET quantity_ordered = :qty "
+            " WHERE so_line_id = :sol_id"
+        ),
+        {"qty": new_qty, "sol_id": so_line_id},
+    )
+
+    write_audit_log(
+        g.db,
+        ACTION_SO_LINE_UPDATED,
+        "SO_LINE",
+        so_line_id,
+        g.current_user["user_id"],
+        so.warehouse_id,
+        details={
+            "so_id": so_id, "sku": line.sku,
+            "old_quantity_ordered": line.quantity_ordered,
+            "new_quantity_ordered": new_qty,
+        },
+    )
+    g.db.commit()
+    return jsonify({
+        "so_line_id": so_line_id,
+        "quantity_ordered": new_qty,
+        "released_allocation": released,
+    })
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/lines/<int:so_line_id>", methods=["DELETE"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@with_db
+def delete_sales_order_line(so_id, so_line_id):
+    so = g.db.execute(
+        text("SELECT so_id, status, warehouse_id FROM sales_orders WHERE so_id = :sid FOR UPDATE"),
+        {"sid": so_id},
+    ).fetchone()
+    if not so:
+        return jsonify({"error": "Sales order not found"}), 404
+
+    allowed, err = _so_line_edit_gate(so)
+    if not allowed:
+        return err
+
+    line = g.db.execute(
+        text(
+            """
+            SELECT sol.so_line_id, sol.quantity_ordered, sol.quantity_allocated,
+                   sol.quantity_picked, sol.quantity_packed, sol.quantity_shipped,
+                   i.sku
+              FROM sales_order_lines sol JOIN items i ON i.item_id = sol.item_id
+             WHERE sol.so_line_id = :sol_id AND sol.so_id = :sid
+            """
+        ),
+        {"sol_id": so_line_id, "sid": so_id},
+    ).fetchone()
+    if not line:
+        return jsonify({"error": "Line not found"}), 404
+
+    # Picked / packed / shipped units block deletion at any tier. To
+    # remove these the operator must unwind through the dedicated
+    # surfaces (short-pick / void-ship) so inventory movements stay
+    # consistent.
+    if line.quantity_picked > 0 or line.quantity_packed > 0 or line.quantity_shipped > 0:
+        return jsonify({
+            "error": (
+                "Line has picked/packed/shipped units; unwind via the "
+                "ship-void or short-pick path before removing the line"
+            ),
+            "quantity_picked": line.quantity_picked,
+            "quantity_packed": line.quantity_packed,
+            "quantity_shipped": line.quantity_shipped,
+        }), 400
+
+    released = 0
+    if line.quantity_allocated > 0:
+        released = _release_so_line_allocation(g.db, so_line_id, so.warehouse_id)
+        if released > 0:
+            write_audit_log(
+                g.db,
+                ACTION_SO_ALLOCATION_RELEASED,
+                "SO_LINE",
+                so_line_id,
+                g.current_user["user_id"],
+                so.warehouse_id,
+                details={
+                    "so_id": so_id, "sku": line.sku,
+                    "released_quantity": released,
+                    "reason": "line_deleted",
+                },
+            )
+
+    g.db.execute(
+        text("DELETE FROM sales_order_lines WHERE so_line_id = :sol_id"),
+        {"sol_id": so_line_id},
+    )
+
+    write_audit_log(
+        g.db,
+        ACTION_SO_LINE_REMOVED,
+        "SO_LINE",
+        so_line_id,
+        g.current_user["user_id"],
+        so.warehouse_id,
+        details={
+            "so_id": so_id, "sku": line.sku,
+            "quantity_ordered": line.quantity_ordered,
+        },
+    )
+    g.db.commit()
+    return jsonify({
+        "so_line_id": so_line_id, "deleted": True,
+        "released_allocation": released,
     })
 
 

--- a/api/routes/admin/admin_users.py
+++ b/api/routes/admin/admin_users.py
@@ -13,6 +13,7 @@ from constants import (
     BATCH_OPEN, BATCH_IN_PROGRESS,
     ADJ_PENDING, ADJ_APPROVED, ADJ_REJECTED,
     BIN_STAGING, ACTION_ADJUST,
+    ALL_OVERRIDE_KEYS,
     ALL_PAGE_KEYS,
 )
 from middleware.auth_middleware import require_admin_or_page_permission, require_auth
@@ -248,10 +249,14 @@ def get_user_permissions(user_id):
         return jsonify({"error": "User not found"}), 404
 
     if user.role == "ADMIN":
+        # ADMIN bypasses both page and override
+        # checks, so the modal should render every checkbox (including
+        # the override card) as checked. The PUT path no-ops for ADMIN
+        # so this is purely display.
         return jsonify({
             "user_id": user_id,
             "role": "ADMIN",
-            "page_keys": list(ALL_PAGE_KEYS),
+            "page_keys": list(ALL_PAGE_KEYS) + list(ALL_OVERRIDE_KEYS),
             "is_full_access": True,
         })
 
@@ -296,7 +301,11 @@ def replace_user_permissions(user_id, validated):
         return jsonify({"error": "User not found"}), 404
 
     requested = list(dict.fromkeys(validated.page_keys))  # de-dup, preserve order
-    unknown = [k for k in requested if k not in ALL_PAGE_KEYS]
+    # Override grants (mig 062) ride on the same junction
+    # table so the multi-select can write them in one PUT. The full
+    # acceptable set is ALL_PAGE_KEYS ∪ ALL_OVERRIDE_KEYS.
+    valid_keys = set(ALL_PAGE_KEYS) | set(ALL_OVERRIDE_KEYS)
+    unknown = [k for k in requested if k not in valid_keys]
     if unknown:
         return jsonify({
             "error": "Unknown page_key(s)",
@@ -309,7 +318,7 @@ def replace_user_permissions(user_id, validated):
         return jsonify({
             "user_id": user_id,
             "role": "ADMIN",
-            "page_keys": list(ALL_PAGE_KEYS),
+            "page_keys": list(ALL_PAGE_KEYS) + list(ALL_OVERRIDE_KEYS),
             "is_full_access": True,
         })
 

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -215,15 +215,25 @@ def me():
     # registered page; USER sees only their explicit grants. Returned
     # alongside the existing mobile allowed_functions so the React
     # admin's sidebar can filter NAV in one shot.
-    from constants import ALL_PAGE_KEYS
+    #
+    # Override grants (mig 062): so-full-edit (and future override keys)
+    # ride on the same user_page_permissions table but live in a
+    # separate response field so the frontend can light up edit
+    # controls without scanning allowed_pages for the override slug.
+    # ADMIN gets every override implicitly.
+    from constants import ALL_PAGE_KEYS, ALL_OVERRIDE_KEYS
+    override_set = set(ALL_OVERRIDE_KEYS)
     if row.role == "ADMIN":
         allowed_pages = list(ALL_PAGE_KEYS)
+        allowed_overrides = list(ALL_OVERRIDE_KEYS)
     else:
         page_rows = g.db.execute(
             text("SELECT page_key FROM user_page_permissions WHERE user_id = :uid"),
             {"uid": user_id},
         ).fetchall()
-        allowed_pages = [r.page_key for r in page_rows]
+        all_keys = [r.page_key for r in page_rows]
+        allowed_pages = [k for k in all_keys if k not in override_set]
+        allowed_overrides = [k for k in all_keys if k in override_set]
 
     return jsonify({
         "user_id": row.user_id,
@@ -233,6 +243,7 @@ def me():
         "warehouse_id": row.warehouse_id,
         "allowed_functions": functions,
         "allowed_pages": allowed_pages,
+        "allowed_overrides": allowed_overrides,
         "require_packing": require_packing,
         "must_change_password": bool(row.must_change_password),
     })

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -67,6 +67,33 @@ class UpdateSalesOrderRequest(BaseModel):
     # Shipped Date. The route anchors it at noon in COMPANY_TIMEZONE
     # before storing. Empty string clears to NULL.
     shipped_at: Optional[str] = Field(None, max_length=64)
+    # source_system reassignment (mig 062). ADMIN-only OR
+    # so-full-edit override; the canonical allowlist FK enforces that
+    # the value is a recognised tag. Empty string clears the column.
+    source_system: Optional[str] = Field(None, max_length=64)
+
+
+class AddSalesOrderLineRequest(BaseModel):
+    """Add a new line to an existing SO.
+
+    item_id must already exist; the handler rejects duplicates against
+    (so_id, item_id) so allocation/pick paths stay deterministic when
+    fetching lines by item_id.
+    """
+
+    item_id: int = Field(..., gt=0)
+    quantity_ordered: int = Field(..., gt=0, le=1000000)
+
+
+class UpdateSalesOrderLineRequest(BaseModel):
+    """Edit an existing SO line's quantity_ordered.
+
+    Reducing below quantity_picked / quantity_shipped is rejected (those
+    units have already left their source bin or shipped). Reducing below
+    quantity_allocated triggers an allocation release on the backend.
+    """
+
+    quantity_ordered: int = Field(..., gt=0, le=1000000)
 
 
 class UpdateSalesOrderAddressRequest(BaseModel):

--- a/api/tests/test_so_shipped_date.py
+++ b/api/tests/test_so_shipped_date.py
@@ -174,6 +174,7 @@ class TestPutRoundTrip:
             headers=auth_headers,
         )
         assert put.status_code == 200, put.get_json()
+        assert "shipped_at" in put.get_json()["edited_fields"]
         # Reads back as the same calendar date.
         body = client.get(
             f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
@@ -232,15 +233,11 @@ class TestPutRoundTrip:
 
 
 class TestAudit:
-    def test_noop_resave_returns_no_valid_fields(
+    def test_put_writes_audit_row_when_changed(
         self, client, auth_headers, _db_transaction,
     ):
-        """Re-sending the same company-local date is change-detected
-        server-side: the shipped_at field is skipped, and a PUT carrying
-        nothing else returns the endpoint's empty-update contract (400
-        "No valid fields provided") instead of touching the row.
-        Edit-audit assertions ride with the salesorderedit.completed
-        event work."""
+        """A real date change writes one SO_HEADER_EDITED audit row
+        carrying the old/new values."""
         so_id = _create_so(client, auth_headers)
         resp = client.put(
             f"/api/admin/sales-orders/{so_id}",
@@ -248,10 +245,46 @@ class TestAudit:
             json={"shipped_at": "2025-07-14"},
         )
         assert resp.status_code == 200
+        rows = _db_transaction.execute(
+            sa_text(
+                "SELECT details FROM audit_log WHERE entity_type = 'SO' "
+                "AND entity_id = :s AND action_type = 'SO_HEADER_EDITED'"
+            ),
+            {"s": so_id},
+        ).fetchall()
+        assert any(r.details.get("field_changed") == "shipped_at" for r in rows)
+
+    def test_noop_resave_writes_no_audit(
+        self, client, auth_headers, _db_transaction,
+    ):
+        """Re-sending the same company-local date is change-detected
+        server-side: no UPDATE fragment, no audit row, 200 unchanged."""
+        so_id = _create_so(client, auth_headers)
+        resp = client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            headers=auth_headers,
+            json={"shipped_at": "2025-07-14"},
+        )
+        assert resp.status_code == 200
+        before = _db_transaction.execute(
+            sa_text(
+                "SELECT count(*) AS n FROM audit_log WHERE entity_type = 'SO' "
+                "AND entity_id = :s"
+            ),
+            {"s": so_id},
+        ).fetchone().n
         resp2 = client.put(
             f"/api/admin/sales-orders/{so_id}",
             headers=auth_headers,
             json={"shipped_at": "2025-07-14"},
         )
-        assert resp2.status_code == 400
-        assert "No valid fields" in resp2.get_json()["error"]
+        assert resp2.status_code == 200
+        assert resp2.get_json().get("unchanged") is True
+        after = _db_transaction.execute(
+            sa_text(
+                "SELECT count(*) AS n FROM audit_log WHERE entity_type = 'SO' "
+                "AND entity_id = :s"
+            ),
+            {"s": so_id},
+        ).fetchone().n
+        assert after == before

--- a/db/migrations/062_sales_orders_source_system.sql
+++ b/db/migrations/062_sales_orders_source_system.sql
@@ -1,0 +1,46 @@
+-- 062: denormalise the SO's originating source_system
+-- onto the sales_orders row so the admin SO edit surface can edit it
+-- without touching the inbound history. Pre-P7 the only path to the
+-- source_system was sales_orders.latest_inbound_id ->
+-- inbound_sales_orders.source_system, which is read-mostly and not
+-- always populated (admin-created and POS-created SOs have no inbound
+-- row at all).
+--
+-- Adding the column directly:
+--   * lets a CSR repoint an SO that ingested under the wrong system
+--     tag (e.g. shopify-us when it should have been shopify-ca) via
+--     PUT /admin/sales-orders/<id> without rewriting inbound history.
+--   * gives POS / admin-created SOs a real source_system value (NULL
+--     pre-P7 because there was no inbound row to derive from).
+--   * stays FK-referenced to inbound_source_systems_allowlist so the
+--     value is always one of the canonical tags.
+--
+-- Backfill walks the latest applied inbound row per SO. SOs without an
+-- inbound history (admin-created, POS-created) stay NULL and become
+-- editable from the admin SO page.
+
+ALTER TABLE sales_orders
+    ADD COLUMN IF NOT EXISTS source_system VARCHAR(64)
+        REFERENCES inbound_source_systems_allowlist(source_system);
+
+-- Backfill from the most-recent applied inbound row. The
+-- inbound_sales_orders_current index already covers (source_system,
+-- external_id, received_at DESC) WHERE status='applied' so the
+-- correlated subquery is index-only.
+UPDATE sales_orders so
+   SET source_system = sub.source_system
+  FROM (
+      SELECT iso.source_system, sales.so_id
+        FROM sales_orders sales
+        JOIN inbound_sales_orders iso
+          ON iso.inbound_id = sales.latest_inbound_id
+       WHERE sales.latest_inbound_id IS NOT NULL
+         AND iso.status = 'applied'
+  ) sub
+ WHERE so.so_id = sub.so_id
+   AND so.source_system IS NULL;
+
+-- Lookups by source_system from the admin SO filter dropdown.
+CREATE INDEX IF NOT EXISTS ix_sales_orders_source_system
+    ON sales_orders (source_system)
+    WHERE source_system IS NOT NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -236,6 +236,11 @@ CREATE TABLE sales_orders (
     -- v1.7.0 Pipe B: pointer back to the most-recent applied inbound row.
     -- Unindexed, no FK; see db/migrations/039_inbound_sales_orders.sql.
     latest_inbound_id BIGINT,
+    -- mig 062: denormalised source_system tag so
+    -- the admin SO edit surface can repoint an order whose ERP-supplied
+    -- system tag was wrong, without rewriting inbound history. NULL on
+    -- admin-created and POS-created SOs that never went through inbound.
+    source_system VARCHAR(64) REFERENCES inbound_source_systems_allowlist(source_system),
     -- v1.10.0 Pipe C: POS endpoint surface columns. Web orders carry
     -- order_source='web' / order_type='sale' (defaults). POS-source
     -- orders carry external_txn_ref + idempotency_key + cached_response_body
@@ -266,7 +271,7 @@ CREATE TABLE sales_order_lines (
     quantity_packed INT NOT NULL DEFAULT 0,
     quantity_shipped INT NOT NULL DEFAULT 0,
     line_number INT NOT NULL,
-    status VARCHAR(20) DEFAULT 'PENDING'   -- 'PENDING', 'PICKED', 'PACKED', 'SHIPPED'. ALLOCATED retired in mig 060 (never written by app code).
+    status VARCHAR(20) DEFAULT 'PENDING'   -- 'PENDING', 'PICKED', 'PACKED', 'SHIPPED'. ALLOCATED retired in mig 062 (never written by app code).
 );
 
 -- ============================================================
@@ -679,6 +684,10 @@ CREATE INDEX ix_purchase_orders_warehouse ON purchase_orders(warehouse_id);
 CREATE INDEX ix_purchase_order_lines_po ON purchase_order_lines(po_id);
 CREATE INDEX ix_sales_orders_warehouse ON sales_orders(warehouse_id);
 CREATE INDEX ix_sales_order_lines_so ON sales_order_lines(so_id);
+-- mig 062: partial index because POS-created
+-- and admin-created SOs leave source_system NULL.
+CREATE INDEX IF NOT EXISTS ix_sales_orders_source_system
+    ON sales_orders (source_system) WHERE source_system IS NOT NULL;
 -- v1.10.0 Pipe C: POS replay + refund lookup paths. Partial indexes
 -- because the columns are NULL for the historical web-order majority.
 CREATE INDEX idx_so_idempotency

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -240,7 +240,10 @@ CREATE TABLE sales_orders (
     -- the admin SO edit surface can repoint an order whose ERP-supplied
     -- system tag was wrong, without rewriting inbound history. NULL on
     -- admin-created and POS-created SOs that never went through inbound.
-    source_system VARCHAR(64) REFERENCES inbound_source_systems_allowlist(source_system),
+    -- FK to inbound_source_systems_allowlist is added later in this
+    -- file via ALTER TABLE so the inline CREATE order does not require
+    -- the allowlist table to be declared above sales_orders.
+    source_system VARCHAR(64),
     -- v1.10.0 Pipe C: POS endpoint surface columns. Web orders carry
     -- order_source='web' / order_type='sale' (defaults). POS-source
     -- orders carry external_txn_ref + idempotency_key + cached_response_body
@@ -828,6 +831,16 @@ CREATE TABLE inbound_source_systems_allowlist (
     notes          TEXT,
     created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
+
+-- mig 062: FK from sales_orders.source_system
+-- to the allowlist. Declared here, after both tables exist, because
+-- sales_orders is defined at line 180 -- ahead of the allowlist -- so
+-- inlining the REFERENCES clause on the column would fail to load
+-- from a clean schema.
+ALTER TABLE sales_orders
+    ADD CONSTRAINT sales_orders_source_system_fkey
+    FOREIGN KEY (source_system)
+    REFERENCES inbound_source_systems_allowlist(source_system);
 
 -- v1.7.0 forensic audit (V-157 pattern, mirrors wms_tokens_audit).
 CREATE TABLE inbound_source_systems_allowlist_audit (


### PR DESCRIPTION
## Summary

SO line CRUD, the so-full-edit override, and a denormalised source_system column, in four commits:

- `feat(orders)` -- the so-full-edit override rides user_page_permissions (kept out of ALL_PAGE_KEYS; rendered in a separate Overrides group on the user form) so an admin can let a non-admin operator edit an SO past the OPEN window. ADMIN bypasses; SHIPPED stays ADMIN-only. SO line add/update/remove endpoints carry an allocation-release pass: shrinking below quantity_allocated or deleting an allocated line walks the pending pick_tasks, decrements bin allocation, and deletes the pending tasks; picked/packed/shipped quantities block both. Migration 062 adds sales_orders.source_system (FK to the inbound allowlist, backfilled from latest_inbound_id) so a CSR can repoint a mis-tagged order without rewriting inbound history. Header edits now write one audit row per changed field and the PUT response carries edited_fields.
- `fix(schema)` -- the inline source_system FK moves to a tail ALTER TABLE; sales_orders declares before the allowlist table, so a fresh schema.sql load would otherwise fail (verified by a clean-room load).
- `feat(admin-ui)` -- the SO edit modal becomes a sectioned detail view with an editable line table (qty stepper with on-blur commit, add-line with SKU typeahead, delete with allocation-release confirm), a status dropdown gated by EDITABLE_STATUS_OPTIONS, and source_system reassignment for ADMIN/override holders; the Users form gains the Overrides grid group.
- `fix(permissions)` -- has_override no longer auto-passes ADMIN inside the helper; callers gate explicitly, keeping the helper a pure grant lookup.

## Mobile

Zero mobile/ diffs.

## Pre-merge gate

- [x] Full api suite green locally (2363 passed); admin vitest 74/74; fresh schema.sql load verified
- [ ] CI green
