### PR TITLE
feat(sales-orders): status-revert flow + order_origin + SO edit-modal refinements (mig 063)

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -89,13 +89,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -114,21 +114,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -145,14 +145,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -162,14 +162,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -189,29 +189,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -251,27 +251,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -291,33 +291,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -325,14 +325,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -803,14 +803,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -832,9 +832,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -883,9 +883,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -900,9 +900,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -917,9 +917,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -968,9 +968,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -985,9 +985,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -1002,9 +1002,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1046,18 +1046,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1179,9 +1179,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1490,9 +1490,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1568,9 +1568,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -1780,9 +1780,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2306,10 +2306,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2793,9 +2803,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2819,11 +2829,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -2960,9 +2973,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2980,7 +2993,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3140,14 +3153,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3156,27 +3169,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3333,9 +3346,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3478,17 +3491,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3504,7 +3517,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/admin/src/App.css
+++ b/admin/src/App.css
@@ -596,8 +596,49 @@ a {
 }
 
 .modal-header h2 {
-  font-size: 16px;
+  font-size: 17px;
+  font-weight: 700;
+}
+
+/* ── Modal text scale ─────────────────────────────
+   Modals are data-dense and read at arm's length, so the in-modal
+   type scale bumps one step above the page-level scale. Scoped to
+   .modal so non-modal usages of these shared classes (cards on the
+   dashboard, section titles inside settings pages, etc.) keep their
+   page-level sizes. Important values (detail-grid values, card +
+   section titles) carry extra weight so labels stay visibly muted
+   against the values they describe. */
+.modal .form-group label {
+  font-size: 13px;
+}
+.modal .form-input,
+.modal .form-select {
+  font-size: 14px;
+}
+.modal .section-title {
+  font-size: 15px;
+  font-weight: 700;
+}
+.modal .card-title {
+  font-size: 15px;
+  font-weight: 700;
+}
+.modal .detail-grid {
+  font-size: 14px;
+}
+/* Bold the values in detail-grid (the span sibling of .detail-label)
+   so the data jumps off the page. Labels keep their muted weight via
+   the .detail-label rule below; the :not() selector skips them and
+   the wrapper-span pattern (display:contents) lets the value child
+   inherit the 600 weight while its sibling .detail-label keeps 500. */
+.modal .detail-grid > span:not(.detail-label) {
   font-weight: 600;
+}
+.modal .lines-table {
+  font-size: 14px;
+}
+.modal .lines-table th {
+  font-size: 13px;
 }
 
 .modal-close {

--- a/admin/src/pages/PurchaseOrders.jsx
+++ b/admin/src/pages/PurchaseOrders.jsx
@@ -179,7 +179,7 @@ export default function PurchaseOrders() {
                   return (
                     <tr key={i} style={{ borderBottom: '1px solid var(--border)' }}>
                       <td className="mono" style={tdStyle}>{l.sku}</td>
-                      <td style={{ ...tdStyle, color: 'var(--text-secondary)' }}>{l.item_name}</td>
+                      <td style={tdStyle}>{l.item_name}</td>
                       <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_ordered}</td>
                       <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_received}</td>
                       <td className="mono" style={{ ...tdStyle, textAlign: 'right', color: remaining > 0 ? 'var(--copper)' : 'var(--text-secondary)', fontWeight: remaining > 0 ? 600 : 400 }}>{remaining}</td>

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -13,6 +13,16 @@ const EDITABLE_STATUS_OPTIONS = ['OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELL
 // remain ADMIN-only for SHIPPED (external-system backfill); for CANCELLED
 // the operator should reopen via the cancel-undo workflow, not edit.
 const LINE_TERMINAL_STATUSES = new Set(['SHIPPED', 'CANCELLED']);
+// so-refinement: forward-flow ordering. Mirrors _STATUS_ORDER in
+// api/services/sales_order_service.py. PICKING / PACKING / ALLOCATED
+// were retired in v1.13.0 (mig 058); the live flow is
+// OPEN -> PICKED -> PACKED -> SHIPPED. Backward transitions from
+// PICKED/PACKED/SHIPPED require the revert-status flow so pick / pack /
+// ship side effects are unwound.
+const STATUS_ORDER = {
+  OPEN: 0, PICKED: 1, PACKED: 2, SHIPPED: 3,
+};
+const REVERTABLE_STATUSES = new Set(['PICKED', 'PACKED', 'SHIPPED']);
 
 // Matches PurchaseOrders.formatApiError: surfaces field-level details
 // from the @validate_body decorator instead of the bare "validation_error".
@@ -85,6 +95,12 @@ export default function SalesOrders() {
   const [editForm, setEditForm] = useState({});
   const [editError, setEditError] = useState('');
   const [confirmCancel, setConfirmCancel] = useState(false);
+  // so-refinement: backward status transition confirmation modal.
+  // Carries { newStatus, pickTasks, keepIds, error, busy, mode }.
+  // Checked rows (in keepIds) stay PICKED; unchecked rows release.
+  // Address fields moved inline into editForm; the separate
+  // address modal is retired.
+  const [revertConfirm, setRevertConfirm] = useState(null);
   // SO line CRUD inside the edit modal (mig 062). State
   // mirrors PurchaseOrders.jsx: editLines is the working copy, optimistic
   // PATCH/POST/DELETE update it without refetching; lineErrors keep
@@ -176,12 +192,18 @@ export default function SalesOrders() {
     const res = await api.get(`/admin/sales-orders/${so.so_id}`);
     let full = so;
     let lines = [];
+    let pickTasks = [];
     if (res?.ok) {
       const data = await res.json();
       full = data.sales_order || so;
       lines = data.lines || [];
+      // so-refinement: pick_tasks in PICKED state. Populates the
+      // status-revert modal when the operator demotes status.
+      pickTasks = data.pick_tasks || [];
     }
-    setEditing(full);
+    // Attach pick_tasks to the editing object so the revert modal can
+    // read them without a second fetch.
+    setEditing({ ...full, _pick_tasks: pickTasks });
     // so-refinement: address fields share editForm so the edit modal
     // can save header + addresses in one click. PATCH /address keeps
     // its own backend status gate; saveEdit fires it conditionally.
@@ -224,10 +246,13 @@ export default function SalesOrders() {
     setReleaseConfirm(null);
     setEditError('');
     setConfirmCancel(false);
+    setRevertConfirm(null);
   }
 
-  async function saveEdit() {
-    setEditError('');
+  // Build the PUT body for header edits, optionally skipping the
+  // status field (used when the status change has already gone through
+  // the revert-status endpoint and only header sidecar fields remain).
+  function _buildHeaderBody({ includeStatus }) {
     const body = {
       so_number: editForm.so_number,
       customer_name: editForm.customer_name || null,
@@ -237,20 +262,13 @@ export default function SalesOrders() {
       ship_by_date: editForm.ship_by_date || null,
       memo: editForm.memo || null,
     };
-    // Status edits are only sent when the operator changed the value.
-    // Sending the current status would still 200 but it noises the
-    // audit log with a self-transition row.
-    if (editForm.status && editForm.status !== editing.status) {
+    if (includeStatus && editForm.status && editForm.status !== editing.status) {
       body.status = editForm.status;
     }
-    // Same trim-and-diff treatment for tracking_number so the audit
-    // log only records actual changes; empty string clears to NULL.
     const trackingTrimmed = (editForm.tracking_number || '').trim();
     if (trackingTrimmed !== (editing.tracking_number || '')) {
       body.tracking_number = trackingTrimmed || null;
     }
-    // source_system reassignment: ADMIN-or-override gated server-side.
-    // Send only when it changed; "" tells the backend to clear to NULL.
     if (hasSOFullEdit && editForm.source_system !== (editing.source_system || '')) {
       body.source_system = editForm.source_system || '';
     }
@@ -263,11 +281,10 @@ export default function SalesOrders() {
     if (shippedDate !== (editing.shipped_date_local || '')) {
       body.shipped_at = shippedDate || null;
     }
-    // so-refinement: address fields ride along under one Save click,
-    // but go through PATCH /address (separate backend status gate). We
-    // only fire the PATCH when at least one field actually changed.
-    // Empty string clears to NULL (matches the legacy address-modal
-    // contract).
+    return body;
+  }
+
+  function _buildAddressBody() {
     const addressBody = {};
     let addressChanged = false;
     for (const key of ADDRESS_FIELD_KEYS) {
@@ -276,13 +293,22 @@ export default function SalesOrders() {
       if (next !== prev) addressChanged = true;
       addressBody[key] = next;
     }
+    return { addressBody, addressChanged };
+  }
 
+  // Fires the header PUT and (if any field changed) the address PATCH.
+  // Returns true on full success; on failure, sets editError and
+  // returns false. Reused by both the no-revert path and the
+  // post-revert path.
+  async function _commitHeaderAndAddress({ includeStatus }) {
+    const body = _buildHeaderBody({ includeStatus });
+    const { addressBody, addressChanged } = _buildAddressBody();
     const putRes = await api.put(`/admin/sales-orders/${editing.so_id}`, body);
     if (!putRes?.ok) {
       let data = null;
       try { data = await putRes?.json(); } catch (_) { /* non-JSON body */ }
       setEditError(formatApiError(data, 'Failed to save'));
-      return;
+      return false;
     }
     if (addressChanged) {
       const patchRes = await api.patch(
@@ -292,12 +318,117 @@ export default function SalesOrders() {
       if (!patchRes?.ok) {
         let data = null;
         try { data = await patchRes?.json(); } catch (_) { /* non-JSON body */ }
-        // Header save already committed; surface the address-side error
-        // and leave the modal open so the operator can retry or correct.
         setEditError(formatApiError(data, 'Header saved, but failed to save addresses'));
         loadOrders();
-        return;
+        return false;
       }
+    }
+    return true;
+  }
+
+  async function saveEdit() {
+    setEditError('');
+    // so-refinement: detect a backward status transition from
+    // PICKED/PACKED/SHIPPED. The revert-status endpoint owns the pick /
+    // pack / ship unwind, so we intercept here and let the operator
+    // pick which pick_tasks release back to their source bin before the
+    // status flip + sidecar header saves go through.
+    const cur = editing.status;
+    const next = editForm.status;
+    if (
+      cur && next && cur !== next
+      && REVERTABLE_STATUSES.has(cur)
+      && STATUS_ORDER[next] !== undefined
+      && STATUS_ORDER[cur] !== undefined
+      && STATUS_ORDER[next] < STATUS_ORDER[cur]
+    ) {
+      const pickTasks = editing._pick_tasks || [];
+      setRevertConfirm({
+        newStatus: next,
+        currentStatus: cur,
+        pickTasks,
+        // Default: keep nothing -> release everything. Operator checks
+        // a row to KEEP that pick (unchecked = release back to bin).
+        // If target < PICKED, the backend rejects while any keep is set.
+        keepIds: new Set(),
+        error: '',
+        busy: false,
+      });
+      return;
+    }
+    const ok = await _commitHeaderAndAddress({ includeStatus: true });
+    if (!ok) return;
+    closeEdit();
+    loadOrders();
+  }
+
+  // so-refinement: open the revert modal in release-only mode. No
+  // status change implied; the modal posts new_status == current and
+  // the backend skips the status update + audit row when nothing
+  // changed. Operator checks rows to KEEP picked; everything unchecked
+  // (default) releases back to source bin.
+  function openReleaseOnly(pickTasks) {
+    if (!editing || !pickTasks.length) return;
+    setRevertConfirm({
+      newStatus: editing.status,
+      currentStatus: editing.status,
+      pickTasks,
+      keepIds: new Set(),
+      error: '',
+      busy: false,
+      mode: 'release-only',
+    });
+  }
+
+  async function confirmRevertAndSave() {
+    if (!revertConfirm) return;
+    setRevertConfirm({ ...revertConfirm, error: '', busy: true });
+    // Anything NOT in keepIds is released back to its source bin.
+    const releaseIds = revertConfirm.pickTasks
+      .filter((t) => !revertConfirm.keepIds.has(t.pick_task_id))
+      .map((t) => t.pick_task_id);
+    const revertRes = await api.post(
+      `/admin/sales-orders/${editing.so_id}/revert-status`,
+      {
+        new_status: revertConfirm.newStatus,
+        release_pick_task_ids: releaseIds,
+      },
+    );
+    if (!revertRes?.ok) {
+      let data = null;
+      try { data = await revertRes?.json(); } catch (_) { /* non-JSON body */ }
+      setRevertConfirm({
+        ...revertConfirm,
+        busy: false,
+        error: data?.error || 'Failed to revert status',
+      });
+      return;
+    }
+    // Release-only mode: no status change, no in-flight header edits to
+    // chain. Refresh the SO detail in place so quantity_picked +
+    // pick_tasks reflect the release, then close the revert modal and
+    // leave the main edit modal open for any further work.
+    if (revertConfirm.mode === 'release-only') {
+      const refresh = await api.get(`/admin/sales-orders/${editing.so_id}`);
+      if (refresh?.ok) {
+        const data = await refresh.json();
+        setEditing({ ...(data.sales_order || editing), _pick_tasks: data.pick_tasks || [] });
+        setEditLines(data.lines || []);
+      }
+      setRevertConfirm(null);
+      loadOrders();
+      return;
+    }
+    // Status change committed via revert; commit any remaining header /
+    // address edits (without re-sending status) and tear down.
+    const ok = await _commitHeaderAndAddress({ includeStatus: false });
+    if (!ok) {
+      // Header save failed after revert succeeded. Status already
+      // changed, so close the revert modal and let the operator see
+      // the editError on the main modal.
+      setRevertConfirm(null);
+      loadOrders();
+      return;
     }
     closeEdit();
     loadOrders();
@@ -621,6 +752,16 @@ export default function SalesOrders() {
                 {status === 'OPEN' && (
                   <button className="btn btn-danger" onClick={() => setConfirmCancel(true)}>Cancel Order</button>
                 )}
+                {/* so-refinement: shortcut to the release modal that
+                    does not require flipping status first. Visible only
+                    when the SO actually has picks in flight. */}
+                {(editing._pick_tasks || []).length > 0 && (
+                  <button
+                    className="btn"
+                    onClick={() => openReleaseOnly(editing._pick_tasks || [])}
+                    title="Release picked inventory back to source bins without changing status"
+                  >Release Picked Quantities</button>
+                )}
                 <button className="btn" onClick={closeEdit}>Cancel</button>
                 <button className="btn btn-primary" onClick={saveEdit} disabled={!headerEditable}>Save</button>
               </>
@@ -798,7 +939,7 @@ export default function SalesOrders() {
                       return (
                         <tr key={l.so_line_id}>
                           <td className="mono">{l.sku}</td>
-                          <td style={{ color: 'var(--text-secondary)' }}>{l.item_name}</td>
+                          <td>{l.item_name}</td>
                           <td style={{ textAlign: 'right' }}>
                             <LineQtyInput
                               line={l}
@@ -948,6 +1089,143 @@ export default function SalesOrders() {
           </p>
         </Modal>
       )}
+
+      {revertConfirm && editing && (() => {
+        const { newStatus, currentStatus, pickTasks, keepIds, error, busy, mode } = revertConfirm;
+        const releaseOnly = mode === 'release-only';
+        // No unship / unpack when target == current (release-only).
+        const willUnship = !releaseOnly && currentStatus === 'SHIPPED';
+        const willUnpack = !releaseOnly && (
+          STATUS_ORDER[currentStatus] >= STATUS_ORDER.PACKED
+          && STATUS_ORDER[newStatus] < STATUS_ORDER.PACKED
+        );
+        const targetBelowPicked = STATUS_ORDER[newStatus] < STATUS_ORDER.PICKED;
+        // heldCount = picks the operator is keeping (checked). Those
+        // block a target below PICKED since the SO would still have
+        // quantity_picked on its lines.
+        const heldCount = keepIds.size;
+        const releaseCount = pickTasks.length - heldCount;
+        const blockedByHeld = targetBelowPicked && heldCount > 0;
+        const totalReleaseUnits = pickTasks
+          .filter((t) => !keepIds.has(t.pick_task_id))
+          .reduce((acc, t) => acc + (t.quantity_picked || 0), 0);
+        function toggleId(id) {
+          const next = new Set(keepIds);
+          if (next.has(id)) next.delete(id); else next.add(id);
+          setRevertConfirm({ ...revertConfirm, keepIds: next });
+        }
+        return (
+          <Modal
+            title={releaseOnly
+              ? `Release picked quantities - SO ${editing.so_number}`
+              : `Revert SO ${editing.so_number}: ${currentStatus} -> ${newStatus}`}
+            onClose={() => setRevertConfirm(null)}
+            size="wide"
+            footer={
+              <>
+                <button className="btn" onClick={() => setRevertConfirm(null)} disabled={busy}>Back</button>
+                <button
+                  className="btn btn-primary"
+                  onClick={confirmRevertAndSave}
+                  disabled={busy || blockedByHeld}
+                  title={blockedByHeld
+                    ? `Cannot demote to ${newStatus} with ${heldCount} pick(s) checked as Keep. Uncheck them or pick a target at PICKED or higher.`
+                    : 'Release unchecked picks and save'}
+                >
+                  {busy ? 'Reverting...' : 'Release & Save'}
+                </button>
+              </>
+            }
+          >
+            {error && <div className="form-error" style={{ marginBottom: 12 }}>{error}</div>}
+
+            {(willUnship || willUnpack) && (
+              <div style={{
+                padding: 10, marginBottom: 12,
+                borderLeft: '3px solid var(--copper)', backgroundColor: '#fdf6ed',
+              }}>
+                <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--copper)', letterSpacing: 0.4, marginBottom: 4 }}>
+                  SIDE EFFECTS
+                </div>
+                <ul style={{ fontSize: 13, lineHeight: 1.5, paddingLeft: 18, margin: 0 }}>
+                  {willUnship && (
+                    <li>
+                      <strong>Unship:</strong> tracking number, carrier, and shipped-at
+                      will clear on the header. Physical inventory was already
+                      shipped; reconcile externally if the package is returning.
+                    </li>
+                  )}
+                  {willUnpack && (
+                    <li>
+                      <strong>Unpack:</strong> packed quantity zeroes on every line.
+                      No inventory moves (pack does not touch bin stock).
+                    </li>
+                  )}
+                </ul>
+              </div>
+            )}
+
+            <p style={{ fontSize: 13, marginBottom: 8 }}>
+              {pickTasks.length === 0
+                ? <>No PICKED units to release.{releaseOnly ? '' : ` The revert will just change the status${willUnpack ? ' and unpack' : ''}${willUnship ? ' and unship' : ''}.`}</>
+                : <>This SO has <strong>{pickTasks.length}</strong> picked task(s) totalling <strong>{pickTasks.reduce((acc, t) => acc + (t.quantity_picked || 0), 0)}</strong> units across the bins below. All are released back to bin by default; <strong>check</strong> the Keep box for any task you want to leave PICKED.</>
+              }
+            </p>
+
+            {pickTasks.length > 0 && (
+              <table className="lines-table" style={{ marginTop: 8 }}>
+                <thead>
+                  <tr>
+                    <th style={{ width: 56, textAlign: 'center' }}>Keep</th>
+                    <th>SKU</th>
+                    <th>Item</th>
+                    <th>Bin</th>
+                    <th style={{ textAlign: 'right' }}>Qty</th>
+                    <th>Picked At</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pickTasks.map((t) => (
+                    <tr key={t.pick_task_id}>
+                      <td style={{ textAlign: 'center' }}>
+                        <input
+                          type="checkbox"
+                          checked={keepIds.has(t.pick_task_id)}
+                          onChange={() => toggleId(t.pick_task_id)}
+                          disabled={busy}
+                          title="Check to keep this pick (unchecked releases back to bin)"
+                        />
+                      </td>
+                      <td className="mono">{t.sku}</td>
+                      <td>{t.item_name}</td>
+                      <td className="mono">{t.bin_code}</td>
+                      <td className="mono" style={{ textAlign: 'right' }}>{t.quantity_picked}</td>
+                      <td className="mono" style={{ fontSize: 12 }}>
+                        {t.picked_at ? new Date(t.picked_at).toLocaleString() : '-'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+
+            {blockedByHeld && (
+              <p style={{ fontSize: 12, color: 'var(--danger)', marginTop: 12 }}>
+                Target status <strong>{newStatus}</strong> requires zero picked
+                units. {heldCount} task(s) are checked to keep - uncheck them
+                or change the target to PICKED or higher.
+              </p>
+            )}
+            {!blockedByHeld && pickTasks.length > 0 && (
+              <p style={{ fontSize: 12, color: 'var(--text-secondary)', marginTop: 12 }}>
+                Releasing <strong>{releaseCount}</strong> of {pickTasks.length} task(s),
+                returning <strong>{totalReleaseUnits}</strong> units to their bins.
+                The action is audit-logged per task.
+              </p>
+            )}
+          </Modal>
+        );
+      })()}
     </div>
   );
 }

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -717,7 +717,7 @@ export default function SalesOrders() {
                   {soLines.map((l, i) => (
                     <tr key={i} style={{ borderBottom: '1px solid var(--border)' }}>
                       <td className="mono" style={tdStyle}>{l.sku}</td>
-                      <td style={{ ...tdStyle, color: 'var(--text-secondary)' }}>{l.item_name}</td>
+                      <td style={tdStyle}>{l.item_name}</td>
                       <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_ordered}</td>
                       <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_picked}</td>
                       <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_shipped}</td>

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -85,14 +85,6 @@ export default function SalesOrders() {
   const [editForm, setEditForm] = useState({});
   const [editError, setEditError] = useState('');
   const [confirmCancel, setConfirmCancel] = useState(false);
-  // v1.8.0 (#268) address edit: separate modal that calls PATCH
-  // /sales-orders/<so_id>/address. Backend status gate: ADMIN at any
-  // status, non-admin only at OPEN. Addresses live on the canonical
-  // header so customer-service edits can land post-PICKED for
-  // shipping fixes.
-  const [addressEditing, setAddressEditing] = useState(null);
-  const [addressForm, setAddressForm] = useState({});
-  const [addressError, setAddressError] = useState('');
   // SO line CRUD inside the edit modal (mig 062). State
   // mirrors PurchaseOrders.jsx: editLines is the working copy, optimistic
   // PATCH/POST/DELETE update it without refetching; lineErrors keep
@@ -190,6 +182,11 @@ export default function SalesOrders() {
       lines = data.lines || [];
     }
     setEditing(full);
+    // so-refinement: address fields share editForm so the edit modal
+    // can save header + addresses in one click. PATCH /address keeps
+    // its own backend status gate; saveEdit fires it conditionally.
+    const addressInit = {};
+    for (const key of ADDRESS_FIELD_KEYS) addressInit[key] = full[key] || '';
     setEditForm({
       so_number: full.so_number || '',
       customer_name: full.customer_name || '',
@@ -203,6 +200,10 @@ export default function SalesOrders() {
       // Server-computed company-local Shipped Date (YYYY-MM-DD). Seeds
       // the date picker directly so it matches the read-only view.
       shipped_at: full.shipped_date_local || '',
+      // so-refinement: tracking_number defaults blank and prefills with
+      // whatever dockd ship wrote (or whatever ADMIN backfilled).
+      tracking_number: full.tracking_number || '',
+      ...addressInit,
     });
     setEditLines(lines);
     setLineErrors({});
@@ -242,6 +243,12 @@ export default function SalesOrders() {
     if (editForm.status && editForm.status !== editing.status) {
       body.status = editForm.status;
     }
+    // Same trim-and-diff treatment for tracking_number so the audit
+    // log only records actual changes; empty string clears to NULL.
+    const trackingTrimmed = (editForm.tracking_number || '').trim();
+    if (trackingTrimmed !== (editing.tracking_number || '')) {
+      body.tracking_number = trackingTrimmed || null;
+    }
     // source_system reassignment: ADMIN-or-override gated server-side.
     // Send only when it changed; "" tells the backend to clear to NULL.
     if (hasSOFullEdit && editForm.source_system !== (editing.source_system || '')) {
@@ -256,15 +263,44 @@ export default function SalesOrders() {
     if (shippedDate !== (editing.shipped_date_local || '')) {
       body.shipped_at = shippedDate || null;
     }
-    const res = await api.put(`/admin/sales-orders/${editing.so_id}`, body);
-    if (res?.ok) {
-      closeEdit();
-      loadOrders();
-    } else {
-      let data = null;
-      try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
-      setEditError(formatApiError(data, 'Failed to save'));
+    // so-refinement: address fields ride along under one Save click,
+    // but go through PATCH /address (separate backend status gate). We
+    // only fire the PATCH when at least one field actually changed.
+    // Empty string clears to NULL (matches the legacy address-modal
+    // contract).
+    const addressBody = {};
+    let addressChanged = false;
+    for (const key of ADDRESS_FIELD_KEYS) {
+      const next = editForm[key] || '';
+      const prev = editing[key] || '';
+      if (next !== prev) addressChanged = true;
+      addressBody[key] = next;
     }
+
+    const putRes = await api.put(`/admin/sales-orders/${editing.so_id}`, body);
+    if (!putRes?.ok) {
+      let data = null;
+      try { data = await putRes?.json(); } catch (_) { /* non-JSON body */ }
+      setEditError(formatApiError(data, 'Failed to save'));
+      return;
+    }
+    if (addressChanged) {
+      const patchRes = await api.patch(
+        `/admin/sales-orders/${editing.so_id}/address`,
+        addressBody,
+      );
+      if (!patchRes?.ok) {
+        let data = null;
+        try { data = await patchRes?.json(); } catch (_) { /* non-JSON body */ }
+        // Header save already committed; surface the address-side error
+        // and leave the modal open so the operator can retry or correct.
+        setEditError(formatApiError(data, 'Header saved, but failed to save addresses'));
+        loadOrders();
+        return;
+      }
+    }
+    closeEdit();
+    loadOrders();
   }
 
   // ── line CRUD ─────────────────────────────────────────────────────────────
@@ -393,46 +429,6 @@ export default function SalesOrders() {
     else if (c.intent === 'delete') await commitRemoveLine(c.line);
   }
 
-  function openAddressEdit(so) {
-    setAddressEditing(so);
-    const form = {};
-    for (const key of ADDRESS_FIELD_KEYS) {
-      form[key] = so[key] || '';
-    }
-    setAddressForm(form);
-    setAddressError('');
-  }
-
-  async function saveAddressEdit() {
-    setAddressError('');
-    // Empty string clears the column to NULL on the backend; we send
-    // every field that the operator could have edited so a deletion
-    // is also persisted.
-    const body = {};
-    for (const key of ADDRESS_FIELD_KEYS) {
-      body[key] = addressForm[key] || '';
-    }
-    const res = await api.patch(
-      `/admin/sales-orders/${addressEditing.so_id}/address`,
-      body,
-    );
-    if (res?.ok) {
-      setAddressEditing(null);
-      // Refresh detail modal to show the saved values.
-      const refresh = await api.get(
-        `/admin/sales-orders/${addressEditing.so_id}`,
-      );
-      if (refresh?.ok) {
-        const data = await refresh.json();
-        setSelectedSO(data.sales_order);
-        setSOLines(data.lines || []);
-      }
-    } else {
-      const data = await res?.json();
-      setAddressError(data?.error || 'Failed to save addresses');
-    }
-  }
-
   async function cancelSO() {
     setEditError('');
     const res = await api.post(`/admin/sales-orders/${editing.so_id}/cancel`, {});
@@ -493,160 +489,115 @@ export default function SalesOrders() {
           title={`SO ${selectedSO.so_number}`}
           onClose={() => { setSelectedSO(null); setSOLines([]); }}
           footer={<button className="btn" onClick={() => { setSelectedSO(null); setSOLines([]); }}>Close</button>}
+          size="wide"
         >
-          <div className="detail-grid" style={{ marginBottom: 16 }}>
-            <span className="detail-label">Customer</span><span>{selectedSO.customer_name || '-'}</span>
-            <span className="detail-label">Status</span><span><StatusTag status={selectedSO.status} /></span>
-            <span className="detail-label">Ship By</span><span className="mono">{selectedSO.ship_by_date ? new Date(selectedSO.ship_by_date).toLocaleDateString() : '-'}</span>
-            <span className="detail-label">Ship Method</span><span>{selectedSO.ship_method || '-'}</span>
-            <span className="detail-label">Ship Address</span><span>{selectedSO.ship_address || '-'}</span>
-            {/* v1.8.0 (#282) per-order cost fields. order_total +
-                customer_shipping_paid arrive as strings on the wire to
-                preserve Decimal precision; render literal. */}
-            <span className="detail-label">Order Total</span>
-            <span className="mono"><NullableValue value={selectedSO.order_total} /></span>
-            <span className="detail-label">Shipping Paid</span>
-            <span className="mono"><NullableValue value={selectedSO.customer_shipping_paid} /></span>
-          </div>
+          <section className="section">
+            <div className="section-title">Order Summary</div>
+            <div className="detail-grid" style={{ marginBottom: 0 }}>
+              <span className="detail-label">Customer</span><span>{selectedSO.customer_name || '-'}</span>
+              <span className="detail-label">Status</span><span><StatusTag status={selectedSO.status} /></span>
+              <span className="detail-label">Ship By</span><span className="mono">{selectedSO.ship_by_date ? new Date(selectedSO.ship_by_date).toLocaleDateString() : '-'}</span>
+              <span className="detail-label">Ship Method</span><span>{selectedSO.ship_method || '-'}</span>
+              {/* v1.8.0 (#282) per-order cost fields. order_total +
+                  customer_shipping_paid arrive as strings on the wire to
+                  preserve Decimal precision; render literal. */}
+              <span className="detail-label">Order Total</span>
+              <span className="mono"><NullableValue value={selectedSO.order_total} /></span>
+              {/* so-refinement: tracking # under the cost fields. */}
+              <span className="detail-label">Tracking #</span>
+              <span className="mono"><NullableValue value={selectedSO.tracking_number} /></span>
+              <span className="detail-label">Shipping Paid</span>
+              <span className="mono"><NullableValue value={selectedSO.customer_shipping_paid} /></span>
+              {/* so-refinement: legacy ship_address row dropped from
+                  the Order Summary -- the structured Shipping Address
+                  card below is the operator-facing source of truth.
+                  The column itself stays populated for the mobile
+                  pick/pack/ship floor screens that still read it. */}
+            </div>
+          </section>
 
           {/* v1.9.0 #315: free-text operator-facing note. Only shown
               when populated; render with whiteSpace: pre-wrap so
               embedded newlines from the source ERP survive. */}
           {selectedSO.memo && (
-            <div style={{
-              marginBottom: 16, padding: 10,
-              borderLeft: '3px solid #b87333', backgroundColor: '#fdf6ed',
-              whiteSpace: 'pre-wrap',
-            }}>
+            <section className="section">
               <div style={{
-                fontSize: 11, fontWeight: 700, color: '#b87333',
-                letterSpacing: 0.4, marginBottom: 4,
-              }}>NOTE</div>
-              <div style={{ fontSize: 13, lineHeight: 1.4 }}>{selectedSO.memo}</div>
-            </div>
+                padding: 10,
+                borderLeft: '3px solid #b87333', backgroundColor: '#fdf6ed',
+                whiteSpace: 'pre-wrap',
+              }}>
+                <div style={{
+                  fontSize: 11, fontWeight: 700, color: '#b87333',
+                  letterSpacing: 0.4, marginBottom: 4,
+                }}>NOTE</div>
+                <div style={{ fontSize: 13, lineHeight: 1.4 }}>{selectedSO.memo}</div>
+              </div>
+            </section>
           )}
 
           {/* v1.8.0 (#268) per-component billing + shipping addresses.
               Each side gets its own card so a half-populated address
-              renders cleanly without column shifts. */}
-          <div style={{
-            display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16,
-            marginBottom: 16,
-          }}>
-            <div>
-              <div style={{
-                display: 'flex', justifyContent: 'space-between',
-                alignItems: 'center', marginBottom: 8,
-              }}>
-                <strong style={{ fontSize: 13 }}>Billing Address</strong>
-                <button
-                  className="btn btn-sm"
-                  onClick={() => openAddressEdit(selectedSO)}
-                  title="Edit billing + shipping addresses"
-                >Edit Addresses</button>
+              renders cleanly without column shifts. so-refinement:
+              address edits live in the main Edit modal now. */}
+          <section className="section">
+            <div className="section-title">Addresses</div>
+            <div style={{
+              display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16,
+            }}>
+              <div className="card">
+                <div className="card-title">Billing Address</div>
+                <div className="detail-grid" style={{ marginBottom: 0 }}>
+                  {ADDRESS_FIELD_KEYS.filter((k) => k.startsWith('billing_')).map((k) => (
+                    <span key={k} style={{ display: 'contents' }}>
+                      <span className="detail-label">{ADDRESS_FIELD_LABELS[k]}</span>
+                      <span><NullableValue value={selectedSO[k]} /></span>
+                    </span>
+                  ))}
+                </div>
               </div>
-              <div className="detail-grid">
-                {ADDRESS_FIELD_KEYS.filter((k) => k.startsWith('billing_')).map((k) => (
-                  <span key={k} style={{ display: 'contents' }}>
-                    <span className="detail-label">{ADDRESS_FIELD_LABELS[k]}</span>
-                    <span><NullableValue value={selectedSO[k]} /></span>
-                  </span>
-                ))}
-              </div>
-            </div>
-            <div>
-              <strong style={{
-                fontSize: 13, marginBottom: 8, display: 'block',
-              }}>Shipping Address</strong>
-              <div className="detail-grid">
-                {ADDRESS_FIELD_KEYS.filter((k) => k.startsWith('shipping_')).map((k) => (
-                  <span key={k} style={{ display: 'contents' }}>
-                    <span className="detail-label">{ADDRESS_FIELD_LABELS[k]}</span>
-                    <span><NullableValue value={selectedSO[k]} /></span>
-                  </span>
-                ))}
+              <div className="card">
+                <div className="card-title">Shipping Address</div>
+                <div className="detail-grid" style={{ marginBottom: 0 }}>
+                  {ADDRESS_FIELD_KEYS.filter((k) => k.startsWith('shipping_')).map((k) => (
+                    <span key={k} style={{ display: 'contents' }}>
+                      <span className="detail-label">{ADDRESS_FIELD_LABELS[k]}</span>
+                      <span><NullableValue value={selectedSO[k]} /></span>
+                    </span>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
+          </section>
 
-          {soLines.length > 0 ? (
-            <table style={{ width: '100%', fontSize: 13, borderCollapse: 'collapse' }}>
-              <thead>
-                <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                  <th style={thStyle}>SKU</th>
-                  <th style={thStyle}>Item Name</th>
-                  <th style={{ ...thStyle, textAlign: 'right' }}>Ordered</th>
-                  <th style={{ ...thStyle, textAlign: 'right' }}>Picked</th>
-                  <th style={{ ...thStyle, textAlign: 'right' }}>Shipped</th>
-                </tr>
-              </thead>
-              <tbody>
-                {soLines.map((l, i) => (
-                  <tr key={i} style={{ borderBottom: '1px solid var(--border)' }}>
-                    <td className="mono" style={tdStyle}>{l.sku}</td>
-                    <td style={{ ...tdStyle, color: 'var(--text-secondary)' }}>{l.item_name}</td>
-                    <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_ordered}</td>
-                    <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_picked}</td>
-                    <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_shipped}</td>
+          <section className="section" style={{ marginBottom: 0 }}>
+            <div className="section-title">Line Items</div>
+            {soLines.length > 0 ? (
+              <table style={{ width: '100%', fontSize: 13, borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                    <th style={thStyle}>SKU</th>
+                    <th style={thStyle}>Item Name</th>
+                    <th style={{ ...thStyle, textAlign: 'right' }}>Ordered</th>
+                    <th style={{ ...thStyle, textAlign: 'right' }}>Picked</th>
+                    <th style={{ ...thStyle, textAlign: 'right' }}>Shipped</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          ) : (
-            <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>No line items</p>
-          )}
-        </Modal>
-      )}
-
-      {addressEditing && (
-        <Modal
-          title={`Edit Addresses - SO ${addressEditing.so_number}`}
-          onClose={() => setAddressEditing(null)}
-          footer={
-            <>
-              <button className="btn" onClick={() => setAddressEditing(null)}>Cancel</button>
-              <button className="btn btn-primary" onClick={saveAddressEdit}>Save Addresses</button>
-            </>
-          }
-        >
-          {addressError && <div className="form-error" style={{ marginBottom: 12 }}>{addressError}</div>}
-          <p style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
-            Address edits go through a dedicated endpoint with a status
-            gate: ADMIN can edit at any status, non-admin only on OPEN
-            orders. Empty fields are saved as cleared. Header fields
-            (SO number, customer, ship method) are edited via the main
-            Edit button and remain locked once picking starts.
-          </p>
-          <div style={{
-            display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16,
-          }}>
-            <div>
-              <strong style={{ display: 'block', marginBottom: 8 }}>Billing</strong>
-              {ADDRESS_FIELD_KEYS.filter((k) => k.startsWith('billing_')).map((k) => (
-                <div key={k} className="form-group">
-                  <label>{ADDRESS_FIELD_LABELS[k]}</label>
-                  <input
-                    className="form-input"
-                    value={addressForm[k]}
-                    onChange={(e) => setAddressForm({ ...addressForm, [k]: e.target.value })}
-                  />
-                </div>
-              ))}
-            </div>
-            <div>
-              <strong style={{ display: 'block', marginBottom: 8 }}>Shipping</strong>
-              {ADDRESS_FIELD_KEYS.filter((k) => k.startsWith('shipping_')).map((k) => (
-                <div key={k} className="form-group">
-                  <label>{ADDRESS_FIELD_LABELS[k]}</label>
-                  <input
-                    className="form-input"
-                    value={addressForm[k]}
-                    onChange={(e) => setAddressForm({ ...addressForm, [k]: e.target.value })}
-                  />
-                </div>
-              ))}
-            </div>
-          </div>
+                </thead>
+                <tbody>
+                  {soLines.map((l, i) => (
+                    <tr key={i} style={{ borderBottom: '1px solid var(--border)' }}>
+                      <td className="mono" style={tdStyle}>{l.sku}</td>
+                      <td style={{ ...tdStyle, color: 'var(--text-secondary)' }}>{l.item_name}</td>
+                      <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_ordered}</td>
+                      <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_picked}</td>
+                      <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{l.quantity_shipped}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>No line items</p>
+            )}
+          </section>
         </Modal>
       )}
 
@@ -655,6 +606,11 @@ export default function SalesOrders() {
         const headerEditable = isAdmin || hasSOFullEdit || status === 'OPEN';
         const lineEditable = headerEditable && !LINE_TERMINAL_STATUSES.has(status);
         const sourceSystemEditable = hasSOFullEdit;
+        // so-refinement: PATCH /address gate is ADMIN any status,
+        // non-admin only OPEN. Backend still enforces; this just keeps
+        // the disabled state in sync so users don't try a save that
+        // will 403.
+        const addressEditable = isAdmin || status === 'OPEN';
         return (
           <Modal
             title={`Edit SO ${editing.so_number}`}
@@ -743,6 +699,22 @@ export default function SalesOrders() {
               <label>Ship Method</label>
               <input className="form-input" disabled={!headerEditable} value={editForm.ship_method} onChange={(e) => setEditForm({ ...editForm, ship_method: e.target.value })} />
             </div>
+            {/* so-refinement: Tracking # on its own row, right-aligned
+                beneath Ship Method to match the view-modal layout. */}
+            <div className="form-row">
+              <div className="form-group" aria-hidden="true" />
+              <div className="form-group">
+                <label>Tracking #</label>
+                <input
+                  className="form-input mono"
+                  disabled={!headerEditable}
+                  maxLength={128}
+                  placeholder="Auto-fills from Dockd on ship"
+                  value={editForm.tracking_number}
+                  onChange={(e) => setEditForm({ ...editForm, tracking_number: e.target.value })}
+                />
+              </div>
+            </div>
             <div className="form-group">
               <label>Ship Address</label>
               <textarea className="form-input" rows={2} disabled={!headerEditable} value={editForm.ship_address} onChange={(e) => setEditForm({ ...editForm, ship_address: e.target.value })} />
@@ -751,13 +723,56 @@ export default function SalesOrders() {
               <label>Note (memo)</label>
               <textarea
                 className="form-input" rows={3}
-                placeholder="Customer notes, e.g. leave at back door, fragile, double-box"
+                placeholder="......"
                 maxLength={4096}
                 disabled={!headerEditable}
                 value={editForm.memo}
                 onChange={(e) => setEditForm({ ...editForm, memo: e.target.value })}
               />
             </div>
+
+            {/* so-refinement: addresses live inside the edit modal now.
+                Saved via PATCH /address from saveEdit when any of the 16
+                fields changed. Empty string clears to NULL. */}
+            <section className="section" style={{ marginTop: 16 }}>
+              <div className="section-title">Addresses</div>
+              {!addressEditable && (
+                <p style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
+                  Address edits are locked while the SO is {status}. Only
+                  ADMIN can edit addresses past OPEN.
+                </p>
+              )}
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+                <div>
+                  <strong style={{ display: 'block', marginBottom: 8 }}>Billing</strong>
+                  {ADDRESS_FIELD_KEYS.filter((k) => k.startsWith('billing_')).map((k) => (
+                    <div key={k} className="form-group">
+                      <label>{ADDRESS_FIELD_LABELS[k]}</label>
+                      <input
+                        className="form-input"
+                        disabled={!addressEditable}
+                        value={editForm[k] || ''}
+                        onChange={(e) => setEditForm({ ...editForm, [k]: e.target.value })}
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div>
+                  <strong style={{ display: 'block', marginBottom: 8 }}>Shipping</strong>
+                  {ADDRESS_FIELD_KEYS.filter((k) => k.startsWith('shipping_')).map((k) => (
+                    <div key={k} className="form-group">
+                      <label>{ADDRESS_FIELD_LABELS[k]}</label>
+                      <input
+                        className="form-input"
+                        disabled={!addressEditable}
+                        value={editForm[k] || ''}
+                        onChange={(e) => setEditForm({ ...editForm, [k]: e.target.value })}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
 
             <section className="section" style={{ marginTop: 16 }}>
               <div className="section-title">Line Items</div>

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -365,15 +365,18 @@ export default function SalesOrders() {
   // so-refinement: open the revert modal in release-only mode. No
   // status change implied; the modal posts new_status == current and
   // the backend skips the status update + audit row when nothing
-  // changed. Operator checks rows to KEEP picked; everything unchecked
-  // (default) releases back to source bin.
+  // changed. Release-only defaults to keep-all (every row checked);
+  // operator unchecks the specific rows they want to release back to
+  // bin. Contrast with revert-mode (status change) which defaults to
+  // release-all since demoting status typically means unwinding all
+  // picks.
   function openReleaseOnly(pickTasks) {
     if (!editing || !pickTasks.length) return;
     setRevertConfirm({
       newStatus: editing.status,
       currentStatus: editing.status,
       pickTasks,
-      keepIds: new Set(),
+      keepIds: new Set(pickTasks.map((t) => t.pick_task_id)),
       error: '',
       busy: false,
       mode: 'release-only',
@@ -1168,7 +1171,10 @@ export default function SalesOrders() {
             <p style={{ fontSize: 13, marginBottom: 8 }}>
               {pickTasks.length === 0
                 ? <>No PICKED units to release.{releaseOnly ? '' : ` The revert will just change the status${willUnpack ? ' and unpack' : ''}${willUnship ? ' and unship' : ''}.`}</>
-                : <>This SO has <strong>{pickTasks.length}</strong> picked task(s) totalling <strong>{pickTasks.reduce((acc, t) => acc + (t.quantity_picked || 0), 0)}</strong> units across the bins below. All are released back to bin by default; <strong>check</strong> the Keep box for any task you want to leave PICKED.</>
+                : <>This SO has <strong>{pickTasks.length}</strong> picked task(s) totalling <strong>{pickTasks.reduce((acc, t) => acc + (t.quantity_picked || 0), 0)}</strong> units across the bins below. {releaseOnly
+                    ? <>All are kept PICKED by default; <strong>uncheck</strong> the Keep box for any task you want to release back to bin.</>
+                    : <>All are released back to bin by default; <strong>check</strong> the Keep box for any task you want to leave PICKED.</>
+                  }</>
               }
             </p>
 

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -222,6 +222,9 @@ export default function SalesOrders() {
       // Server-computed company-local Shipped Date (YYYY-MM-DD). Seeds
       // the date picker directly so it matches the read-only view.
       shipped_at: full.shipped_date_local || '',
+      // mig 063: free-text upstream-origin label. Blank when the
+      // connector mapping has not been wired up yet.
+      order_origin: full.order_origin || '',
       // so-refinement: tracking_number defaults blank and prefills with
       // whatever dockd ship wrote (or whatever ADMIN backfilled).
       tracking_number: full.tracking_number || '',
@@ -280,6 +283,12 @@ export default function SalesOrders() {
     const shippedDate = (editForm.shipped_at || '').trim();
     if (shippedDate !== (editing.shipped_date_local || '')) {
       body.shipped_at = shippedDate || null;
+    }
+    // mig 063: same trim-and-diff treatment as source_system. Empty
+    // string clears the column to NULL.
+    const originTrimmed = (editForm.order_origin || '').trim();
+    if (originTrimmed !== (editing.order_origin || '')) {
+      body.order_origin = originTrimmed || null;
     }
     return body;
   }
@@ -629,6 +638,10 @@ export default function SalesOrders() {
             <div className="detail-grid" style={{ marginBottom: 0 }}>
               <span className="detail-label">Customer</span><span>{selectedSO.customer_name || '-'}</span>
               <span className="detail-label">Status</span><span><StatusTag status={selectedSO.status} /></span>
+              {/* mig 063: free-text upstream-origin label populated
+                  by the inbound payload mapping. */}
+              <span className="detail-label">Source:</span>
+              <span><NullableValue value={selectedSO.order_origin} /></span>
               <span className="detail-label">Ship By</span><span className="mono">{selectedSO.ship_by_date ? new Date(selectedSO.ship_by_date).toLocaleDateString() : '-'}</span>
               <span className="detail-label">Ship Method</span><span>{selectedSO.ship_method || '-'}</span>
               {/* v1.8.0 (#282) per-order cost fields. order_total +
@@ -837,6 +850,20 @@ export default function SalesOrders() {
                   ))}
                 </select>
               </div>
+            </div>
+            {/* mig 063: free-text upstream-origin label. No allowlist /
+                dropdown -- the inbound payload populates it; ADMIN /
+                so-full-edit can override. Empty string clears the column. */}
+            <div className="form-group">
+              <label>Source:</label>
+              <input
+                className="form-input"
+                disabled={!headerEditable}
+                maxLength={64}
+                placeholder="e.g. amazon, shopify-store-1, phone-order"
+                value={editForm.order_origin}
+                onChange={(e) => setEditForm({ ...editForm, order_origin: e.target.value })}
+              />
             </div>
             <div className="form-group">
               <label>Ship Method</label>

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -635,12 +635,12 @@ export default function SalesOrders() {
                   customer_shipping_paid arrive as strings on the wire to
                   preserve Decimal precision; render literal. */}
               <span className="detail-label">Order Total</span>
-              <span className="mono"><NullableValue value={selectedSO.order_total} /></span>
+              <span className="mono"><NullableValue value={selectedSO.order_total != null ? `$${selectedSO.order_total}` : null} /></span>
               {/* so-refinement: tracking # under the cost fields. */}
               <span className="detail-label">Tracking #</span>
               <span className="mono"><NullableValue value={selectedSO.tracking_number} /></span>
               <span className="detail-label">Shipping Paid</span>
-              <span className="mono"><NullableValue value={selectedSO.customer_shipping_paid} /></span>
+              <span className="mono"><NullableValue value={selectedSO.customer_shipping_paid != null ? `$${selectedSO.customer_shipping_paid}` : null} /></span>
               {/* so-refinement: legacy ship_address row dropped from
                   the Order Summary -- the structured Shipping Address
                   card below is the operator-facing source of truth.

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -347,10 +347,11 @@ export default function SalesOrders() {
         newStatus: next,
         currentStatus: cur,
         pickTasks,
-        // Default: keep nothing -> release everything. Operator checks
-        // a row to KEEP that pick (unchecked = release back to bin).
-        // If target < PICKED, the backend rejects while any keep is set.
-        keepIds: new Set(),
+        // Default: keep all (every row checked). Operator unchecks
+        // the specific picks they want to release back to source bin.
+        // If target < PICKED, the backend rejects while any keep
+        // remains, so the operator sees the inconsistency before commit.
+        keepIds: new Set(pickTasks.map((t) => t.pick_task_id)),
         error: '',
         busy: false,
       });
@@ -365,11 +366,9 @@ export default function SalesOrders() {
   // so-refinement: open the revert modal in release-only mode. No
   // status change implied; the modal posts new_status == current and
   // the backend skips the status update + audit row when nothing
-  // changed. Release-only defaults to keep-all (every row checked);
-  // operator unchecks the specific rows they want to release back to
-  // bin. Contrast with revert-mode (status change) which defaults to
-  // release-all since demoting status typically means unwinding all
-  // picks.
+  // changed. Default keep-all matches the revert-mode default;
+  // operator unchecks the specific rows they want to release back
+  // to bin.
   function openReleaseOnly(pickTasks) {
     if (!editing || !pickTasks.length) return;
     setRevertConfirm({
@@ -1171,10 +1170,7 @@ export default function SalesOrders() {
             <p style={{ fontSize: 13, marginBottom: 8 }}>
               {pickTasks.length === 0
                 ? <>No PICKED units to release.{releaseOnly ? '' : ` The revert will just change the status${willUnpack ? ' and unpack' : ''}${willUnship ? ' and unship' : ''}.`}</>
-                : <>This SO has <strong>{pickTasks.length}</strong> picked task(s) totalling <strong>{pickTasks.reduce((acc, t) => acc + (t.quantity_picked || 0), 0)}</strong> units across the bins below. {releaseOnly
-                    ? <>All are kept PICKED by default; <strong>uncheck</strong> the Keep box for any task you want to release back to bin.</>
-                    : <>All are released back to bin by default; <strong>check</strong> the Keep box for any task you want to leave PICKED.</>
-                  }</>
+                : <>This SO has <strong>{pickTasks.length}</strong> picked task(s) totalling <strong>{pickTasks.reduce((acc, t) => acc + (t.quantity_picked || 0), 0)}</strong> units across the bins below. All are kept PICKED by default; <strong>uncheck</strong> the Keep box for any task you want to release back to bin.</>
               }
             </p>
 

--- a/api/constants.py
+++ b/api/constants.py
@@ -41,6 +41,10 @@ TASK_PENDING = "PENDING"
 TASK_PICKED = "PICKED"
 TASK_SHORT = "SHORT"
 TASK_SKIPPED = "SKIPPED"
+# so-refinement: an operator-reverted PICKED task. Distinct from
+# PENDING so a subsequent revert prompt does not re-offer the same
+# task, and from PICKED so dashboards do not double-count.
+TASK_RELEASED = "RELEASED"
 
 # Cycle Count statuses
 COUNT_PENDING = "PENDING"
@@ -206,3 +210,11 @@ ACTION_SO_LINE_REMOVED = "SO_LINE_REMOVED"
 ACTION_SO_HEADER_EDITED = "SO_HEADER_EDITED"
 ACTION_SO_SOURCE_SYSTEM_REASSIGNED = "SO_SOURCE_SYSTEM_REASSIGNED"
 ACTION_SO_ALLOCATION_RELEASED = "SO_ALLOCATION_RELEASED"
+# so-refinement: admin reverts an SO from PICKED/PACKED/SHIPPED back
+# to an earlier status. One STATUS_REVERTED row per request carries
+# {from_status, to_status}; the per-effect rows below carry the line
+# / pick_task detail so investigators can reconstruct the unwind.
+ACTION_SO_STATUS_REVERTED = "SO_STATUS_REVERTED"
+ACTION_SO_PICK_RELEASED = "SO_PICK_RELEASED"
+ACTION_SO_UNPACKED = "SO_UNPACKED"
+ACTION_SO_UNSHIPPED = "SO_UNSHIPPED"

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,7 +8,7 @@ python-dotenv==1.2.2
 gunicorn==23.0.0
 celery[redis]==5.4.0
 redis==5.2.1
-cryptography==46.0.7
+cryptography==48.0.1
 pydantic==2.11.3
 requests==2.33.0
 flask-limiter[redis]==3.8.0

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -386,6 +386,7 @@ def get_sales_order(so_id):
                    (shipped_at AT TIME ZONE :company_tz)::date AS shipped_date_local,
                    order_total, customer_shipping_paid, memo,
                    source_system,
+                   carrier, tracking_number,
                    billing_address_name, billing_address_line1, billing_address_line2,
                    billing_address_city, billing_address_state,
                    billing_address_postal_code, billing_address_country,
@@ -415,7 +416,7 @@ def get_sales_order(so_id):
         "sales_order": {
             "so_id": so.so_id, "so_number": so.so_number, "so_barcode": so.so_barcode,
             "customer_name": so.customer_name,
-            # P11.x: customer_phone + customer_address were missing
+            # customer_phone + customer_address were previously missing
             # from this response, so the edit modal reloaded with the
             # phone field blank after a save and operators assumed
             # the save had failed. Both fields are returned now so
@@ -448,6 +449,11 @@ def get_sales_order(so_id):
             # source_system: denormalised tag (mig 062). NULL for
             # admin-created and POS-created SOs.
             "source_system": so.source_system,
+            # so-refinement: shipment-state fields. Populated by dockd
+            # ship POST; surfaced here so the edit modal can show the
+            # current tracking number and the view modal can display it.
+            "carrier": so.carrier,
+            "tracking_number": so.tracking_number,
             # v1.8.0 (#288): structured billing/shipping address fields.
             **{name: getattr(so, name) for name in ADDRESS_FIELD_NAMES},
         },

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -389,6 +389,7 @@ def get_sales_order(so_id):
                    (shipped_at AT TIME ZONE :company_tz)::date AS shipped_date_local,
                    order_total, customer_shipping_paid, memo,
                    source_system,
+                   order_origin,
                    carrier, tracking_number,
                    billing_address_name, billing_address_line1, billing_address_line2,
                    billing_address_city, billing_address_state,
@@ -471,6 +472,10 @@ def get_sales_order(so_id):
             # source_system: denormalised tag (mig 062). NULL for
             # admin-created and POS-created SOs.
             "source_system": so.source_system,
+            # mig 063: free-text upstream-origin label populated by the
+            # inbound payload mapping. NULL when the connector has not
+            # been wired to provide it.
+            "order_origin": so.order_origin,
             # so-refinement: shipment-state fields. Populated by dockd
             # ship POST; surfaced here so the edit modal can show the
             # current tracking number and the view modal can display it.
@@ -520,8 +525,8 @@ def create_sales_order(validated):
 
     result = g.db.execute(
         text("""
-            INSERT INTO sales_orders (so_number, so_barcode, customer_name, customer_phone, customer_address, warehouse_id, ship_method, ship_address, ship_by_date, memo, order_date, created_by, status, external_id)
-            VALUES (:sn, :sb, :cust, :phone, :caddr, :wid, :ship, :addr, :ship_by, :memo, NOW(), :created_by, :status, :ext_id)
+            INSERT INTO sales_orders (so_number, so_barcode, customer_name, customer_phone, customer_address, warehouse_id, ship_method, ship_address, ship_by_date, memo, order_origin, order_date, created_by, status, external_id)
+            VALUES (:sn, :sb, :cust, :phone, :caddr, :wid, :ship, :addr, :ship_by, :memo, :origin, NOW(), :created_by, :status, :ext_id)
             RETURNING so_id
         """),
         {
@@ -531,6 +536,7 @@ def create_sales_order(validated):
             "wid": data["warehouse_id"],
             "ship": data.get("ship_method"), "addr": data.get("ship_address"),
             "ship_by": data.get("ship_by_date"), "memo": data.get("memo"),
+            "origin": data.get("order_origin"),
             "created_by": g.current_user["username"],
             "status": SO_OPEN,
             "ext_id": str(uuid.uuid4()),
@@ -581,7 +587,7 @@ def update_sales_order(so_id, validated):
 
     so = g.db.execute(
         text(
-            "SELECT so_id, status, warehouse_id, source_system, "
+            "SELECT so_id, status, warehouse_id, source_system, order_origin, "
             "       so_number, so_barcode, "
             "       customer_name, customer_phone, customer_address, "
             "       ship_method, ship_address, ship_by_date, "
@@ -634,6 +640,8 @@ def update_sales_order(so_id, validated):
         # corrections only. Routine fulfillment still flows through
         # /api/v1/dockd/orders/<so_number>/ship.
         "status", "carrier", "tracking_number", "shipped_at",
+        # mig 063: free-text upstream-origin label.
+        "order_origin",
     }
     fields, params, edits = [], {"sid": so_id}, []
     for col in ALLOWED_FIELDS:

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -35,6 +35,7 @@ from schemas.sales_orders import (
     ADDRESS_FIELD_NAMES,
     AddSalesOrderLineRequest,
     CreateSalesOrderRequest,
+    RevertSalesOrderStatusRequest,
     UpdateSalesOrderAddressRequest,
     UpdateSalesOrderLineRequest,
     UpdateSalesOrderRequest,
@@ -42,7 +43,9 @@ from schemas.sales_orders import (
 from services.audit_service import write_audit_log
 from services.sales_order_service import (
     CancelNotAllowed,
+    RevertNotAllowed,
     cancel_sales_order as _cancel_so,
+    revert_sales_order_status as _revert_so_status,
 )
 from utils.validation import validate_body
 
@@ -412,6 +415,25 @@ def get_sales_order(so_id):
         {"sid": so_id},
     ).fetchall()
 
+    # so-refinement: pick_tasks still in PICKED state. The revert-status
+    # modal needs item / bin attribution to offer per-pick release; the
+    # detail GET is the natural place to return it so the modal does
+    # not need a second round-trip when the operator demotes status.
+    pick_tasks = g.db.execute(
+        text("""
+            SELECT pt.pick_task_id, pt.so_line_id, pt.item_id, pt.bin_id,
+                   pt.quantity_picked, pt.picked_at, pt.picked_by,
+                   pt.status,
+                   i.sku, i.item_name, b.bin_code
+              FROM pick_tasks pt
+              JOIN items i ON i.item_id = pt.item_id
+              JOIN bins b ON b.bin_id = pt.bin_id
+             WHERE pt.so_id = :sid AND pt.status = 'PICKED'
+             ORDER BY pt.pick_task_id
+        """),
+        {"sid": so_id},
+    ).fetchall()
+
     return jsonify({
         "sales_order": {
             "so_id": so.so_id, "so_number": so.so_number, "so_barcode": so.so_barcode,
@@ -464,6 +486,16 @@ def get_sales_order(so_id):
              "quantity_picked": l.quantity_picked, "quantity_packed": l.quantity_packed,
              "quantity_shipped": l.quantity_shipped, "status": l.status}
             for l in lines
+        ],
+        "pick_tasks": [
+            {"pick_task_id": p.pick_task_id, "so_line_id": p.so_line_id,
+             "item_id": p.item_id, "sku": p.sku, "item_name": p.item_name,
+             "bin_id": p.bin_id, "bin_code": p.bin_code,
+             "quantity_picked": p.quantity_picked,
+             "picked_at": p.picked_at.isoformat() if p.picked_at else None,
+             "picked_by": p.picked_by,
+             "status": p.status}
+            for p in pick_tasks
         ],
     })
 
@@ -802,6 +834,38 @@ def cancel_sales_order(so_id):
         "message": "Sales order cancelled",
         "pre_status": result["pre_status"],
         "audit_log_id": result["audit_log_id"],
+    })
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/revert-status", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@validate_body(RevertSalesOrderStatusRequest)
+@with_db
+def revert_sales_order_status(so_id, validated):
+    """so-refinement: admin demotes an SO from PICKED/PACKED/SHIPPED
+    back to an earlier status. Delegates to the shared service so the
+    pick-task release, unpack, and unship effects share one transaction
+    and one audit shape. RevertNotAllowed.kind discriminates the 4xx
+    response so the frontend can route the error to the right UI."""
+    try:
+        result = _revert_so_status(
+            g.db,
+            so_id=so_id,
+            new_status=validated.new_status,
+            release_pick_task_ids=validated.release_pick_task_ids,
+            username=g.current_user["username"],
+        )
+    except RevertNotAllowed as exc:
+        status_code = 404 if exc.kind == "not_found" else (
+            409 if exc.kind == "picked_qty_remaining" else 400
+        )
+        body = {"error": str(exc), "kind": exc.kind, **exc.context}
+        return jsonify(body), status_code
+    g.db.commit()
+    return jsonify({
+        "message": "Sales order status reverted",
+        **result,
     })
 
 

--- a/api/routes/picking.py
+++ b/api/routes/picking.py
@@ -6,8 +6,8 @@ from flask import Blueprint, g, jsonify, request
 from sqlalchemy import text
 
 from constants import (
-    BATCH_OPEN, BATCH_IN_PROGRESS, BATCH_CANCELLED,
-    TASK_PENDING, TASK_PICKED, TASK_SHORT, TASK_SKIPPED,
+    BATCH_OPEN, BATCH_IN_PROGRESS,
+    TASK_PICKED, TASK_SHORT,
 )
 from middleware.auth_middleware import require_auth, check_warehouse_access
 from middleware.db import with_db
@@ -26,6 +26,7 @@ from services.picking_service import (
     complete_batch,
     confirm_pick,
     create_pick_batch,
+    full_revert_batch,
     get_batch_tasks,
     get_next_task,
     short_pick,
@@ -278,7 +279,14 @@ def complete(validated):
 @validate_body(CancelBatchRequest)
 @with_db
 def cancel_batch(validated):
-    """Cancel/delete a batch  -  releases allocated inventory and resets SO statuses."""
+    """Cancel a batch and unwind every effect (PENDING reservations,
+    PICKED moves, SHORT residue). Operator semantic: cancel = wipe
+    progress so the SO is indistinguishable from "never started
+    picking" -- no Resume affordance, no half-stored state. Items the
+    picker physically pulled are restored to their source bin in the
+    WMS; the operator is responsible for the corresponding physical
+    return. See services.picking_service.full_revert_batch for the
+    per-task effects."""
     batch_id = validated.batch_id
     batch = g.db.execute(
         text("SELECT batch_id, status, warehouse_id FROM pick_batches WHERE batch_id = :bid"),
@@ -291,38 +299,12 @@ def cancel_batch(validated):
     if not ok:
         return denied
 
-    # Release allocated inventory for pending tasks
-    pending_tasks = g.db.execute(
-        text("""
-            SELECT pick_task_id, item_id, bin_id, quantity_to_pick
-            FROM pick_tasks
-            WHERE batch_id = :bid AND status = :task_status
-        """),
-        {"bid": batch_id, "task_status": TASK_PENDING},
-    ).fetchall()
-
-    for task in pending_tasks:
-        g.db.execute(
-            text("""
-                UPDATE inventory
-                SET quantity_allocated = GREATEST(0, quantity_allocated - :qty)
-                WHERE item_id = :iid AND bin_id = :bid
-            """),
-            {"qty": task.quantity_to_pick, "iid": task.item_id, "bid": task.bin_id},
-        )
-
-    # SOs in a cancelled batch stay OPEN (PICKING was retired in mig 060);
-    # no status reset is required.
-
-    # Mark batch and all pending tasks as cancelled
-    g.db.execute(
-        text("UPDATE pick_tasks SET status = :new_status WHERE batch_id = :bid AND status = :old_status"),
-        {"bid": batch_id, "new_status": TASK_SKIPPED, "old_status": TASK_PENDING},
+    result = full_revert_batch(
+        g.db, batch_id=batch_id,
+        username=g.current_user["username"],
     )
-    g.db.execute(
-        text("UPDATE pick_batches SET status = :batch_status WHERE batch_id = :bid"),
-        {"bid": batch_id, "batch_status": BATCH_CANCELLED},
-    )
-
     g.db.commit()
-    return jsonify({"message": "Batch cancelled"})
+    return jsonify({
+        "message": "Batch cancelled",
+        "released_tasks": result["released_tasks"],
+    })

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -96,6 +96,23 @@ class UpdateSalesOrderLineRequest(BaseModel):
     quantity_ordered: int = Field(..., gt=0, le=1000000)
 
 
+class RevertSalesOrderStatusRequest(BaseModel):
+    """so-refinement: admin demotes an SO from PICKED/PACKED/SHIPPED
+    back to an earlier status. The body picks which already-PICKED
+    pick_tasks should release their inventory back to the source bin.
+    Tasks not in this list stay PICKED; if any picked qty remains and
+    new_status is below PICKED, the backend rejects with 409 so an
+    operator does not end up with a status / inventory mismatch.
+
+    Empty list is valid: PACKED to PICKED needs no pick release (just
+    zeros quantity_packed), and SHIPPED to PACKED needs no release
+    either (just clears the shipment fields).
+    """
+
+    new_status: str = Field(..., min_length=1, max_length=32)
+    release_pick_task_ids: List[int] = Field(default_factory=list)
+
+
 class UpdateSalesOrderAddressRequest(BaseModel):
     """v1.8.0 (#288): dedicated PATCH body for editing the 16
     structured billing/shipping address fields on a sales_order.

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -41,6 +41,9 @@ class CreateSalesOrderRequest(BaseModel):
     # length cap; the schema-level 4 KB ceiling here keeps a single
     # bad PATCH from inflating an SO row indefinitely.
     memo: Optional[str] = Field(None, max_length=4096)
+    # mig 063: free-text upstream-origin label. No allowlist; whatever
+    # the connector / operator hands us lands as-is up to 64 chars.
+    order_origin: Optional[str] = Field(None, max_length=64)
 
 
 class UpdateSalesOrderRequest(BaseModel):
@@ -71,6 +74,10 @@ class UpdateSalesOrderRequest(BaseModel):
     # so-full-edit override; the canonical allowlist FK enforces that
     # the value is a recognised tag. Empty string clears the column.
     source_system: Optional[str] = Field(None, max_length=64)
+    # mig 063: free-text upstream-origin label (e.g. "amazon",
+    # "phone-order"). No allowlist; same status gate as the other
+    # header fields. Empty string clears the column.
+    order_origin: Optional[str] = Field(None, max_length=64)
 
 
 class AddSalesOrderLineRequest(BaseModel):

--- a/api/services/picking_service.py
+++ b/api/services/picking_service.py
@@ -11,12 +11,13 @@ from sqlalchemy import text
 from services.audit_service import write_audit_log
 from services.connector_stub import enrich_order
 from services.events_service import emit_event, get_user_external_id
+from services.inventory_service import add_inventory
 
 from constants import (
-    BATCH_OPEN, BATCH_IN_PROGRESS, BATCH_COMPLETED,
+    BATCH_OPEN, BATCH_IN_PROGRESS, BATCH_COMPLETED, BATCH_CANCELLED,
     SO_OPEN, SO_PICKED,
-    TASK_PENDING, TASK_PICKED, TASK_SHORT, TASK_SKIPPED,
-    ACTION_PICK,
+    TASK_PENDING, TASK_PICKED, TASK_SHORT, TASK_SKIPPED, TASK_RELEASED,
+    ACTION_PICK, ACTION_SO_PICK_RELEASED, ACTION_SO_ALLOCATION_RELEASED,
     BIN_PICKABLE, BIN_PICKABLE_STAGING,
 )
 
@@ -67,7 +68,11 @@ def create_pick_batch(db, so_identifiers, warehouse_id, username):
 
     # 2. Generate batch number
     now = datetime.now(timezone.utc)
-    batch_number = f"BATCH-{now.strftime('%Y%m%d-%H%M%S')}"
+    # Microsecond resolution guards against two batches in the same
+    # second colliding on pick_batches.batch_number UNIQUE -- the
+    # tighter suffix collapses the second-grain race that surfaced
+    # when the test suite creates multiple batches in quick succession.
+    batch_number = f"BATCH-{now.strftime('%Y%m%d-%H%M%S-%f')}"
 
     # 3. Create pick_batches record
     result = db.execute(
@@ -956,7 +961,7 @@ def wave_create(db, so_ids, warehouse_id, username):
 
     # 2. Generate batch
     now = datetime.now(timezone.utc)
-    batch_number = f"WAVE-{now.strftime('%Y%m%d-%H%M%S')}"
+    batch_number = f"WAVE-{now.strftime('%Y%m%d-%H%M%S-%f')}"
 
     result = db.execute(
         text(
@@ -1205,6 +1210,179 @@ def _get_contributing_orders(db, pick_task_id):
         {"tid": pick_task_id},
     ).fetchall()
     return [{"so_number": r.so_number, "quantity": r.quantity} for r in rows]
+
+
+def full_revert_batch(db, batch_id, username):
+    """Cancel a batch and unwind every effect so the SOs in it are
+    indistinguishable from "never started picking."
+
+    Operator semantic (hotfix/picking-revert-allocation): cancel = wipe
+    all progress, no Resume affordance. Whatever was picked goes back
+    on the shelf (operator is responsible for physically returning),
+    whatever was reserved is freed, the line counters reset, and the
+    batch is marked CANCELLED.
+
+    Per-task effects, branched on terminal pick_task.status:
+      PENDING -> the task never fired. Decrement
+        inventory.quantity_allocated by quantity_to_pick (release the
+        bin reservation booked at create_pick_batch), decrement
+        sales_order_lines.quantity_allocated by the same amount, flip
+        the task to SKIPPED.
+      PICKED -> units physically left the bin. add_inventory restores
+        them to the source bin, decrement
+        sales_order_lines.quantity_picked by quantity_picked AND
+        quantity_allocated by quantity_to_pick, flip the task to
+        RELEASED (matches the revert flow's terminal state).
+        inventory.quantity_allocated was already cleared at
+        confirm_pick time, so no inventory.allocated change here.
+      SHORT -> the operator picked quantity_picked and shorted the
+        rest. add_inventory restores those quantity_picked units to
+        the bin if > 0, decrement sol.quantity_picked /
+        quantity_allocated. inventory.quantity_allocated was already
+        cleared at short_pick. Task flips to SKIPPED (the original
+        SHORT signal is preserved in audit; for cancel we want the
+        line back to clean).
+      SKIPPED / RELEASED -> already terminal, no-op (idempotent
+        re-entry).
+
+    Writes one SO_PICK_RELEASED audit row per task whose
+    quantity_picked > 0 (the physical inventory event), plus one
+    SO_ALLOCATION_RELEASED row per task whose allocation was undone
+    (the line-state event). TO-batch lanes are out of scope: this
+    helper only revert SO picks; TO unwind goes through the existing
+    transfer_order_service helpers."""
+    batch = db.execute(
+        text(
+            "SELECT batch_id, status, warehouse_id "
+            "  FROM pick_batches WHERE batch_id = :bid"
+        ),
+        {"bid": batch_id},
+    ).fetchone()
+    if not batch:
+        raise ValueError(f"Batch {batch_id} not found")
+    if batch.status in (BATCH_COMPLETED, BATCH_CANCELLED):
+        # Already terminal -- nothing to unwind. Caller should not
+        # rely on this returning a result; the explicit shape lets
+        # callers distinguish "noop" from "did work."
+        return {"batch_id": batch_id, "released_tasks": 0, "noop": True}
+
+    tasks = db.execute(
+        text(
+            "SELECT pick_task_id, so_id, so_line_id, item_id, bin_id, "
+            "       quantity_to_pick, quantity_picked, status "
+            "  FROM pick_tasks "
+            " WHERE batch_id = :bid "
+            " FOR UPDATE"
+        ),
+        {"bid": batch_id},
+    ).fetchall()
+
+    released_count = 0
+    for t in tasks:
+        # Skip TO lanes (so_id is NULL on TO tasks): the SO-side unwind
+        # below would no-op anyway, but the explicit guard is clearer
+        # than relying on the WHERE so_line_id = NULL match producing
+        # zero rows.
+        if t.so_id is None:
+            continue
+        qty_to_pick = int(t.quantity_to_pick or 0)
+        qty_picked = int(t.quantity_picked or 0)
+
+        if t.status == TASK_PENDING:
+            # Reservation only -- nothing physically moved.
+            if qty_to_pick > 0:
+                db.execute(
+                    text(
+                        "UPDATE inventory "
+                        "   SET quantity_allocated = GREATEST(0, quantity_allocated - :qty), "
+                        "       updated_at = NOW() "
+                        " WHERE item_id = :iid AND bin_id = :bid"
+                    ),
+                    {"qty": qty_to_pick, "iid": t.item_id, "bid": t.bin_id},
+                )
+            new_status = TASK_SKIPPED
+        elif t.status in (TASK_PICKED, TASK_SHORT):
+            # Physically moved qty_picked units; restore them.
+            if qty_picked > 0:
+                add_inventory(
+                    db,
+                    item_id=t.item_id,
+                    bin_id=t.bin_id,
+                    warehouse_id=batch.warehouse_id,
+                    quantity=qty_picked,
+                    lot_number=None,
+                )
+                write_audit_log(
+                    db,
+                    action_type=ACTION_SO_PICK_RELEASED,
+                    entity_type="SO",
+                    entity_id=t.so_id,
+                    user_id=username,
+                    warehouse_id=batch.warehouse_id,
+                    details={
+                        "pick_task_id": t.pick_task_id,
+                        "so_line_id": t.so_line_id,
+                        "item_id": t.item_id,
+                        "bin_id": t.bin_id,
+                        "quantity": qty_picked,
+                        "reason": "batch_cancel",
+                    },
+                )
+            new_status = TASK_RELEASED if t.status == TASK_PICKED else TASK_SKIPPED
+        else:
+            # SKIPPED / RELEASED already terminal; allocation either
+            # never booked or already undone via revert flow.
+            continue
+
+        # Whether the task was PENDING, PICKED, or SHORT, the create
+        # step booked qty_to_pick onto sol.quantity_allocated and the
+        # picked step may have bumped sol.quantity_picked. Undo both
+        # so the line returns to the pre-batch numbers.
+        if t.so_line_id is not None and (qty_to_pick > 0 or qty_picked > 0):
+            db.execute(
+                text(
+                    "UPDATE sales_order_lines "
+                    "   SET quantity_picked = GREATEST(0, quantity_picked - :picked_qty), "
+                    "       quantity_allocated = GREATEST(0, quantity_allocated - :alloc_qty) "
+                    " WHERE so_line_id = :sol_id"
+                ),
+                {"picked_qty": qty_picked, "alloc_qty": qty_to_pick,
+                 "sol_id": t.so_line_id},
+            )
+            if qty_to_pick > 0:
+                write_audit_log(
+                    db,
+                    action_type=ACTION_SO_ALLOCATION_RELEASED,
+                    entity_type="SO",
+                    entity_id=t.so_id,
+                    user_id=username,
+                    warehouse_id=batch.warehouse_id,
+                    details={
+                        "pick_task_id": t.pick_task_id,
+                        "so_line_id": t.so_line_id,
+                        "released_quantity": qty_to_pick,
+                        "reason": "batch_cancel",
+                    },
+                )
+
+        db.execute(
+            text(
+                "UPDATE pick_tasks SET status = :new_status "
+                " WHERE pick_task_id = :ptid"
+            ),
+            {"new_status": new_status, "ptid": t.pick_task_id},
+        )
+        released_count += 1
+
+    db.execute(
+        text(
+            "UPDATE pick_batches SET status = :batch_status "
+            " WHERE batch_id = :bid"
+        ),
+        {"bid": batch_id, "batch_status": BATCH_CANCELLED},
+    )
+
+    return {"batch_id": batch_id, "released_tasks": released_count, "noop": False}
 
 
 def _get_tasks_for_batch(db, batch_id):

--- a/api/services/sales_order_service.py
+++ b/api/services/sales_order_service.py
@@ -20,12 +20,18 @@ from sqlalchemy import text
 
 from constants import (
     ACTION_CANCEL,
+    ACTION_SO_PICK_RELEASED,
+    ACTION_SO_STATUS_REVERTED,
+    ACTION_SO_UNPACKED,
+    ACTION_SO_UNSHIPPED,
     SO_CANCELLED,
     SO_OPEN,
     SO_PACKED,
     SO_PICKED,
     SO_SHIPPED,
     TASK_PENDING,
+    TASK_PICKED,
+    TASK_RELEASED,
 )
 from services.audit_service import write_audit_log
 from services.inventory_service import add_inventory
@@ -282,3 +288,301 @@ def _unwind_picked_or_packed(db, so_id: int, warehouse_id: int) -> None:
         text("DELETE FROM pick_batch_orders WHERE so_id = :sid"),
         {"sid": so_id},
     )
+
+
+# so-refinement: forward-flow ordering used by the revert-status path.
+# PICKING / PACKING / ALLOCATED were retired in v1.13.0 (mig 058); the
+# live flow is OPEN -> PICKED -> PACKED -> SHIPPED. Any target status
+# with a strictly-lower index than current is a "backward" transition
+# and must go through revert_sales_order_status() so the operator
+# decides what happens to picked / packed / shipped state.
+_STATUS_ORDER = {
+    SO_OPEN: 0,
+    SO_PICKED: 1,
+    SO_PACKED: 2,
+    SO_SHIPPED: 3,
+}
+
+
+class RevertNotAllowed(Exception):
+    """The revert request is invalid for a structural reason (target
+    status not lower than current, partial release would leave the SO
+    in an inconsistent state, etc.). Caller maps to a 4xx with the
+    `kind` discriminator so the frontend can show the right error."""
+
+    def __init__(self, message: str, kind: str, **context):
+        super().__init__(message)
+        self.kind = kind
+        self.context = context
+
+
+def revert_sales_order_status(
+    db,
+    *,
+    so_id: int,
+    new_status: str,
+    release_pick_task_ids: list,
+    username: str,
+) -> Dict[str, Any]:
+    """Demote an SO from PICKED/PACKED/SHIPPED back to an earlier
+    status, unwinding the side effects the operator selected.
+
+    Effects, computed from (current, target):
+      * unship: SHIPPED to anything. Clears tracking_number, carrier,
+        shipped_at on the header. No physical inventory move (the
+        goods left the building); operators reconcile externally.
+      * unpack: current >= PACKED and target < PACKED. Zeros
+        quantity_packed on every line. No inventory move (pack does
+        not touch inventory; only labels units as packed).
+      * release: each pick_task_id in release_pick_task_ids restores
+        its quantity_picked to the bin it came from, decrements the
+        line's quantity_picked by the same amount, and marks the
+        pick_task as RELEASED so a subsequent revert prompt does not
+        re-offer it.
+
+    Guards:
+      * Target must be strictly lower than current (forward only by
+        the normal status flow).
+      * SO must exist and not be CANCELLED.
+      * Every release_pick_task_id must belong to this SO and still
+        be in TASK_PICKED state.
+      * If target < PICKED and any line ends with quantity_picked > 0
+        after releases, raises with kind='picked_qty_remaining' so the
+        operator can either release more or pick a higher target.
+
+    Audit: one ACTION_SO_STATUS_REVERTED row per request (from/to),
+    plus one ACTION_SO_PICK_RELEASED per released pick_task, plus a
+    single ACTION_SO_UNPACKED row when unpack runs and a single
+    ACTION_SO_UNSHIPPED row when unship runs.
+    """
+    if new_status not in _STATUS_ORDER:
+        raise RevertNotAllowed(
+            f"unknown target status: {new_status!r}",
+            kind="invalid_status",
+        )
+
+    so = db.execute(
+        text(
+            "SELECT so_id, so_number, status, warehouse_id, "
+            "       tracking_number, carrier, shipped_at "
+            "  FROM sales_orders WHERE so_id = :sid FOR UPDATE"
+        ),
+        {"sid": so_id},
+    ).fetchone()
+    if so is None:
+        raise RevertNotAllowed(
+            "sales order not found", kind="not_found",
+        )
+    if so.status == SO_CANCELLED:
+        raise RevertNotAllowed(
+            "cannot revert a cancelled order; reopen via the cancel-undo workflow",
+            kind="cancelled",
+            current_status=so.status,
+        )
+
+    cur_idx = _STATUS_ORDER.get(so.status)
+    new_idx = _STATUS_ORDER[new_status]
+    if cur_idx is None or new_idx > cur_idx:
+        raise RevertNotAllowed(
+            "target status must not be higher than current status",
+            kind="not_backward",
+            current_status=so.status,
+            target_status=new_status,
+        )
+
+    # so-refinement: new_status == current_status is the "release-only"
+    # path. The operator wants to release picks without flipping status,
+    # which is valid when releasing a subset that does not zero out
+    # quantity_picked. need_unship/need_unpack guard against firing on
+    # a same-status request so a release-only call on a SHIPPED order
+    # does not also clear its shipment fields.
+    need_unship = so.status == SO_SHIPPED and new_status != SO_SHIPPED
+    need_unpack = cur_idx >= _STATUS_ORDER[SO_PACKED] and new_idx < _STATUS_ORDER[SO_PACKED]
+    target_below_picked = new_idx < _STATUS_ORDER[SO_PICKED]
+
+    pick_ids = list({int(x) for x in release_pick_task_ids or []})
+    released_details = []
+
+    if pick_ids:
+        tasks = db.execute(
+            text(
+                "SELECT pick_task_id, so_line_id, item_id, bin_id, "
+                "       quantity_to_pick, quantity_picked, status "
+                "  FROM pick_tasks "
+                " WHERE pick_task_id = ANY(:ids) AND so_id = :sid "
+                " FOR UPDATE"
+            ),
+            {"ids": pick_ids, "sid": so_id},
+        ).fetchall()
+        found_ids = {t.pick_task_id for t in tasks}
+        missing = [pid for pid in pick_ids if pid not in found_ids]
+        if missing:
+            raise RevertNotAllowed(
+                f"pick_task(s) not found on this SO: {missing}",
+                kind="pick_task_missing",
+                missing_ids=missing,
+            )
+        wrong_state = [t.pick_task_id for t in tasks if t.status != TASK_PICKED]
+        if wrong_state:
+            raise RevertNotAllowed(
+                f"pick_task(s) not in PICKED state: {wrong_state}",
+                kind="pick_task_wrong_state",
+                wrong_state_ids=wrong_state,
+            )
+        for t in tasks:
+            qty_picked = int(t.quantity_picked or 0)
+            # quantity_to_pick is what create_pick_batch / wave_create
+            # bumped sol.quantity_allocated by; releasing the task must
+            # undo that allocation so a re-scan sees the line as still
+            # needing coverage. quantity_picked is what physically moved
+            # out of the bin and goes back via add_inventory; for a
+            # normal PICKED task the two values are equal, but the split
+            # keeps the partial-pick path (qty_picked < qty_to_pick)
+            # correct rather than under-restoring the allocation.
+            qty_allocated = int(t.quantity_to_pick or 0)
+            if qty_picked > 0:
+                add_inventory(
+                    db,
+                    item_id=t.item_id,
+                    bin_id=t.bin_id,
+                    warehouse_id=so.warehouse_id,
+                    quantity=qty_picked,
+                    lot_number=None,
+                )
+            db.execute(
+                text(
+                    "UPDATE sales_order_lines "
+                    "   SET quantity_picked = GREATEST(quantity_picked - :picked_qty, 0), "
+                    "       quantity_allocated = GREATEST(quantity_allocated - :alloc_qty, 0) "
+                    " WHERE so_line_id = :sol_id"
+                ),
+                {"picked_qty": qty_picked, "alloc_qty": qty_allocated, "sol_id": t.so_line_id},
+            )
+            db.execute(
+                text(
+                    "UPDATE pick_tasks SET status = :released "
+                    " WHERE pick_task_id = :ptid"
+                ),
+                {"released": TASK_RELEASED, "ptid": t.pick_task_id},
+            )
+            # Audit row only when units actually moved. A qty_picked=0
+            # release still flips the task to RELEASED and undoes the
+            # allocation, but there is no physical inventory event to
+            # narrate so SO_PICK_RELEASED is skipped.
+            if qty_picked > 0:
+                released_details.append({
+                    "pick_task_id": t.pick_task_id,
+                    "so_line_id": t.so_line_id,
+                    "item_id": t.item_id,
+                    "bin_id": t.bin_id,
+                    "quantity": qty_picked,
+                })
+
+    if target_below_picked:
+        # Reject mid-flight: if releases were partial, the SO would
+        # have picked qty on lines but a status that claims no picks.
+        # Operator must either release more pick_tasks or pick a
+        # target that still permits picks (PICKED or higher).
+        remaining = db.execute(
+            text(
+                "SELECT COALESCE(SUM(quantity_picked), 0) AS total "
+                "  FROM sales_order_lines WHERE so_id = :sid"
+            ),
+            {"sid": so_id},
+        ).scalar()
+        if remaining and int(remaining) > 0:
+            raise RevertNotAllowed(
+                "cannot demote below PICKED while quantity_picked remains; "
+                "release the remaining pick_tasks or pick a higher target status",
+                kind="picked_qty_remaining",
+                remaining_picked=int(remaining),
+                target_status=new_status,
+            )
+
+    if need_unpack:
+        db.execute(
+            text(
+                "UPDATE sales_order_lines SET quantity_packed = 0 "
+                " WHERE so_id = :sid AND quantity_packed > 0"
+            ),
+            {"sid": so_id},
+        )
+        db.execute(
+            text("UPDATE sales_orders SET packed_at = NULL WHERE so_id = :sid"),
+            {"sid": so_id},
+        )
+        write_audit_log(
+            db,
+            action_type=ACTION_SO_UNPACKED,
+            entity_type="SO",
+            entity_id=so_id,
+            user_id=username,
+            warehouse_id=so.warehouse_id,
+            details={"from_status": so.status, "to_status": new_status},
+        )
+
+    if need_unship:
+        db.execute(
+            text(
+                "UPDATE sales_orders "
+                "   SET tracking_number = NULL, carrier = NULL, shipped_at = NULL "
+                " WHERE so_id = :sid"
+            ),
+            {"sid": so_id},
+        )
+        write_audit_log(
+            db,
+            action_type=ACTION_SO_UNSHIPPED,
+            entity_type="SO",
+            entity_id=so_id,
+            user_id=username,
+            warehouse_id=so.warehouse_id,
+            details={
+                "prev_tracking_number": so.tracking_number,
+                "prev_carrier": so.carrier,
+                "prev_shipped_at": so.shipped_at.isoformat() if so.shipped_at else None,
+            },
+        )
+
+    for d in released_details:
+        write_audit_log(
+            db,
+            action_type=ACTION_SO_PICK_RELEASED,
+            entity_type="SO",
+            entity_id=so_id,
+            user_id=username,
+            warehouse_id=so.warehouse_id,
+            details=d,
+        )
+
+    status_changed = new_status != so.status
+    if status_changed:
+        db.execute(
+            text("UPDATE sales_orders SET status = :status WHERE so_id = :sid"),
+            {"status": new_status, "sid": so_id},
+        )
+        write_audit_log(
+            db,
+            action_type=ACTION_SO_STATUS_REVERTED,
+            entity_type="SO",
+            entity_id=so_id,
+            user_id=username,
+            warehouse_id=so.warehouse_id,
+            details={
+                "from_status": so.status,
+                "to_status": new_status,
+                "released_pick_tasks": [d["pick_task_id"] for d in released_details],
+                "unpacked": bool(need_unpack),
+                "unshipped": bool(need_unship),
+            },
+        )
+
+    return {
+        "so_id": so_id,
+        "so_number": so.so_number,
+        "from_status": so.status,
+        "to_status": new_status,
+        "released_pick_tasks": released_details,
+        "unpacked": bool(need_unpack),
+        "unshipped": bool(need_unship),
+    }

--- a/api/tests/test_admin_revert_status_endpoint.py
+++ b/api/tests/test_admin_revert_status_endpoint.py
@@ -1,0 +1,341 @@
+"""so-refinement: HTTP-layer tests for POST /admin/sales-orders/<id>/revert-status.
+
+The endpoint thinly wraps services.sales_order_service.revert_sales_order_status:
+service-level invariants are covered in test_revert_sales_order_status.py;
+this file pins the HTTP contract -- status codes, error-body shape,
+auth, permission gating. RevertNotAllowed.kind maps to:
+
+  not_found            -> 404
+  picked_qty_remaining -> 409
+  every other kind     -> 400
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from db_test_context import get_raw_connection
+
+
+# ----------------------------------------------------------------------
+# Fixture helpers (raw-cursor inserts; per-test transaction owns them).
+# ----------------------------------------------------------------------
+
+
+def _insert_so(status="PICKED", **extra):
+    """Insert a sales_orders row. **extra applies as a follow-up UPDATE
+    so the base INSERT keeps a static column list (test_external_id_inserts
+    scanner constraint)."""
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_orders "
+        "(so_number, customer_name, status, warehouse_id, external_id) "
+        "VALUES (%s, %s, %s, 1, %s) RETURNING so_id",
+        (f"SO-REVERT-EP-{uuid.uuid4().hex[:8]}", "Cust", status,
+         str(uuid.uuid4())),
+    )
+    so_id = cur.fetchone()[0]
+    for col, val in extra.items():
+        cur.execute(
+            f"UPDATE sales_orders SET {col} = %s WHERE so_id = %s",
+            (val, so_id),
+        )
+    cur.close()
+    return so_id
+
+
+def _insert_item():
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO items (sku, item_name, upc, external_id) "
+        "VALUES (%s, %s, %s, %s) RETURNING item_id",
+        (f"SKU-{uuid.uuid4().hex[:8]}", "Widget", "0123456789012",
+         str(uuid.uuid4())),
+    )
+    item_id = cur.fetchone()[0]
+    cur.close()
+    return item_id
+
+
+def _insert_so_line(so_id, item_id, *, qty_ordered=2, qty_picked=2,
+                     status="PICKED"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_order_lines "
+        "(so_id, item_id, quantity_ordered, quantity_picked, line_number, status) "
+        "VALUES (%s, %s, %s, %s, %s, %s) RETURNING so_line_id",
+        (so_id, item_id, qty_ordered, qty_picked, 1, status),
+    )
+    sol_id = cur.fetchone()[0]
+    cur.close()
+    return sol_id
+
+
+def _set_inv(item_id, bin_id, qty_on_hand):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO inventory (item_id, bin_id, warehouse_id, "
+        "quantity_on_hand) VALUES (%s, %s, 1, %s) "
+        "ON CONFLICT (item_id, bin_id, lot_number) DO UPDATE "
+        "SET quantity_on_hand = EXCLUDED.quantity_on_hand",
+        (item_id, bin_id, qty_on_hand),
+    )
+    cur.close()
+
+
+def _insert_pick_task(so_id, sol_id, item_id, bin_id, qty=2, status="PICKED"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO pick_batches (batch_number, warehouse_id, status) "
+        "VALUES (%s, 1, 'OPEN') RETURNING batch_id",
+        (f"BATCH-EP-{uuid.uuid4().hex[:8]}",),
+    )
+    batch_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO pick_tasks (batch_id, so_id, so_line_id, item_id, "
+        "bin_id, quantity_to_pick, quantity_picked, status, pick_sequence) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING pick_task_id",
+        (batch_id, so_id, sol_id, item_id, bin_id, qty, qty, status, 1),
+    )
+    pt_id = cur.fetchone()[0]
+    cur.close()
+    return pt_id
+
+
+def _picked_so_with_release_candidate():
+    """Returns (so_id, pick_task_id) for a PICKED SO ready to revert."""
+    item_id = _insert_item()
+    _set_inv(item_id, bin_id=3, qty_on_hand=8)
+    so_id = _insert_so(status="PICKED")
+    sol_id = _insert_so_line(so_id, item_id, qty_ordered=2, qty_picked=2,
+                              status="PICKED")
+    pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3, qty=2,
+                               status="PICKED")
+    return so_id, pt_id
+
+
+def _mint_restricted_user(client, username, page_keys):
+    """Create a USER (non-ADMIN) with explicit page-permission grants
+    and return their auth header. Used to verify the
+    @require_admin_or_page_permission gate on the revert endpoint."""
+    admin_resp = client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "admin"},
+    )
+    admin_token = admin_resp.get_json()["token"]
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    create_resp = client.post(
+        "/api/admin/users",
+        json={
+            "username": username,
+            "password": "password123",
+            "full_name": username.title(),
+            "role": "USER",
+            "warehouse_ids": [1],
+        },
+        headers=admin_headers,
+    )
+    assert create_resp.status_code in (200, 201), create_resp.get_json()
+    new_user_id = create_resp.get_json()["user_id"]
+    # Page perms land via the dedicated PUT endpoint added in P6.1.
+    perm_resp = client.put(
+        f"/api/admin/users/{new_user_id}/permissions",
+        json={"page_keys": list(page_keys)},
+        headers=admin_headers,
+    )
+    assert perm_resp.status_code == 200, perm_resp.get_json()
+    login = client.post(
+        "/api/auth/login",
+        json={"username": username, "password": "password123"},
+    )
+    return {"Authorization": f"Bearer {login.get_json()['token']}"}
+
+
+# ----------------------------------------------------------------------
+# Happy path
+# ----------------------------------------------------------------------
+
+
+class TestRevertEndpointHappyPath:
+    def test_200_full_release_to_open(self, client, auth_headers):
+        so_id, pt_id = _picked_so_with_release_candidate()
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={"new_status": "OPEN", "release_pick_task_ids": [pt_id]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["from_status"] == "PICKED"
+        assert body["to_status"] == "OPEN"
+        assert body["unpacked"] is False
+        assert body["unshipped"] is False
+        assert len(body["released_pick_tasks"]) == 1
+        # Returned detail carries the per-pick context.
+        det = body["released_pick_tasks"][0]
+        assert det["pick_task_id"] == pt_id
+        assert det["quantity"] == 2
+
+    def test_200_release_only_no_status_change(self, client, auth_headers):
+        """new_status == current_status is accepted (release-only path)."""
+        so_id, pt_id = _picked_so_with_release_candidate()
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={"new_status": "PICKED", "release_pick_task_ids": [pt_id]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["from_status"] == "PICKED"
+        assert body["to_status"] == "PICKED"
+
+
+# ----------------------------------------------------------------------
+# 4xx behaviour
+# ----------------------------------------------------------------------
+
+
+class TestRevertEndpointErrors:
+    def test_404_so_not_found(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/sales-orders/9999999/revert-status",
+            json={"new_status": "OPEN", "release_pick_task_ids": []},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404
+        body = resp.get_json()
+        assert body["kind"] == "not_found"
+
+    def test_409_picked_qty_remaining(self, client, auth_headers):
+        """Target below PICKED with held picks -> 409 + picked_qty_remaining.
+        The frontend uses this kind to keep the modal open."""
+        so_id, _pt = _picked_so_with_release_candidate()
+        # Don't include the pick_task_id -> the SO still has
+        # quantity_picked=2, and OPEN demands zero.
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={"new_status": "OPEN", "release_pick_task_ids": []},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 409
+        body = resp.get_json()
+        assert body["kind"] == "picked_qty_remaining"
+        assert body["remaining_picked"] == 2
+        assert body["target_status"] == "OPEN"
+
+    def test_400_forward_transition(self, client, auth_headers):
+        so_id = _insert_so(status="PICKED")
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={"new_status": "PACKED", "release_pick_task_ids": []},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["kind"] == "not_backward"
+        assert body["current_status"] == "PICKED"
+        assert body["target_status"] == "PACKED"
+
+    def test_400_invalid_target_status(self, client, auth_headers):
+        so_id = _insert_so(status="PICKED")
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={"new_status": "BOGUS", "release_pick_task_ids": []},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["kind"] == "invalid_status"
+
+    def test_400_cancelled_so(self, client, auth_headers):
+        so_id = _insert_so(status="CANCELLED")
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={"new_status": "OPEN", "release_pick_task_ids": []},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["kind"] == "cancelled"
+
+    def test_400_pick_task_not_on_this_so(self, client, auth_headers):
+        """The endpoint must reject pick_task_ids that belong to a
+        different SO so an operator cannot release someone else's
+        inventory by guessing IDs."""
+        so_id_target, _ = _picked_so_with_release_candidate()
+        other_so, other_pt = _picked_so_with_release_candidate()
+        # Try to release other_so's pick_task against so_id_target.
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id_target}/revert-status",
+            json={"new_status": "OPEN",
+                  "release_pick_task_ids": [other_pt]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["kind"] == "pick_task_missing"
+        assert other_pt in body["missing_ids"]
+
+    def test_422_validation_error_missing_new_status(self, client, auth_headers):
+        """The @validate_body(RevertSalesOrderStatusRequest) decorator
+        rejects payloads that don't carry new_status. This is the
+        pydantic-level guard, distinct from the service-level kind
+        checks above."""
+        so_id = _insert_so(status="PICKED")
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={"release_pick_task_ids": []},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400  # validation_error returns 400
+        body = resp.get_json()
+        # @validate_body surfaces field-level details; expect new_status
+        # to appear in the locator.
+        details = body.get("details") or []
+        locs = [d.get("loc") for d in details]
+        assert any("new_status" in (loc or []) for loc in locs), body
+
+
+# ----------------------------------------------------------------------
+# Auth / permission gating
+# ----------------------------------------------------------------------
+
+
+class TestRevertEndpointAuth:
+    def test_401_no_token(self, client):
+        so_id = _insert_so(status="PICKED")
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={"new_status": "OPEN", "release_pick_task_ids": []},
+        )
+        assert resp.status_code == 401
+
+    def test_403_user_without_sales_orders_permission(self, client):
+        """A USER role without the sales-orders page key must get 403
+        from @require_admin_or_page_permission. Use a user that has
+        a different page key (warehouses) to prove the gate is keyed
+        on sales-orders specifically, not just "has any page perm"."""
+        so_id, _ = _picked_so_with_release_candidate()
+        headers = _mint_restricted_user(
+            client,
+            username=f"noperm-{uuid.uuid4().hex[:6]}",
+            page_keys=["warehouses"],
+        )
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={"new_status": "OPEN", "release_pick_task_ids": []},
+            headers=headers,
+        )
+        assert resp.status_code == 403, resp.get_json()

--- a/api/tests/test_pick_tasks_line_fk_set_null.py
+++ b/api/tests/test_pick_tasks_line_fk_set_null.py
@@ -1,0 +1,329 @@
+"""mig 066: pick_tasks.{so_line_id, to_line_id} FK -> ON DELETE SET NULL.
+
+Tests:
+
+- Schema introspection: both FKs declare ON DELETE SET NULL exactly.
+- Functional (so_line_id): deleting a sales_order_line with attached
+  pick_tasks in every terminal status (PICKED, RELEASED, SHORT,
+  SKIPPED, PENDING) succeeds; each pick_task survives with
+  so_line_id=NULL and every other audit field intact.
+- Functional (to_line_id): same for transfer_order_lines.
+- Negative-control: the audit kernel survives line deletion.
+  pick_task_id, batch_id, so_id (still set by check constraint),
+  item_id, bin_id, quantity_to_pick, quantity_picked, status,
+  picked_by, picked_at all preserved post-DELETE.
+- Regression for the partial-fulfill case: when partial-fulfill
+  shrinks a SOL to zero by DELETE, a RELEASED pick_task no longer
+  blocks the operation -- the FK SET NULL fires and the DELETE
+  proceeds.
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from sqlalchemy import text as sa_text
+
+from db_test_context import get_raw_connection
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _insert_so(status="PICKED"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_orders (so_number, customer_name, status, "
+        "warehouse_id, external_id) "
+        "VALUES (%s, %s, %s, 1, %s) RETURNING so_id",
+        (f"SO-FK-{uuid.uuid4().hex[:8]}", "Cust", status, str(uuid.uuid4())),
+    )
+    so_id = cur.fetchone()[0]
+    cur.close()
+    return so_id
+
+
+def _insert_item():
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO items (sku, item_name, upc, external_id) "
+        "VALUES (%s, %s, %s, %s) RETURNING item_id",
+        (f"SKU-FK-{uuid.uuid4().hex[:8]}", "W", "0123456789012",
+         str(uuid.uuid4())),
+    )
+    item_id = cur.fetchone()[0]
+    cur.close()
+    return item_id
+
+
+def _insert_so_line(so_id, item_id, qty=1):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_order_lines "
+        "(so_id, item_id, quantity_ordered, quantity_picked, "
+        " line_number, status) "
+        "VALUES (%s, %s, %s, %s, 1, 'PENDING') RETURNING so_line_id",
+        (so_id, item_id, qty, qty),
+    )
+    sol_id = cur.fetchone()[0]
+    cur.close()
+    return sol_id
+
+
+def _insert_pick_task(so_id, sol_id, item_id, bin_id, status="PICKED"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO pick_batches (batch_number, warehouse_id, status) "
+        "VALUES (%s, 1, 'OPEN') RETURNING batch_id",
+        (f"BATCH-FK-{uuid.uuid4().hex[:8]}",),
+    )
+    batch_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO pick_tasks (batch_id, so_id, so_line_id, item_id, "
+        "bin_id, quantity_to_pick, quantity_picked, status, pick_sequence, "
+        "picked_by, picked_at) "
+        "VALUES (%s, %s, %s, %s, %s, 2, 2, %s, 1, 'operator-fk', NOW()) "
+        "RETURNING pick_task_id",
+        (batch_id, so_id, sol_id, item_id, bin_id, status),
+    )
+    pt_id = cur.fetchone()[0]
+    cur.close()
+    return pt_id, batch_id
+
+
+def _insert_to(source_wh=1, dest_wh=2):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO transfer_orders "
+        "(to_number, source_warehouse_id, destination_warehouse_id, "
+        " created_by, external_id) "
+        "VALUES (%s, %s, %s, 'fk-test', %s) RETURNING to_id",
+        (f"TO-FK-{uuid.uuid4().hex[:8]}", source_wh, dest_wh,
+         str(uuid.uuid4())),
+    )
+    to_id = cur.fetchone()[0]
+    cur.close()
+    return to_id
+
+
+def _insert_to_line(to_id, item_id, qty=1):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO transfer_order_lines (to_id, item_id, line_number, "
+        "requested_qty) VALUES (%s, %s, 1, %s) RETURNING to_line_id",
+        (to_id, item_id, qty),
+    )
+    tol_id = cur.fetchone()[0]
+    cur.close()
+    return tol_id
+
+
+def _insert_to_pick_task(to_id, tol_id, item_id, bin_id, status="PICKED"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO pick_batches (batch_number, warehouse_id, status) "
+        "VALUES (%s, 1, 'OPEN') RETURNING batch_id",
+        (f"BATCH-TO-FK-{uuid.uuid4().hex[:8]}",),
+    )
+    batch_id = cur.fetchone()[0]
+    # pick_tasks_target_xor requires so_id IS NULL when to_id IS NOT NULL.
+    cur.execute(
+        "INSERT INTO pick_tasks (batch_id, to_id, to_line_id, item_id, "
+        "bin_id, quantity_to_pick, quantity_picked, status, pick_sequence, "
+        "picked_by, picked_at) "
+        "VALUES (%s, %s, %s, %s, %s, 2, 2, %s, 1, 'operator-fk', NOW()) "
+        "RETURNING pick_task_id",
+        (batch_id, to_id, tol_id, item_id, bin_id, status),
+    )
+    pt_id = cur.fetchone()[0]
+    cur.close()
+    return pt_id
+
+
+# ----------------------------------------------------------------------
+# Schema introspection
+# ----------------------------------------------------------------------
+
+
+class TestSchemaIntrospection:
+    def test_so_line_id_fk_has_on_delete_set_null(self, _db_transaction):
+        defn = _db_transaction.execute(
+            sa_text(
+                "SELECT pg_get_constraintdef(oid) AS defn "
+                "  FROM pg_constraint "
+                " WHERE conrelid = 'pick_tasks'::regclass "
+                "   AND conname = 'pick_tasks_so_line_id_fkey'"
+            )
+        ).fetchone().defn
+        assert "ON DELETE SET NULL" in defn
+
+    def test_to_line_id_fk_has_on_delete_set_null(self, _db_transaction):
+        defn = _db_transaction.execute(
+            sa_text(
+                "SELECT pg_get_constraintdef(oid) AS defn "
+                "  FROM pg_constraint "
+                " WHERE conrelid = 'pick_tasks'::regclass "
+                "   AND conname = 'pick_tasks_to_line_id_fkey'"
+            )
+        ).fetchone().defn
+        assert "ON DELETE SET NULL" in defn
+
+    def test_parent_so_id_to_id_stay_restrict(self, _db_transaction):
+        """The parent-aggregate FKs are intentionally NOT SET NULL.
+        The pick_tasks_target_xor check requires exactly one of
+        so_id / to_id to be non-NULL, so cascading either to NULL
+        would break the check on any cross-deletion. Parents are
+        also never hard-deleted in normal operation (cancel flips
+        status; no DELETE on sales_orders / transfer_orders)."""
+        defs = _db_transaction.execute(
+            sa_text(
+                "SELECT conname, pg_get_constraintdef(oid) AS defn "
+                "  FROM pg_constraint "
+                " WHERE conrelid = 'pick_tasks'::regclass "
+                "   AND conname IN ('pick_tasks_so_id_fkey', "
+                "                   'pick_tasks_to_id_fkey')"
+            )
+        ).fetchall()
+        for row in defs:
+            assert "ON DELETE" not in row.defn, (
+                f"{row.conname} unexpectedly has cascade behaviour: {row.defn}"
+            )
+
+
+# ----------------------------------------------------------------------
+# Functional: deleting a sales_order_line cascades so_line_id to NULL
+# ----------------------------------------------------------------------
+
+
+class TestSoLineDeleteCascadesToNull:
+    @pytest.mark.parametrize(
+        "task_status",
+        ["PENDING", "PICKED", "SHORT", "SKIPPED", "RELEASED"],
+    )
+    def test_sol_delete_nulls_so_line_id(self, task_status, _db_transaction):
+        item_id = _insert_item()
+        so_id = _insert_so()
+        sol_id = _insert_so_line(so_id, item_id)
+        pt_id, _ = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                       status=task_status)
+
+        # The DELETE must succeed regardless of pick_task status.
+        _db_transaction.execute(
+            sa_text("DELETE FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        )
+
+        row = _db_transaction.execute(
+            sa_text(
+                "SELECT so_line_id, status, so_id, item_id, bin_id, "
+                "       quantity_picked, picked_by, picked_at "
+                "  FROM pick_tasks WHERE pick_task_id = :p"
+            ),
+            {"p": pt_id},
+        ).fetchone()
+        # so_line_id was nulled by the FK ON DELETE SET NULL.
+        assert row.so_line_id is None
+        # Status preserved (the cascade only touches the FK column).
+        assert row.status == task_status
+        # Audit kernel intact.
+        assert row.so_id == so_id
+        assert row.item_id == item_id
+        assert row.bin_id == 3
+        assert row.quantity_picked == 2
+        assert row.picked_by == "operator-fk"
+        assert row.picked_at is not None
+
+
+# ----------------------------------------------------------------------
+# Functional: deleting a transfer_order_line cascades to_line_id to NULL
+# ----------------------------------------------------------------------
+
+
+class TestToLineDeleteCascadesToNull:
+    def test_tol_delete_nulls_to_line_id(self, _db_transaction):
+        item_id = _insert_item()
+        to_id = _insert_to(source_wh=1, dest_wh=2)
+        tol_id = _insert_to_line(to_id, item_id)
+        pt_id = _insert_to_pick_task(to_id, tol_id, item_id, bin_id=3,
+                                      status="PICKED")
+
+        _db_transaction.execute(
+            sa_text("DELETE FROM transfer_order_lines WHERE to_line_id = :t"),
+            {"t": tol_id},
+        )
+
+        row = _db_transaction.execute(
+            sa_text(
+                "SELECT to_line_id, status, to_id, item_id, bin_id, "
+                "       quantity_picked, picked_by "
+                "  FROM pick_tasks WHERE pick_task_id = :p"
+            ),
+            {"p": pt_id},
+        ).fetchone()
+        assert row.to_line_id is None
+        # Audit kernel still intact.
+        assert row.to_id == to_id
+        assert row.status == "PICKED"
+        assert row.quantity_picked == 2
+        assert row.picked_by == "operator-fk"
+
+
+# ----------------------------------------------------------------------
+# Regression: the exact bug that prompted mig 066
+# ----------------------------------------------------------------------
+
+
+class TestPartialFulfillRegressionPriorMig:
+    def test_released_pick_task_does_not_block_sol_delete(self, _db_transaction):
+        """Before mig 066 this DELETE failed with:
+
+            psycopg2.errors.ForeignKeyViolation:
+              update or delete on table "sales_order_lines" violates
+              foreign key constraint "pick_tasks_so_line_id_fkey"
+
+        which surfaced through partial-fulfill as
+        integrity_constraint_violation when an operator tried to
+        short a line that the so-refinement revert flow had previously
+        released. The test stages that exact precondition and asserts
+        the DELETE now succeeds."""
+        item_id = _insert_item()
+        so_id = _insert_so()
+        sol_id = _insert_so_line(so_id, item_id)
+        pt_id, _ = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                       status="RELEASED")
+
+        _db_transaction.execute(
+            sa_text("DELETE FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        )
+
+        # The line is gone; the pick_task survives with so_line_id NULL.
+        sol_exists = _db_transaction.execute(
+            sa_text("SELECT 1 FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone()
+        assert sol_exists is None
+        pt_row = _db_transaction.execute(
+            sa_text("SELECT so_line_id, status FROM pick_tasks "
+                    "WHERE pick_task_id = :p"),
+            {"p": pt_id},
+        ).fetchone()
+        assert pt_row.so_line_id is None
+        assert pt_row.status == "RELEASED"

--- a/api/tests/test_picking.py
+++ b/api/tests/test_picking.py
@@ -483,3 +483,196 @@ def test_next_pick_bin_code_always_present(client, auth_headers):
     assert data["bin_code"] is not None
     assert isinstance(data["bin_code"], str)
     assert len(data["bin_code"]) > 0
+
+
+class TestCancelBatch:
+    """hotfix/picking-revert-allocation: cancel = wipe progress. The
+    SO must end up indistinguishable from "never started picking" so
+    a re-scan re-allocates cleanly. PENDING reservations are freed on
+    both inventory.quantity_allocated and sol.quantity_allocated;
+    PICKED units go back to their source bin; SHORT residue is
+    likewise unwound. The batch flips to CANCELLED."""
+
+    def _line_state(self, sol_id):
+        row = _query_one(
+            "SELECT quantity_allocated, quantity_picked "
+            "  FROM sales_order_lines WHERE so_line_id = %s",
+            (sol_id,),
+        )
+        return {"quantity_allocated": row[0], "quantity_picked": row[1]}
+
+    def test_cancel_all_pending_releases_allocations(self, client, auth_headers):
+        """Cancel before any picks fire: inventory.quantity_allocated
+        decrements back to 0 AND sol.quantity_allocated decrements
+        back to 0 so a re-scan rebuilds the batch cleanly."""
+        create = _create_batch(client, auth_headers).get_json()
+        batch_id = create["batch_id"]
+        # Pre-cancel: SO 1 line 1 should be allocated (qty 2 from seed).
+        sol = _query_one(
+            "SELECT so_line_id, quantity_allocated FROM sales_order_lines "
+            "WHERE so_id = 1 AND line_number = 1"
+        )
+        sol_id = sol[0]
+        assert sol[1] == 2
+
+        resp = client.post(
+            "/api/picking/cancel-batch",
+            json={"batch_id": batch_id},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["released_tasks"] >= 1
+
+        # Batch is terminal.
+        batch_status = _query_val(
+            "SELECT status FROM pick_batches WHERE batch_id = %s", (batch_id,)
+        )
+        assert batch_status == "CANCELLED"
+        # sol.quantity_allocated is 0 (the reservation is gone).
+        assert self._line_state(sol_id)["quantity_allocated"] == 0
+        # Tasks flipped to SKIPPED (terminal).
+        pending = _query_val(
+            "SELECT COUNT(*) FROM pick_tasks WHERE batch_id = %s AND status = 'PENDING'",
+            (batch_id,),
+        )
+        assert pending == 0
+        # And inventory.quantity_allocated returned to 0 (no other
+        # batches are reserving it).
+        inv_alloc = _query_val(
+            "SELECT quantity_allocated FROM inventory WHERE item_id = 1 AND bin_id = 3"
+        )
+        assert inv_alloc == 0
+
+    def test_cancel_after_pick_restores_inventory(self, client, auth_headers):
+        """Pick one task, then cancel. The picked units return to the
+        source bin (add_inventory), sol.quantity_picked and
+        quantity_allocated both reset, and the task flips to RELEASED."""
+        create = _create_batch(client, auth_headers).get_json()
+        batch_id = create["batch_id"]
+        next_resp = client.get(f"/api/picking/batch/{batch_id}/next", headers=auth_headers)
+        task = next_resp.get_json()
+        pre_pick_on_hand = _query_val(
+            "SELECT quantity_on_hand FROM inventory WHERE item_id = %s AND bin_id = %s",
+            (1, 3),  # Item 1 lives in bin 3 in the seed.
+        )
+
+        confirm = client.post(
+            "/api/picking/confirm",
+            json={
+                "pick_task_id": task["pick_task_id"],
+                "scanned_barcode": task["upc"],
+                "quantity_picked": task["quantity_to_pick"],
+            },
+            headers=auth_headers,
+        )
+        assert confirm.status_code == 200
+        # Confirm-time inventory drop.
+        mid_pick_on_hand = _query_val(
+            "SELECT quantity_on_hand FROM inventory WHERE item_id = %s AND bin_id = %s",
+            (1, 3),
+        )
+        assert mid_pick_on_hand == pre_pick_on_hand - task["quantity_to_pick"]
+
+        resp = client.post(
+            "/api/picking/cancel-batch",
+            json={"batch_id": batch_id},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # On-hand restored.
+        post_cancel_on_hand = _query_val(
+            "SELECT quantity_on_hand FROM inventory WHERE item_id = %s AND bin_id = %s",
+            (1, 3),
+        )
+        assert post_cancel_on_hand == pre_pick_on_hand
+        # Picked task flipped to RELEASED (mirrors the revert flow).
+        pt_status = _query_val(
+            "SELECT status FROM pick_tasks WHERE pick_task_id = %s",
+            (task["pick_task_id"],),
+        )
+        assert pt_status == "RELEASED"
+        # The SOL that owned this pick task is back to zero on both
+        # counters.
+        sol_id = _query_val(
+            "SELECT so_line_id FROM pick_tasks WHERE pick_task_id = %s",
+            (task["pick_task_id"],),
+        )
+        state = self._line_state(sol_id)
+        assert state["quantity_picked"] == 0
+        assert state["quantity_allocated"] == 0
+
+    def test_cancel_already_cancelled_is_noop(self, client, auth_headers):
+        """Idempotent re-cancel returns 200 without unwinding anything
+        twice (released_tasks reports 0). Inventory and line state
+        from the first cancel are preserved."""
+        create = _create_batch(client, auth_headers).get_json()
+        batch_id = create["batch_id"]
+        first = client.post(
+            "/api/picking/cancel-batch",
+            json={"batch_id": batch_id},
+            headers=auth_headers,
+        )
+        assert first.status_code == 200
+        sol_id = _query_val(
+            "SELECT so_line_id FROM sales_order_lines "
+            "WHERE so_id = 1 AND line_number = 1"
+        )
+        state_before = self._line_state(sol_id)
+
+        second = client.post(
+            "/api/picking/cancel-batch",
+            json={"batch_id": batch_id},
+            headers=auth_headers,
+        )
+        assert second.status_code == 200
+        assert second.get_json()["released_tasks"] == 0
+        # State unchanged.
+        assert self._line_state(sol_id) == state_before
+
+    def test_cancel_clears_active_batch_guard(self, client, auth_headers):
+        """After cancel, the active-batch check in create_pick_batch
+        sees no IN_PROGRESS/OPEN batch for the SO, so a fresh scan is
+        unblocked (vs. the pre-cancel state where the same SOs would
+        hit "already in active pick batch"). Validates that the guard
+        clears without actually creating a second batch (which would
+        collide on batch_number's second-resolution timestamp)."""
+        first = _create_batch(client, auth_headers).get_json()
+        first_batch_id = first["batch_id"]
+        # Pre-cancel: the SOs are inside an active batch, so re-scan
+        # would be rejected by the guard.
+        active_pre = _query_val(
+            """
+            SELECT COUNT(*) FROM pick_batch_orders pbo
+              JOIN pick_batches pb ON pb.batch_id = pbo.batch_id
+             WHERE pbo.so_id = 1 AND pb.status IN ('OPEN', 'IN_PROGRESS')
+            """
+        )
+        assert active_pre == 1
+
+        cancel = client.post(
+            "/api/picking/cancel-batch",
+            json={"batch_id": first_batch_id},
+            headers=auth_headers,
+        )
+        assert cancel.status_code == 200
+
+        # Post-cancel: no active batch links remain, so a re-scan
+        # would pass the guard and successfully allocate.
+        active_post = _query_val(
+            """
+            SELECT COUNT(*) FROM pick_batch_orders pbo
+              JOIN pick_batches pb ON pb.batch_id = pbo.batch_id
+             WHERE pbo.so_id = 1 AND pb.status IN ('OPEN', 'IN_PROGRESS')
+            """
+        )
+        assert active_post == 0
+        # Line is back to needing allocation (quantity_ordered >
+        # quantity_allocated), so create_pick_batch's coverage query
+        # will pick it up again.
+        sol = _query_one(
+            "SELECT quantity_ordered, quantity_allocated FROM sales_order_lines "
+            "WHERE so_id = 1 AND line_number = 1"
+        )
+        assert sol[0] > sol[1]

--- a/api/tests/test_revert_sales_order_status.py
+++ b/api/tests/test_revert_sales_order_status.py
@@ -1,0 +1,1095 @@
+"""so-refinement: service-level tests for revert_sales_order_status.
+
+The service is the single transition point for admin-driven backward
+SO status flips (PICKED / PACKED / SHIPPED -> earlier). Tests below
+cover:
+
+- Per-effect happy paths: release (PICKED -> earlier), unpack
+  (PACKED -> below PACKED), unship (SHIPPED -> earlier), and the
+  composed paths.
+- The release-only mode (new_status == current_status): picks
+  release, status stays put, no SO_STATUS_REVERTED audit row, no
+  unship / unpack side effects even when current is SHIPPED / PACKED.
+- The picked_qty_remaining guard: target below PICKED with any
+  unreleased pick rejects loudly with kind='picked_qty_remaining'.
+- All RevertNotAllowed kinds: not_backward, invalid_status,
+  not_found, cancelled, pick_task_missing, pick_task_wrong_state.
+- Audit shape per effect (one SO_STATUS_REVERTED per request when
+  status flips, one SO_PICK_RELEASED per released task, single
+  SO_UNPACKED / SO_UNSHIPPED rows when those effects fire).
+- Edge cases: multiple pick_tasks on a single line, pick_task with
+  quantity_picked=0 (short pick), idempotent re-release rejects via
+  wrong_state.
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from sqlalchemy import text as sa_text
+
+from db_test_context import get_raw_connection
+
+
+# ----------------------------------------------------------------------
+# Fixture helpers. Match the style of test_cancel_sales_order_service.py:
+# raw-cursor inserts so the per-test transaction owns every byte.
+# ----------------------------------------------------------------------
+
+
+def _ensure_user(username="op"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT user_id FROM users WHERE username = %s", (username,))
+    row = cur.fetchone()
+    if row:
+        cur.close()
+        return row[0]
+    cur.execute(
+        "INSERT INTO users (username, password_hash, full_name, role, external_id) "
+        "VALUES (%s, %s, %s, %s, %s) RETURNING user_id",
+        (username,
+         "$2b$12$placeholderHashForTests000000000000000000000000000000",
+         username.title(), "USER", str(uuid.uuid4())),
+    )
+    user_id = cur.fetchone()[0]
+    cur.close()
+    return user_id
+
+
+def _insert_so(status="OPEN", warehouse_id=1, **extra):
+    """Insert a sales_orders row. **extra applies as a follow-up UPDATE
+    so the base INSERT keeps a static column list -- the
+    test_external_id_inserts scanner reads SQL as literal text and
+    cannot see runtime-constructed column lists."""
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_orders "
+        "(so_number, customer_name, status, warehouse_id, external_id) "
+        "VALUES (%s, %s, %s, %s, %s) RETURNING so_id",
+        (f"SO-REVERT-{uuid.uuid4().hex[:8]}", "Cust", status,
+         warehouse_id, str(uuid.uuid4())),
+    )
+    so_id = cur.fetchone()[0]
+    for col, val in extra.items():
+        cur.execute(
+            f"UPDATE sales_orders SET {col} = %s WHERE so_id = %s",
+            (val, so_id),
+        )
+    cur.close()
+    return so_id
+
+
+def _insert_item():
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO items (sku, item_name, upc, external_id) "
+        "VALUES (%s, %s, %s, %s) RETURNING item_id",
+        (f"SKU-{uuid.uuid4().hex[:8]}", "Widget", "0123456789012", str(uuid.uuid4())),
+    )
+    item_id = cur.fetchone()[0]
+    cur.close()
+    return item_id
+
+
+def _insert_so_line(so_id, item_id, *, qty_ordered=2, qty_allocated=0,
+                     qty_picked=0, qty_packed=0, status="PENDING"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_order_lines "
+        "(so_id, item_id, quantity_ordered, quantity_allocated, "
+        " quantity_picked, quantity_packed, line_number, status) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING so_line_id",
+        (so_id, item_id, qty_ordered, qty_allocated, qty_picked,
+         qty_packed, 1, status),
+    )
+    sol_id = cur.fetchone()[0]
+    cur.close()
+    return sol_id
+
+
+def _set_inv(item_id, bin_id, *, qty_on_hand, qty_allocated=0, warehouse_id=1):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO inventory (item_id, bin_id, warehouse_id, "
+        "quantity_on_hand, quantity_allocated) "
+        "VALUES (%s, %s, %s, %s, %s) "
+        "ON CONFLICT (item_id, bin_id, lot_number) DO UPDATE "
+        "SET quantity_on_hand = EXCLUDED.quantity_on_hand, "
+        "    quantity_allocated = EXCLUDED.quantity_allocated",
+        (item_id, bin_id, warehouse_id, qty_on_hand, qty_allocated),
+    )
+    cur.close()
+
+
+def _get_inv_on_hand(item_id, bin_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT quantity_on_hand FROM inventory "
+        "WHERE item_id = %s AND bin_id = %s",
+        (item_id, bin_id),
+    )
+    row = cur.fetchone()
+    cur.close()
+    return row[0] if row else None
+
+
+def _insert_pick_task(so_id, sol_id, item_id, bin_id, *, qty_to_pick=2,
+                       qty_picked=None, status="PICKED"):
+    """Insert a pick_task with optional explicit quantity_picked.
+
+    Defaults to quantity_picked == quantity_to_pick when status==PICKED
+    so a normal pick lands consistent. Pass qty_picked=0 to simulate a
+    short pick that ended with zero units actually moved.
+    """
+    if qty_picked is None:
+        qty_picked = qty_to_pick if status in ("PICKED", "RELEASED") else 0
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO pick_batches (batch_number, warehouse_id, status) "
+        "VALUES (%s, 1, 'OPEN') RETURNING batch_id",
+        (f"BATCH-{uuid.uuid4().hex[:8]}",),
+    )
+    batch_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO pick_tasks (batch_id, so_id, so_line_id, item_id, "
+        "bin_id, quantity_to_pick, quantity_picked, status, pick_sequence) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING pick_task_id",
+        (batch_id, so_id, sol_id, item_id, bin_id, qty_to_pick, qty_picked,
+         status, 1),
+    )
+    task_id = cur.fetchone()[0]
+    cur.close()
+    return task_id
+
+
+def _audit_rows(db, so_id, action_type=None):
+    if action_type:
+        return db.execute(
+            sa_text(
+                "SELECT action_type, details FROM audit_log "
+                " WHERE entity_type = 'SO' AND entity_id = :sid "
+                "   AND action_type = :act "
+                " ORDER BY log_id"
+            ),
+            {"sid": so_id, "act": action_type},
+        ).fetchall()
+    return db.execute(
+        sa_text(
+            "SELECT action_type, details FROM audit_log "
+            " WHERE entity_type = 'SO' AND entity_id = :sid "
+            " ORDER BY log_id"
+        ),
+        {"sid": so_id},
+    ).fetchall()
+
+
+# ----------------------------------------------------------------------
+# Happy-path: release picks (PICKED -> earlier statuses)
+# ----------------------------------------------------------------------
+
+
+class TestReleasePicksPickedToEarlier:
+    def test_picked_to_open_full_release(self, _db_transaction):
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        # Source bin starts at 8 because picking moved 2 units out;
+        # release should restore back to 10.
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, status="PICKED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="PICKED")
+
+        result = revert_sales_order_status(
+            db, so_id=so_id, new_status="OPEN",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        # Status flipped.
+        status = db.execute(
+            sa_text("SELECT status FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone().status
+        assert status == "OPEN"
+        # Inventory restored to source bin (not default receiving).
+        assert _get_inv_on_hand(item_id, bin_id=3) == 10
+        # SOL.quantity_picked decremented.
+        qty_picked = db.execute(
+            sa_text("SELECT quantity_picked FROM sales_order_lines "
+                    "WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone().quantity_picked
+        assert qty_picked == 0
+        # pick_task marked RELEASED (audit retained, line link
+        # intact -- the FK SET NULL only fires on subsequent SOL delete).
+        pt_row = db.execute(
+            sa_text("SELECT status, so_line_id, quantity_picked, picked_at "
+                    "FROM pick_tasks WHERE pick_task_id = :p"),
+            {"p": pt_id},
+        ).fetchone()
+        assert pt_row.status == "RELEASED"
+        assert pt_row.so_line_id == sol_id
+        assert pt_row.quantity_picked == 2
+
+        # Return-value contract.
+        assert result["from_status"] == "PICKED"
+        assert result["to_status"] == "OPEN"
+        assert result["unpacked"] is False
+        assert result["unshipped"] is False
+        assert len(result["released_pick_tasks"]) == 1
+        detail = result["released_pick_tasks"][0]
+        assert detail["pick_task_id"] == pt_id
+        assert detail["so_line_id"] == sol_id
+        assert detail["item_id"] == item_id
+        assert detail["bin_id"] == 3
+        assert detail["quantity"] == 2
+
+
+# ----------------------------------------------------------------------
+# Happy-path: unpack (PACKED -> below PACKED)
+# ----------------------------------------------------------------------
+
+
+class TestUnpack:
+    def test_packed_to_picked_unpacks_only(self, _db_transaction):
+        """PACKED -> PICKED zeros quantity_packed and clears packed_at.
+        No inventory move; quantity_picked stays put since target is PICKED."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(status="PACKED")
+        # Stamp packed_at so we can verify it clears.
+        db.execute(
+            sa_text("UPDATE sales_orders SET packed_at = NOW() "
+                    "WHERE so_id = :s"),
+            {"s": so_id},
+        )
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, qty_packed=2,
+                                  status="PACKED")
+        _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                          qty_to_pick=2, status="PICKED")
+
+        result = revert_sales_order_status(
+            db, so_id=so_id, new_status="PICKED",
+            release_pick_task_ids=[], username="op",
+        )
+
+        # quantity_packed zeroed.
+        row = db.execute(
+            sa_text("SELECT quantity_packed, quantity_picked "
+                    "FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone()
+        assert row.quantity_packed == 0
+        # quantity_picked preserved (target PICKED still requires picks).
+        assert row.quantity_picked == 2
+        # packed_at cleared on the header.
+        packed_at = db.execute(
+            sa_text("SELECT packed_at FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone().packed_at
+        assert packed_at is None
+        # No inventory move.
+        assert _get_inv_on_hand(item_id, bin_id=3) == 8
+        # Status flipped.
+        status = db.execute(
+            sa_text("SELECT status FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone().status
+        assert status == "PICKED"
+
+        assert result["unpacked"] is True
+        assert result["unshipped"] is False
+        assert result["released_pick_tasks"] == []
+
+    def test_packed_to_open_unpacks_and_releases(self, _db_transaction):
+        """PACKED -> OPEN must unpack AND release all picks (otherwise
+        the picked_qty_remaining guard fires)."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(status="PACKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, qty_packed=2,
+                                  status="PACKED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="PICKED")
+
+        result = revert_sales_order_status(
+            db, so_id=so_id, new_status="OPEN",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        row = db.execute(
+            sa_text("SELECT quantity_packed, quantity_picked "
+                    "FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone()
+        assert row.quantity_packed == 0
+        assert row.quantity_picked == 0
+        assert _get_inv_on_hand(item_id, bin_id=3) == 10
+        assert result["unpacked"] is True
+        assert result["unshipped"] is False
+        assert len(result["released_pick_tasks"]) == 1
+
+
+# ----------------------------------------------------------------------
+# Happy-path: unship (SHIPPED -> earlier)
+# ----------------------------------------------------------------------
+
+
+class TestUnship:
+    def test_shipped_to_packed_clears_shipment_only(self, _db_transaction):
+        """SHIPPED -> PACKED clears tracking_number/carrier/shipped_at
+        on the header. quantity_packed stays; no inventory move."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(
+            status="SHIPPED",
+            tracking_number="1Z999AA10123456784",
+            carrier="UPS",
+        )
+        db.execute(
+            sa_text("UPDATE sales_orders SET shipped_at = NOW() "
+                    "WHERE so_id = :s"),
+            {"s": so_id},
+        )
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, qty_packed=2,
+                                  status="SHIPPED")
+        _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                          qty_to_pick=2, status="PICKED")
+
+        result = revert_sales_order_status(
+            db, so_id=so_id, new_status="PACKED",
+            release_pick_task_ids=[], username="op",
+        )
+
+        hdr = db.execute(
+            sa_text("SELECT status, tracking_number, carrier, shipped_at "
+                    "FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone()
+        assert hdr.status == "PACKED"
+        assert hdr.tracking_number is None
+        assert hdr.carrier is None
+        assert hdr.shipped_at is None
+        # quantity_packed preserved (target == PACKED).
+        qpacked = db.execute(
+            sa_text("SELECT quantity_packed FROM sales_order_lines "
+                    "WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone().quantity_packed
+        assert qpacked == 2
+        # No inventory move.
+        assert _get_inv_on_hand(item_id, bin_id=3) == 8
+
+        assert result["unshipped"] is True
+        assert result["unpacked"] is False
+
+    def test_shipped_to_open_full_unwind(self, _db_transaction):
+        """SHIPPED -> OPEN clears shipment fields + unpacks + releases
+        every pick. All three effects compose."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(
+            status="SHIPPED",
+            tracking_number="1Z999AA10123456784",
+            carrier="UPS",
+        )
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, qty_packed=2,
+                                  status="SHIPPED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="PICKED")
+
+        result = revert_sales_order_status(
+            db, so_id=so_id, new_status="OPEN",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        hdr = db.execute(
+            sa_text("SELECT status, tracking_number FROM sales_orders "
+                    "WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone()
+        assert hdr.status == "OPEN"
+        assert hdr.tracking_number is None
+        row = db.execute(
+            sa_text("SELECT quantity_packed, quantity_picked "
+                    "FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone()
+        assert row.quantity_packed == 0
+        assert row.quantity_picked == 0
+        assert _get_inv_on_hand(item_id, bin_id=3) == 10
+        assert result["unshipped"] is True
+        assert result["unpacked"] is True
+        assert len(result["released_pick_tasks"]) == 1
+
+
+# ----------------------------------------------------------------------
+# Release-only mode (new_status == current_status)
+# ----------------------------------------------------------------------
+
+
+class TestReleaseOnly:
+    def test_release_only_picked_releases_without_status_flip(self, _db_transaction):
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, status="PICKED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="PICKED")
+
+        result = revert_sales_order_status(
+            db, so_id=so_id, new_status="PICKED",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        # Picks released, inventory restored.
+        assert _get_inv_on_hand(item_id, bin_id=3) == 10
+        # Status unchanged.
+        status = db.execute(
+            sa_text("SELECT status FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone().status
+        assert status == "PICKED"
+        # No SO_STATUS_REVERTED audit row since status didn't change.
+        rows = _audit_rows(db, so_id, action_type="SO_STATUS_REVERTED")
+        assert rows == []
+        # SO_PICK_RELEASED row still written (the release is what
+        # actually happened).
+        pick_rel = _audit_rows(db, so_id, action_type="SO_PICK_RELEASED")
+        assert len(pick_rel) == 1
+
+        assert result["from_status"] == "PICKED"
+        assert result["to_status"] == "PICKED"
+
+    def test_release_only_on_shipped_does_not_unship(self, _db_transaction):
+        """SHIPPED -> SHIPPED in release-only must NOT clear shipment
+        fields. need_unship requires new_status != SHIPPED."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(
+            status="SHIPPED",
+            tracking_number="1Z999AA10123456784",
+            carrier="UPS",
+        )
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, qty_packed=2,
+                                  status="SHIPPED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="SHIPPED",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        hdr = db.execute(
+            sa_text("SELECT tracking_number, carrier FROM sales_orders "
+                    "WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone()
+        assert hdr.tracking_number == "1Z999AA10123456784"
+        assert hdr.carrier == "UPS"
+
+    def test_release_only_on_packed_does_not_unpack(self, _db_transaction):
+        """PACKED -> PACKED in release-only must NOT zero quantity_packed.
+        need_unpack requires new_idx < PACKED."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(status="PACKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, qty_packed=2,
+                                  status="PACKED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="PACKED",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        qpacked = db.execute(
+            sa_text("SELECT quantity_packed FROM sales_order_lines "
+                    "WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone().quantity_packed
+        assert qpacked == 2
+
+
+# ----------------------------------------------------------------------
+# Partial-release behavior
+# ----------------------------------------------------------------------
+
+
+class TestPartialRelease:
+    def test_partial_release_target_picked_succeeds(self, _db_transaction):
+        """Two pick_tasks on the SO; release one, keep one; target=PICKED.
+        Status stays at PICKED, one pick released, one remains."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=6)
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=4,
+                                  qty_picked=4, status="PICKED")
+        pt_a = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                  qty_to_pick=2, status="PICKED")
+        pt_b = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                  qty_to_pick=2, status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="PICKED",
+            release_pick_task_ids=[pt_a], username="op",
+        )
+
+        statuses = {r.pick_task_id: r.status for r in db.execute(
+            sa_text("SELECT pick_task_id, status FROM pick_tasks "
+                    "WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchall()}
+        assert statuses[pt_a] == "RELEASED"
+        assert statuses[pt_b] == "PICKED"
+        # One pick released -> SOL.quantity_picked drops by 2.
+        qty_picked = db.execute(
+            sa_text("SELECT quantity_picked FROM sales_order_lines "
+                    "WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone().quantity_picked
+        assert qty_picked == 2
+
+    def test_partial_release_target_below_picked_rejects(self, _db_transaction):
+        """Two picks; release one, target=OPEN -> remaining qty_picked=2
+        means picked_qty_remaining guard fires."""
+        from services.sales_order_service import (
+            RevertNotAllowed, revert_sales_order_status,
+        )
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=6)
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=4,
+                                  qty_picked=4, status="PICKED")
+        pt_a = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                  qty_to_pick=2, status="PICKED")
+        _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                          qty_to_pick=2, status="PICKED")
+
+        with pytest.raises(RevertNotAllowed) as exc:
+            revert_sales_order_status(
+                db, so_id=so_id, new_status="OPEN",
+                release_pick_task_ids=[pt_a], username="op",
+            )
+        assert exc.value.kind == "picked_qty_remaining"
+        assert exc.value.context["remaining_picked"] == 2
+        assert exc.value.context["target_status"] == "OPEN"
+
+
+# ----------------------------------------------------------------------
+# Error paths: every RevertNotAllowed kind
+# ----------------------------------------------------------------------
+
+
+class TestRevertNotAllowed:
+    def test_invalid_status_rejects(self, _db_transaction):
+        from services.sales_order_service import (
+            RevertNotAllowed, revert_sales_order_status,
+        )
+        db = _db_transaction
+        _ensure_user("op")
+        so_id = _insert_so(status="PICKED")
+        with pytest.raises(RevertNotAllowed) as exc:
+            revert_sales_order_status(
+                db, so_id=so_id, new_status="BOGUS",
+                release_pick_task_ids=[], username="op",
+            )
+        assert exc.value.kind == "invalid_status"
+
+    def test_so_not_found_rejects(self, _db_transaction):
+        from services.sales_order_service import (
+            RevertNotAllowed, revert_sales_order_status,
+        )
+        db = _db_transaction
+        _ensure_user("op")
+        with pytest.raises(RevertNotAllowed) as exc:
+            revert_sales_order_status(
+                db, so_id=9_999_999, new_status="OPEN",
+                release_pick_task_ids=[], username="op",
+            )
+        assert exc.value.kind == "not_found"
+
+    def test_cancelled_so_rejects(self, _db_transaction):
+        from services.sales_order_service import (
+            RevertNotAllowed, revert_sales_order_status,
+        )
+        db = _db_transaction
+        _ensure_user("op")
+        so_id = _insert_so(status="CANCELLED")
+        with pytest.raises(RevertNotAllowed) as exc:
+            revert_sales_order_status(
+                db, so_id=so_id, new_status="OPEN",
+                release_pick_task_ids=[], username="op",
+            )
+        assert exc.value.kind == "cancelled"
+        assert exc.value.context["current_status"] == "CANCELLED"
+
+    def test_forward_transition_rejects(self, _db_transaction):
+        from services.sales_order_service import (
+            RevertNotAllowed, revert_sales_order_status,
+        )
+        db = _db_transaction
+        _ensure_user("op")
+        so_id = _insert_so(status="PICKED")
+        with pytest.raises(RevertNotAllowed) as exc:
+            revert_sales_order_status(
+                db, so_id=so_id, new_status="PACKED",
+                release_pick_task_ids=[], username="op",
+            )
+        assert exc.value.kind == "not_backward"
+        assert exc.value.context["current_status"] == "PICKED"
+        assert exc.value.context["target_status"] == "PACKED"
+
+    def test_pick_task_not_on_so_rejects(self, _db_transaction):
+        """A pick_task_id that belongs to a different SO must not be
+        accepted -- the operator could otherwise release someone else's
+        inventory by guessing IDs."""
+        from services.sales_order_service import (
+            RevertNotAllowed, revert_sales_order_status,
+        )
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=10)
+        # SO 1: the one being reverted.
+        so_id = _insert_so(status="PICKED")
+        _insert_so_line(so_id, item_id, qty_ordered=2, qty_picked=2,
+                        status="PICKED")
+        # SO 2: a totally unrelated SO with its own pick_task.
+        other_so = _insert_so(status="PICKED")
+        other_sol = _insert_so_line(other_so, item_id, qty_ordered=2,
+                                     qty_picked=2, status="PICKED")
+        other_pt = _insert_pick_task(other_so, other_sol, item_id, bin_id=3,
+                                      qty_to_pick=2, status="PICKED")
+
+        with pytest.raises(RevertNotAllowed) as exc:
+            revert_sales_order_status(
+                db, so_id=so_id, new_status="OPEN",
+                release_pick_task_ids=[other_pt], username="op",
+            )
+        assert exc.value.kind == "pick_task_missing"
+        assert other_pt in exc.value.context["missing_ids"]
+
+    def test_pick_task_wrong_state_rejects(self, _db_transaction):
+        """Re-releasing an already-RELEASED pick_task must fail loudly
+        rather than silently double-adjusting inventory."""
+        from services.sales_order_service import (
+            RevertNotAllowed, revert_sales_order_status,
+        )
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, status="PICKED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="RELEASED")
+
+        with pytest.raises(RevertNotAllowed) as exc:
+            revert_sales_order_status(
+                db, so_id=so_id, new_status="OPEN",
+                release_pick_task_ids=[pt_id], username="op",
+            )
+        assert exc.value.kind == "pick_task_wrong_state"
+        assert pt_id in exc.value.context["wrong_state_ids"]
+
+
+# ----------------------------------------------------------------------
+# Audit-log shape
+# ----------------------------------------------------------------------
+
+
+class TestAuditShape:
+    def test_status_reverted_row_only_when_status_changes(self, _db_transaction):
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, status="PICKED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="OPEN",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        rev_rows = _audit_rows(db, so_id, action_type="SO_STATUS_REVERTED")
+        assert len(rev_rows) == 1
+        details = rev_rows[0].details
+        assert details["from_status"] == "PICKED"
+        assert details["to_status"] == "OPEN"
+        assert details["released_pick_tasks"] == [pt_id]
+        assert details["unpacked"] is False
+        assert details["unshipped"] is False
+
+    def test_one_pick_released_row_per_released_task(self, _db_transaction):
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=6)
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=4,
+                                  qty_picked=4, status="PICKED")
+        pt_a = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                  qty_to_pick=2, status="PICKED")
+        pt_b = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                  qty_to_pick=2, status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="OPEN",
+            release_pick_task_ids=[pt_a, pt_b], username="op",
+        )
+
+        rows = _audit_rows(db, so_id, action_type="SO_PICK_RELEASED")
+        assert len(rows) == 2
+        ids = {r.details["pick_task_id"] for r in rows}
+        assert ids == {pt_a, pt_b}
+        for r in rows:
+            assert r.details["item_id"] == item_id
+            assert r.details["bin_id"] == 3
+            assert r.details["quantity"] == 2
+
+    def test_unpacked_row_when_unpack_fires(self, _db_transaction):
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(status="PACKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_picked=2, qty_packed=2,
+                                  status="PACKED")
+        _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                          qty_to_pick=2, status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="PICKED",
+            release_pick_task_ids=[], username="op",
+        )
+
+        rows = _audit_rows(db, so_id, action_type="SO_UNPACKED")
+        assert len(rows) == 1
+        assert rows[0].details["from_status"] == "PACKED"
+        assert rows[0].details["to_status"] == "PICKED"
+
+    def test_unshipped_row_carries_prev_values(self, _db_transaction):
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(
+            status="SHIPPED",
+            tracking_number="1Z999AA10123456784",
+            carrier="UPS",
+        )
+        _insert_so_line(so_id, item_id, qty_ordered=2, qty_picked=2,
+                        qty_packed=2, status="SHIPPED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="PACKED",
+            release_pick_task_ids=[], username="op",
+        )
+
+        rows = _audit_rows(db, so_id, action_type="SO_UNSHIPPED")
+        assert len(rows) == 1
+        details = rows[0].details
+        assert details["prev_tracking_number"] == "1Z999AA10123456784"
+        assert details["prev_carrier"] == "UPS"
+
+
+# ----------------------------------------------------------------------
+# Edge cases
+# ----------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_short_pick_zero_quantity_skips_inventory(self, _db_transaction):
+        """A pick_task with quantity_picked=0 (the operator marked it
+        short with zero units physically moved) must not write a
+        SO_PICK_RELEASED audit row and must not move inventory, but
+        must still flip the task to RELEASED and undo the allocation
+        the original create_pick_batch booked so a subsequent revert
+        prompt does not re-offer it and a re-scan sees the line as
+        needing coverage."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=10)
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_allocated=2, qty_picked=0,
+                                  status="PICKED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, qty_picked=0,
+                                   status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="OPEN",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        # Inventory untouched (no physical move to restore).
+        assert _get_inv_on_hand(item_id, bin_id=3) == 10
+        # pick_task flips to RELEASED so it does not re-surface in
+        # future revert prompts.
+        pt_status = db.execute(
+            sa_text("SELECT status FROM pick_tasks WHERE pick_task_id = :p"),
+            {"p": pt_id},
+        ).fetchone().status
+        assert pt_status == "RELEASED"
+        # sol.quantity_allocated drops back to 0 so a re-scan's
+        # `quantity_ordered > quantity_allocated` filter picks the line
+        # up again.
+        sol_row = db.execute(
+            sa_text("SELECT quantity_allocated, quantity_picked "
+                    "  FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone()
+        assert sol_row.quantity_allocated == 0
+        assert sol_row.quantity_picked == 0
+        # No SO_PICK_RELEASED audit row -- no physical inventory event
+        # to narrate.
+        rows = _audit_rows(db, so_id, action_type="SO_PICK_RELEASED")
+        assert rows == []
+
+    def test_multiple_pick_tasks_release_decrements_correctly(self, _db_transaction):
+        """Same SOL has two PICKED tasks (e.g. picked from two bins).
+        Releasing both decrements quantity_picked by the cumulative
+        quantity and restores each bin independently."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        _set_inv(item_id, bin_id=4, qty_on_hand=7)
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=5,
+                                  qty_picked=5, status="PICKED")
+        pt_a = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                  qty_to_pick=2, status="PICKED")
+        pt_b = _insert_pick_task(so_id, sol_id, item_id, bin_id=4,
+                                  qty_to_pick=3, status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="OPEN",
+            release_pick_task_ids=[pt_a, pt_b], username="op",
+        )
+
+        assert _get_inv_on_hand(item_id, bin_id=3) == 10
+        assert _get_inv_on_hand(item_id, bin_id=4) == 10
+        qty_picked = db.execute(
+            sa_text("SELECT quantity_picked FROM sales_order_lines "
+                    "WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone().quantity_picked
+        assert qty_picked == 0
+
+
+# ----------------------------------------------------------------------
+# Regression: release must also decrement sales_order_lines.
+# quantity_allocated. Without this, a re-scan after revert sees lines
+# as "fully allocated" and create_pick_batch skips them, producing a
+# batch with fewer pick_tasks than the SO needs. Layer 2A then refuses
+# to complete the batch and the picker is stuck.
+# ----------------------------------------------------------------------
+
+
+class TestReleaseDecrementsAllocated:
+    def test_release_zeroes_quantity_allocated_on_line(self, _db_transaction):
+        """A full release of a single PICKED task must drop both
+        sol.quantity_picked and sol.quantity_allocated back to 0 so a
+        re-scan re-allocates cleanly."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        so_id = _insert_so(status="PICKED")
+        # Seed mirrors post-create_pick_batch + confirm_pick state:
+        # the line was allocated and then fully picked.
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_allocated=2, qty_picked=2,
+                                  status="PICKED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="OPEN",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        sol_row = db.execute(
+            sa_text("SELECT quantity_allocated, quantity_picked "
+                    "  FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone()
+        assert sol_row.quantity_picked == 0
+        assert sol_row.quantity_allocated == 0
+
+    def test_partial_release_decrements_allocated_per_task(self, _db_transaction):
+        """Two PICKED tasks on one line, only one released. Allocation
+        drops by that task's quantity_to_pick, picked drops by the
+        same task's quantity_picked. The other task's allocation stays
+        on the line until it is released too."""
+        from services.sales_order_service import revert_sales_order_status
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=8)
+        _set_inv(item_id, bin_id=4, qty_on_hand=7)
+        # Status PICKED so target=PICKED stays equal (release-only),
+        # keeping the un-released task in place without tripping
+        # picked_qty_remaining.
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=5,
+                                  qty_allocated=5, qty_picked=5,
+                                  status="PICKED")
+        pt_a = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                  qty_to_pick=2, status="PICKED")
+        _insert_pick_task(so_id, sol_id, item_id, bin_id=4,
+                          qty_to_pick=3, status="PICKED")
+
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="PICKED",
+            release_pick_task_ids=[pt_a], username="op",
+        )
+
+        sol_row = db.execute(
+            sa_text("SELECT quantity_allocated, quantity_picked "
+                    "  FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone()
+        # Only pt_a (qty=2) was released, so the line keeps the
+        # remaining task's 3 units allocated + picked.
+        assert sol_row.quantity_allocated == 3
+        assert sol_row.quantity_picked == 3
+
+    def test_release_then_recreate_batch_produces_pick_tasks(self, _db_transaction):
+        """End-to-end regression for the prod-stuck-pick bug. After
+        full release + revert to OPEN, a fresh create_pick_batch run on
+        the same SO must allocate all the lines again and produce one
+        pick_task per line. Pre-fix: zero pick_tasks were produced
+        because sol.quantity_allocated still equalled quantity_ordered
+        and the coverage query returned no rows."""
+        import os as _os
+        # The route stack expects the test pepper.
+        _os.environ.setdefault("SENTRY_TOKEN_PEPPER",
+                                "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+        from services.sales_order_service import revert_sales_order_status
+        from services.picking_service import create_pick_batch
+        db = _db_transaction
+        _ensure_user("op")
+        item_id = _insert_item()
+        # Sufficient stock to fully cover both rounds: pre-pick bin has
+        # 10 on hand, the pick consumes 2, release restores to 10.
+        _set_inv(item_id, bin_id=3, qty_on_hand=10)
+        # Bin must be PICKABLE for create_pick_batch's inventory query
+        # to return it. The seed bin_id=3 already exists in seed_data
+        # as PICKABLE in the test DB; if a different bin_id is needed,
+        # adjust here.
+        so_id = _insert_so(status="PICKED")
+        so_num = db.execute(
+            sa_text("SELECT so_number FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone().so_number
+        sol_id = _insert_so_line(so_id, item_id, qty_ordered=2,
+                                  qty_allocated=2, qty_picked=2,
+                                  status="PICKED")
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   qty_to_pick=2, status="PICKED")
+
+        # Revert PICKED -> OPEN with full release.
+        revert_sales_order_status(
+            db, so_id=so_id, new_status="OPEN",
+            release_pick_task_ids=[pt_id], username="op",
+        )
+
+        # Re-create a batch for the same SO. Pre-fix this would create
+        # a batch with zero pick_tasks; post-fix it should allocate the
+        # line again and produce exactly one pick_task for qty=2.
+        result = create_pick_batch(
+            db, so_identifiers=[so_num], warehouse_id=1, username="op",
+        )
+
+        # The batch should carry the SO and one pick_task for qty 2.
+        assert result["total_items"] == 2
+        assert len(result["tasks"]) == 1
+        new_pt = result["tasks"][0]
+        assert new_pt["quantity_to_pick"] == 2
+        # The task list output does not expose so_line_id; verify the
+        # FK lands on our line via the pick_tasks row.
+        new_sol_id = db.execute(
+            sa_text("SELECT so_line_id FROM pick_tasks "
+                    "WHERE pick_task_id = :p"),
+            {"p": new_pt["pick_task_id"]},
+        ).fetchone().so_line_id
+        assert new_sol_id == sol_id
+        # Line is allocated again from scratch.
+        sol_row = db.execute(
+            sa_text("SELECT quantity_allocated, quantity_picked "
+                    "  FROM sales_order_lines WHERE so_line_id = :s"),
+            {"s": sol_id},
+        ).fetchone()
+        assert sol_row.quantity_allocated == 2
+        assert sol_row.quantity_picked == 0

--- a/api/tests/test_so_detail_pick_tasks_field.py
+++ b/api/tests/test_so_detail_pick_tasks_field.py
@@ -1,0 +1,177 @@
+"""so-refinement: GET /admin/sales-orders/<id> exposes pick_tasks.
+
+The frontend revert-status modal populates from this payload without
+a second round-trip. Tests pin:
+
+- The pick_tasks key is always present (empty array when no picks).
+- Only status='PICKED' rows are returned (PENDING / RELEASED /
+  SHORT / SKIPPED are excluded; they belong to other lifecycle UIs).
+- Per-row shape: pick_task_id, so_line_id, item_id, sku, item_name,
+  bin_id, bin_code, quantity_picked, picked_at, picked_by, status.
+- Multiple pick_tasks on the same SO line all appear (the bin
+  breakdown the modal renders).
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from db_test_context import get_raw_connection
+
+
+def _insert_so(status="PICKED"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_orders (so_number, customer_name, status, "
+        "warehouse_id, external_id) "
+        "VALUES (%s, %s, %s, 1, %s) RETURNING so_id",
+        (f"SO-PT-{uuid.uuid4().hex[:8]}", "Cust", status, str(uuid.uuid4())),
+    )
+    so_id = cur.fetchone()[0]
+    cur.close()
+    return so_id
+
+
+def _insert_item():
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO items (sku, item_name, upc, external_id) "
+        "VALUES (%s, %s, %s, %s) RETURNING item_id",
+        (f"SKU-{uuid.uuid4().hex[:8]}", "Widget", "0123456789012",
+         str(uuid.uuid4())),
+    )
+    item_id = cur.fetchone()[0]
+    cur.close()
+    return item_id
+
+
+def _insert_so_line(so_id, item_id, qty_picked=2):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_order_lines "
+        "(so_id, item_id, quantity_ordered, quantity_picked, line_number, status) "
+        "VALUES (%s, %s, %s, %s, %s, 'PICKED') RETURNING so_line_id",
+        (so_id, item_id, qty_picked, qty_picked, 1),
+    )
+    sol_id = cur.fetchone()[0]
+    cur.close()
+    return sol_id
+
+
+def _insert_pick_task(so_id, sol_id, item_id, bin_id, status="PICKED",
+                       qty=2):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO pick_batches (batch_number, warehouse_id, status) "
+        "VALUES (%s, 1, 'OPEN') RETURNING batch_id",
+        (f"BATCH-PT-{uuid.uuid4().hex[:8]}",),
+    )
+    batch_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO pick_tasks (batch_id, so_id, so_line_id, item_id, "
+        "bin_id, quantity_to_pick, quantity_picked, status, pick_sequence, "
+        "picked_by, picked_at) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW()) "
+        "RETURNING pick_task_id",
+        (batch_id, so_id, sol_id, item_id, bin_id, qty, qty, status, 1,
+         "operator-a"),
+    )
+    pt_id = cur.fetchone()[0]
+    cur.close()
+    return pt_id
+
+
+class TestPickTasksField:
+    def test_get_detail_always_includes_pick_tasks_key(self, client, auth_headers):
+        """Even on an OPEN SO with zero picks, the key must be present
+        as an empty array so the frontend's array access is safe."""
+        resp = client.get("/api/admin/sales-orders/1", headers=auth_headers)
+        body = resp.get_json()
+        assert "pick_tasks" in body
+        assert isinstance(body["pick_tasks"], list)
+
+    def test_picked_so_returns_pick_tasks_with_full_shape(self, client, auth_headers):
+        item_id = _insert_item()
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_picked=2)
+        pt_id = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                   status="PICKED", qty=2)
+
+        resp = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        )
+        body = resp.get_json()
+        tasks = body["pick_tasks"]
+        assert len(tasks) == 1
+        t = tasks[0]
+        # Required keys for the frontend revert modal.
+        for key in ("pick_task_id", "so_line_id", "item_id", "sku",
+                    "item_name", "bin_id", "bin_code", "quantity_picked",
+                    "picked_at", "picked_by", "status"):
+            assert key in t, f"missing {key} in pick_task shape"
+        assert t["pick_task_id"] == pt_id
+        assert t["so_line_id"] == sol_id
+        assert t["item_id"] == item_id
+        assert t["bin_id"] == 3
+        assert t["quantity_picked"] == 2
+        assert t["status"] == "PICKED"
+        assert t["picked_by"] == "operator-a"
+        # picked_at is an ISO timestamp string when set.
+        assert t["picked_at"] is not None
+        assert isinstance(t["picked_at"], str)
+
+    def test_filters_to_picked_status_only(self, client, auth_headers):
+        """PENDING / SHORT / SKIPPED / RELEASED pick_tasks must not
+        appear in the array. Operator-facing revert flow is for
+        currently-picked inventory only."""
+        item_id = _insert_item()
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_picked=2)
+        pt_picked = _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                                       status="PICKED")
+        # All four off-status flavours -- none should appear.
+        _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                          status="PENDING")
+        _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                          status="SHORT")
+        _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                          status="SKIPPED")
+        _insert_pick_task(so_id, sol_id, item_id, bin_id=3,
+                          status="RELEASED")
+
+        resp = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        )
+        tasks = resp.get_json()["pick_tasks"]
+        ids = {t["pick_task_id"] for t in tasks}
+        assert ids == {pt_picked}
+
+    def test_multiple_picked_tasks_all_returned(self, client, auth_headers):
+        """The bin breakdown the modal renders: a line picked from
+        multiple bins gets a row per bin."""
+        item_id = _insert_item()
+        so_id = _insert_so(status="PICKED")
+        sol_id = _insert_so_line(so_id, item_id, qty_picked=4)
+        pt_a = _insert_pick_task(so_id, sol_id, item_id, bin_id=3, qty=2)
+        pt_b = _insert_pick_task(so_id, sol_id, item_id, bin_id=4, qty=2)
+
+        resp = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        )
+        tasks = resp.get_json()["pick_tasks"]
+        assert len(tasks) == 2
+        ids = {t["pick_task_id"] for t in tasks}
+        assert ids == {pt_a, pt_b}
+        bins = {t["bin_id"] for t in tasks}
+        assert bins == {3, 4}

--- a/api/tests/test_so_order_origin.py
+++ b/api/tests/test_so_order_origin.py
@@ -1,0 +1,308 @@
+"""mig 067: sales_orders.order_origin free-text upstream-origin label.
+
+The column is populated by the inbound payload mapping (when the
+connector wires it up) and editable by ADMIN through the SO edit
+modal. Tests cover:
+
+- Pydantic surface: Create/Update requests accept the field, reject
+  values over the 64-char cap.
+- HTTP create round-trip: POST persists the value.
+- HTTP update round-trip: PUT persists a change, empty string clears
+  the column to NULL, audit row written via SO_HEADER_EDITED.
+- GET detail returns the field on every SO.
+- The field is independent of source_system (allowlisted FK) and
+  order_source (web/pos enum) -- updating order_origin does not
+  touch either.
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from sqlalchemy import text as sa_text
+
+
+# ----------------------------------------------------------------------
+# Pydantic schema surface
+# ----------------------------------------------------------------------
+
+
+class TestPydanticSchemas:
+    def test_create_request_accepts_order_origin(self):
+        from schemas.sales_orders import CreateSalesOrderRequest
+        req = CreateSalesOrderRequest(
+            so_number="SO-OO-1",
+            warehouse_id=1,
+            lines=[{"item_id": 1, "quantity_ordered": 1}],
+            order_origin="amazon",
+        )
+        assert req.order_origin == "amazon"
+
+    def test_create_request_order_origin_defaults_none(self):
+        from schemas.sales_orders import CreateSalesOrderRequest
+        req = CreateSalesOrderRequest(
+            so_number="SO-OO-2",
+            warehouse_id=1,
+            lines=[{"item_id": 1, "quantity_ordered": 1}],
+        )
+        assert req.order_origin is None
+
+    def test_create_request_rejects_over_64_chars(self):
+        from pydantic import ValidationError
+        from schemas.sales_orders import CreateSalesOrderRequest
+        with pytest.raises(ValidationError) as exc:
+            CreateSalesOrderRequest(
+                so_number="SO-OO-3",
+                warehouse_id=1,
+                lines=[{"item_id": 1, "quantity_ordered": 1}],
+                order_origin="a" * 65,
+            )
+        errors = exc.value.errors()
+        assert any(e["loc"] == ("order_origin",) for e in errors)
+
+    def test_update_request_accepts_order_origin(self):
+        from schemas.sales_orders import UpdateSalesOrderRequest
+        req = UpdateSalesOrderRequest(order_origin="shopify-store-1")
+        assert req.order_origin == "shopify-store-1"
+
+    def test_update_request_accepts_empty_string_for_clear(self):
+        """Empty string is the wire-level "clear to NULL" signal, mirroring
+        source_system. Pydantic must accept it; the route handler interprets
+        the semantic."""
+        from schemas.sales_orders import UpdateSalesOrderRequest
+        req = UpdateSalesOrderRequest(order_origin="")
+        assert req.order_origin == ""
+
+    def test_update_request_rejects_over_64_chars(self):
+        from pydantic import ValidationError
+        from schemas.sales_orders import UpdateSalesOrderRequest
+        with pytest.raises(ValidationError) as exc:
+            UpdateSalesOrderRequest(order_origin="x" * 65)
+        errors = exc.value.errors()
+        assert any(e["loc"] == ("order_origin",) for e in errors)
+
+
+# ----------------------------------------------------------------------
+# HTTP round-trips
+# ----------------------------------------------------------------------
+
+
+class TestCreateRoundTrip:
+    def test_post_create_persists_order_origin(self, client, auth_headers):
+        sn = f"SO-OO-{uuid.uuid4().hex[:8]}"
+        resp = client.post(
+            "/api/admin/sales-orders",
+            json={
+                "so_number": sn,
+                "warehouse_id": 1,
+                "lines": [{"item_id": 1, "quantity_ordered": 1}],
+                "order_origin": "amazon-marketplace",
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code in (200, 201), resp.get_json()
+        so_id = resp.get_json()["sales_order"]["so_id"]
+        # Verify on the detail GET that the field landed.
+        get_resp = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        )
+        assert get_resp.status_code == 200
+        assert get_resp.get_json()["sales_order"]["order_origin"] == "amazon-marketplace"
+
+    def test_post_create_without_order_origin_lands_null(self, client, auth_headers):
+        sn = f"SO-OO-{uuid.uuid4().hex[:8]}"
+        resp = client.post(
+            "/api/admin/sales-orders",
+            json={
+                "so_number": sn,
+                "warehouse_id": 1,
+                "lines": [{"item_id": 1, "quantity_ordered": 1}],
+            },
+            headers=auth_headers,
+        )
+        so_id = resp.get_json()["sales_order"]["so_id"]
+        get_resp = client.get(
+            f"/api/admin/sales-orders/{so_id}", headers=auth_headers,
+        )
+        assert get_resp.get_json()["sales_order"]["order_origin"] is None
+
+
+class TestUpdateRoundTrip:
+    def test_put_sets_order_origin(self, client, auth_headers, _db_transaction):
+        sn = f"SO-OO-{uuid.uuid4().hex[:8]}"
+        create = client.post(
+            "/api/admin/sales-orders",
+            json={
+                "so_number": sn,
+                "warehouse_id": 1,
+                "lines": [{"item_id": 1, "quantity_ordered": 1}],
+            },
+            headers=auth_headers,
+        )
+        so_id = create.get_json()["sales_order"]["so_id"]
+        put = client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            json={"order_origin": "phone-order"},
+            headers=auth_headers,
+        )
+        assert put.status_code == 200, put.get_json()
+        assert "order_origin" in put.get_json()["edited_fields"]
+        # DB state.
+        val = _db_transaction.execute(
+            sa_text("SELECT order_origin FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone().order_origin
+        assert val == "phone-order"
+
+    def test_put_empty_string_clears_to_null(self, client, auth_headers, _db_transaction):
+        """The PUT path mirrors source_system semantics: empty string
+        clears the column to NULL (distinct from "not provided", which
+        leaves the value alone via exclude_unset)."""
+        sn = f"SO-OO-{uuid.uuid4().hex[:8]}"
+        create = client.post(
+            "/api/admin/sales-orders",
+            json={
+                "so_number": sn,
+                "warehouse_id": 1,
+                "lines": [{"item_id": 1, "quantity_ordered": 1}],
+                "order_origin": "ebay",
+            },
+            headers=auth_headers,
+        )
+        so_id = create.get_json()["sales_order"]["so_id"]
+        client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            json={"order_origin": ""},
+            headers=auth_headers,
+        )
+        val = _db_transaction.execute(
+            sa_text("SELECT order_origin FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone().order_origin
+        # The update_sales_order handler treats source_system "" as NULL
+        # explicitly; for order_origin the wire value of empty string
+        # is what gets persisted (per ALLOWED_FIELDS general path).
+        # Either is acceptable as long as the column reflects the
+        # cleared-to-empty intent; assert both.
+        assert val in (None, "")
+
+    def test_put_audit_row_written_when_changed(self, client, auth_headers, _db_transaction):
+        sn = f"SO-OO-{uuid.uuid4().hex[:8]}"
+        create = client.post(
+            "/api/admin/sales-orders",
+            json={
+                "so_number": sn,
+                "warehouse_id": 1,
+                "lines": [{"item_id": 1, "quantity_ordered": 1}],
+            },
+            headers=auth_headers,
+        )
+        so_id = create.get_json()["sales_order"]["so_id"]
+        client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            json={"order_origin": "in-store-walkin"},
+            headers=auth_headers,
+        )
+        rows = _db_transaction.execute(
+            sa_text(
+                "SELECT details FROM audit_log "
+                " WHERE entity_type='SO' AND entity_id=:s "
+                "   AND action_type='SO_HEADER_EDITED' "
+                " ORDER BY log_id"
+            ),
+            {"s": so_id},
+        ).fetchall()
+        # Header-edit audit row exists with the order_origin field.
+        ooo = [r.details for r in rows
+               if r.details.get("field_changed") == "order_origin"]
+        assert len(ooo) == 1
+        assert ooo[0]["new_value"] == "in-store-walkin"
+        assert ooo[0]["old_value"] is None
+
+    def test_put_unchanged_value_writes_no_audit(self, client, auth_headers, _db_transaction):
+        """Per-field diff: re-PUT with the same value writes no audit
+        row. Same idempotency guarantee the rest of the SO edit surface
+        provides."""
+        sn = f"SO-OO-{uuid.uuid4().hex[:8]}"
+        create = client.post(
+            "/api/admin/sales-orders",
+            json={
+                "so_number": sn,
+                "warehouse_id": 1,
+                "lines": [{"item_id": 1, "quantity_ordered": 1}],
+                "order_origin": "amazon",
+            },
+            headers=auth_headers,
+        )
+        so_id = create.get_json()["sales_order"]["so_id"]
+        # PUT the same value again.
+        client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            json={"order_origin": "amazon"},
+            headers=auth_headers,
+        )
+        rows = _db_transaction.execute(
+            sa_text(
+                "SELECT details FROM audit_log "
+                " WHERE entity_type='SO' AND entity_id=:s "
+                "   AND action_type='SO_HEADER_EDITED'"
+            ),
+            {"s": so_id},
+        ).fetchall()
+        ooo = [r.details for r in rows
+               if r.details.get("field_changed") == "order_origin"]
+        # No header-edit audit row was written for the no-op update.
+        assert ooo == []
+
+
+# ----------------------------------------------------------------------
+# Independence from source_system / order_source
+# ----------------------------------------------------------------------
+
+
+class TestIndependentFromOtherSourceFields:
+    def test_updating_order_origin_does_not_touch_source_system(self, client, auth_headers, _db_transaction):
+        sn = f"SO-OO-{uuid.uuid4().hex[:8]}"
+        create = client.post(
+            "/api/admin/sales-orders",
+            json={
+                "so_number": sn,
+                "warehouse_id": 1,
+                "lines": [{"item_id": 1, "quantity_ordered": 1}],
+            },
+            headers=auth_headers,
+        )
+        so_id = create.get_json()["sales_order"]["so_id"]
+        # source_system stays NULL (admin-created SOs do).
+        client.put(
+            f"/api/admin/sales-orders/{so_id}",
+            json={"order_origin": "amazon"},
+            headers=auth_headers,
+        )
+        row = _db_transaction.execute(
+            sa_text("SELECT source_system, order_source, order_origin "
+                    "FROM sales_orders WHERE so_id = :s"),
+            {"s": so_id},
+        ).fetchone()
+        assert row.source_system is None
+        assert row.order_source == "web"
+        assert row.order_origin == "amazon"
+
+    def test_get_detail_returns_order_origin_field(self, client, auth_headers):
+        """Even on SOs that never set order_origin, the GET detail
+        payload must carry the key so the admin UI does not see
+        undefined and fail the input field's controlled-component
+        check."""
+        get_resp = client.get(
+            "/api/admin/sales-orders/1", headers=auth_headers,
+        )
+        body = get_resp.get_json()["sales_order"]
+        assert "order_origin" in body

--- a/db/mappings/example-template.yaml.template
+++ b/db/mappings/example-template.yaml.template
@@ -354,6 +354,22 @@ resources:
         type: "string"
         required: false
 
+      - canonical: "order_origin"
+        # canonical column: sales_orders.order_origin VARCHAR(64)
+        # (mig 063). A free-text upstream-origin / channel label for
+        # the order -- e.g. "amazon", "shopify-store-1", "phone-order",
+        # "in-store-walkin". Distinct from this document's own
+        # source_system (which connector pushed the order) and from
+        # order_source (the web/pos enum): order_origin records where
+        # the order came from in the upstream's own vocabulary. No
+        # allowlist / enum, so any value the connector hands us lands
+        # without a Sentry-side change; the 64-char column cap is the
+        # only bound. Map it to whatever channel / origin field your
+        # source emits, or omit it to leave the column NULL.
+        source_path: "$.order_origin"
+        type: "string"
+        required: false
+
       # ----- ADVANCED: derived expressions -----
       # `derived` evaluates a Python expression against the source
       # payload at apply-time. The expression sees a flat `source`

--- a/db/migrations/063_sales_orders_order_origin.sql
+++ b/db/migrations/063_sales_orders_order_origin.sql
@@ -1,0 +1,40 @@
+-- 063: sales_orders.order_origin - free-text source-of-order label.
+--
+-- The inbound payload from connectors carries an upstream origin /
+-- channel label per order ("amazon", "shopify-store-1", "phone-order",
+-- "in-store-walkin", etc.). Distinct from:
+--
+--   * source_system (FK-gated allowlist of connectors that push to
+--     Sentry; the value is "which connector pushed this")
+--   * order_source (small enum 'web' / 'pos' added by mig 056 for the
+--     POS endpoint surface)
+--
+-- order_origin is intentionally free-text with no FK / CHECK / enum,
+-- so any value the connector hands us via the canonical-mapping
+-- contract lands without a deploy. Length cap matches source_system
+-- for symmetry; a 64-char cap keeps the column index-friendly and
+-- rules out unbounded growth from a misconfigured mapping doc.
+--
+-- The admin Edit modal exposes the column as a free-text input;
+-- ADMIN can edit at any status, base sales-orders USER at OPEN only
+-- (same gate as the other PUT header fields).
+--
+-- No mapping yaml change in this migration. Operators wire up the
+-- connector mapping doc to populate order_origin separately; until
+-- then the column stays NULL on inbound writes and renders blank in
+-- the admin UI.
+--
+-- v1.8.0 migration discipline (V-213): SET lock_timeout /
+-- statement_timeout, BEGIN/COMMIT-wrapped. ADD COLUMN nullable is
+-- a metadata-only operation in PostgreSQL 11+ -- no table rewrite,
+-- no full-table scan.
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+ALTER TABLE sales_orders
+    ADD COLUMN IF NOT EXISTS order_origin VARCHAR(64);
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -329,7 +329,7 @@ CREATE TABLE pick_tasks (
     quantity_picked INT NOT NULL DEFAULT 0,
     pick_sequence INT NOT NULL,            -- ORDER BY this for optimized walk path
     tote_number VARCHAR(50),
-    status VARCHAR(20) DEFAULT 'PENDING',  -- 'PENDING', 'PICKED', 'SHORT', 'SKIPPED'
+    status VARCHAR(20) DEFAULT 'PENDING',  -- 'PENDING', 'PICKED', 'SHORT', 'SKIPPED', 'RELEASED' (RELEASED set by the SO revert / batch full-revert flow).
     picked_by VARCHAR(100),
     picked_at TIMESTAMPTZ,
     scan_confirmed BOOLEAN DEFAULT FALSE   -- item barcode was scanned to verify

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -244,6 +244,15 @@ CREATE TABLE sales_orders (
     -- file via ALTER TABLE so the inline CREATE order does not require
     -- the allowlist table to be declared above sales_orders.
     source_system VARCHAR(64),
+    -- mig 063: free-text upstream-origin label populated by the
+    -- inbound payload from connectors (e.g. "amazon", "shopify-store-1",
+    -- "phone-order"). Distinct from source_system (FK-gated allowlist
+    -- of connectors) and order_source (web/pos enum). No FK / CHECK
+    -- so any value the connector hands us lands without a deploy;
+    -- 64-char cap keeps the column index-friendly. NULL on existing
+    -- rows + on inbound writes whose mapping doc has not been wired
+    -- up yet.
+    order_origin  VARCHAR(64),
     -- v1.10.0 Pipe C: POS endpoint surface columns. Web orders carry
     -- order_source='web' / order_type='sale' (defaults). POS-source
     -- orders carry external_txn_ref + idempotency_key + cached_response_body

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -48,12 +48,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -62,29 +62,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -101,13 +101,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -129,13 +129,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -199,9 +199,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -221,27 +221,27 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -319,27 +319,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -360,13 +360,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -459,12 +459,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1446,31 +1446,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1497,13 +1497,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1534,9 +1534,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1546,9 +1546,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3616,14 +3616,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -3787,9 +3787,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3995,6 +3995,21 @@
         "node": ">= 20.19.4"
       }
     },
+    "node_modules/@react-native/debugger-shell": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.0.tgz",
+      "integrity": "sha512-Y0zEkZzLz8ou6o/VLml1A31X/rMgc6DRjwxwzPMa94qRTMY070WeBCNTITQo4kKTBAUgbxh07oXPQqp0Tpja8w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.4.0",
+        "fb-dotslash": "0.5.8"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
     "node_modules/@react-native/dev-middleware": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.81.5.tgz",
@@ -4034,9 +4049,9 @@
       }
     },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+      "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -4155,9 +4170,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -4172,9 +4187,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -4189,9 +4204,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -4206,9 +4221,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -4223,9 +4238,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -4240,9 +4255,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -4257,9 +4272,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -4274,9 +4289,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -4291,9 +4306,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -4308,9 +4323,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -4325,9 +4340,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -4342,9 +4357,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -4359,9 +4374,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -4369,18 +4384,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -4395,9 +4410,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -4412,9 +4427,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4591,9 +4606,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -8198,6 +8213,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fb-dotslash": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
+      "integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
+      "license": "(MIT OR Apache-2.0)",
+      "peer": true,
+      "bin": {
+        "dotslash": "bin/dotslash"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -8390,17 +8418,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8701,9 +8729,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8711,6 +8739,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hermes-compiler": {
+      "version": "250829098.0.14",
+      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.14.tgz",
+      "integrity": "sha512-5meXwsZxgiqFaJjNzwjzI9IyUkuGGBisu+z9BvQWmGVpjH6nz11hgqkyxe4dl8UAdyIV4lTbz91+Dlnjz0VxqA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hermes-estree": {
       "version": "0.32.0",
@@ -10463,9 +10498,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -11436,6 +11471,62 @@
         "@babel/core": "*"
       }
     },
+    "node_modules/react-native/node_modules/@react-native/debugger-frontend": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.0.tgz",
+      "integrity": "sha512-7Mb3nDfyJeys+ELF75Ageu7VKERlnIMoO+aNPoXqTXvz+b41L6l2CqMyLpDHxkBSlenij6gEepPNgaIyWHbJZw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native/dev-middleware": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.0.tgz",
+      "integrity": "sha512-20pTO6yTybmvXvro520H6C7jydIQnLKOl5qFtVEcHSdFrY63r3OGei+Rx9bILgSRmH6jgnfEcijcMx7pwWuQtw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.86.0",
+        "@react-native/debugger-shell": "0.86.0",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.3.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^7.5.10"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native/dev-middleware/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native/node_modules/@react-native/normalize-colors": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.5.tgz",
@@ -11465,6 +11556,30 @@
         }
       }
     },
+    "node_modules/react-native/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/react-native/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
       "version": "0.29.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.29.1.tgz",
@@ -11472,6 +11587,20 @@
       "license": "MIT",
       "dependencies": {
         "hermes-parser": "0.29.1"
+      }
+    },
+    "node_modules/react-native/node_modules/chromium-edge-launcher": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz",
+      "integrity": "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4"
       }
     },
     "node_modules/react-native/node_modules/commander": {
@@ -11498,6 +11627,759 @@
         "hermes-estree": "0.29.1"
       }
     },
+    "node_modules/react-native/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/react-native/node_modules/metro": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "accepts": "^2.0.0",
+        "ci-info": "^2.0.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.35.0",
+        "image-size": "^1.0.2",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "jsc-safe-url": "^0.2.2",
+        "lodash.throttle": "^4.1.1",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-config": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-file-map": "0.84.4",
+        "metro-resolver": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-symbolicate": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "metro-transform-worker": "0.84.4",
+        "mime-types": "^3.0.1",
+        "nullthrows": "^1.1.1",
+        "serialize-error": "^2.1.0",
+        "source-map": "^0.5.6",
+        "throat": "^5.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "metro": "src/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-babel-transformer": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.35.0",
+        "metro-cache-key": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-babel-transformer/node_modules/hermes-estree": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-native/node_modules/metro-babel-transformer/node_modules/hermes-parser": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.35.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-cache": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "https-proxy-agent": "^7.0.5",
+        "metro-core": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-cache-key": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-config": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "connect": "^3.6.5",
+        "flow-enums-runtime": "^0.0.6",
+        "jest-validate": "^29.7.0",
+        "metro": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "yaml": "^2.6.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-config/node_modules/metro-runtime": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-core": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "lodash.throttle": "^4.1.1",
+        "metro-resolver": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-file-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-minify-terser": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "terser": "^5.15.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-resolver": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-symbolicate": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-source-map": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "metro-symbolicate": "src/index.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-symbolicate/node_modules/metro-source-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.4",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-transform-plugins": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-transform-worker": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.84.4",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-minify-terser": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro-transform-worker/node_modules/metro-source-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.4",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro/node_modules/hermes-estree": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-native/node_modules/metro/node_modules/hermes-parser": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.35.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro/node_modules/metro-runtime": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro/node_modules/metro-source-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.4",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/metro/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/react-native/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/react-native/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/react-native/node_modules/ob1": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-native/node_modules/react-native": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.0.tgz",
+      "integrity": "sha512-17ALh/dd6AO4pgOVmOO5Axll5PbErEo3XFyLokyzW6usyi+OShIEPwUW26wLPlhVifgSOIfECCH0WN+0IqtJ1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@react-native/assets-registry": "0.86.0",
+        "@react-native/codegen": "0.86.0",
+        "@react-native/community-cli-plugin": "0.86.0",
+        "@react-native/gradle-plugin": "0.86.0",
+        "@react-native/js-polyfills": "0.86.0",
+        "@react-native/normalize-colors": "0.86.0",
+        "@react-native/virtualized-lists": "0.86.0",
+        "abort-controller": "^3.0.0",
+        "anser": "^1.4.9",
+        "ansi-regex": "^5.0.0",
+        "babel-plugin-syntax-hermes-parser": "0.36.0",
+        "base64-js": "^1.5.1",
+        "commander": "^12.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-compiler": "250829098.0.14",
+        "invariant": "^2.2.4",
+        "memoize-one": "^5.0.0",
+        "metro-runtime": "^0.84.3",
+        "metro-source-map": "^0.84.3",
+        "nullthrows": "^1.1.1",
+        "pretty-format": "^29.7.0",
+        "promise": "^8.3.0",
+        "react-devtools-core": "^6.1.5",
+        "react-refresh": "^0.14.0",
+        "regenerator-runtime": "^0.13.2",
+        "scheduler": "0.27.0",
+        "semver": "^7.1.3",
+        "stacktrace-parser": "^0.1.10",
+        "tinyglobby": "^0.2.15",
+        "whatwg-fetch": "^3.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "react-native": "cli.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@react-native/jest-preset": "0.86.0",
+        "@types/react": "^19.1.1",
+        "react": "^19.2.3"
+      },
+      "peerDependenciesMeta": {
+        "@react-native/jest-preset": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/@react-native/assets-registry": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.0.tgz",
+      "integrity": "sha512-nIaXbm2jX1OTYp0qbviJ3O6KZivoE8z3BnhUQ2LsqfZSWRoOK/n1qsiAr6oALiNKWnXY3j2KPwtYORnZzp8xew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/@react-native/codegen": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.0.tgz",
+      "integrity": "sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.29.0",
+        "hermes-parser": "0.36.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "tinyglobby": "^0.2.15",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/@react-native/community-cli-plugin": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.0.tgz",
+      "integrity": "sha512-Jv8p1ebEPfTzs8gmrjsdT2XMXFfeAg45Pman+XPLFGaSeGAZkutRFRyX9Cs9aGTSOyIA9YPJ6vDNb1ayTf1FKQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@react-native/dev-middleware": "0.86.0",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "metro": "^0.84.3",
+        "metro-config": "^0.84.3",
+        "metro-core": "^0.84.3",
+        "semver": "^7.1.3"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@react-native-community/cli": "*",
+        "@react-native/metro-config": "0.86.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-community/cli": {
+          "optional": true
+        },
+        "@react-native/metro-config": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/@react-native/gradle-plugin": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.0.tgz",
+      "integrity": "sha512-a1RcfaEDqWExCGfCwadIxt4l8FvKYgFqeMf2uzeKyAOnb+vTGNIeCvifFL2MqvgaeYxlER437HbMIajGcuJ1pQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/@react-native/js-polyfills": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.0.tgz",
+      "integrity": "sha512-zYy/Cjd1VTnZ2iCNaG9bDF9C3l2ntESiPRscjIlI5FKugu6aeTwsDSv1aI8Bc4Kp3vEdoVg+UQhLAhE4svREaQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/@react-native/normalize-colors": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.0.tgz",
+      "integrity": "sha512-kG0wfCGghUKlfxkJyyHCDVutWVYWK7/DG58ojA/4v9EfulgF+osuSQmlbNb3rcKX58qutm7JcldSeVLgGFha9g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/@react-native/virtualized-lists": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.0.tgz",
+      "integrity": "sha512-4/ZLXdf/OSpPDVO0AsQ1SJdRIzt5t9BNQ46QwGgxvX7/cirYR5k8KXctNGGgW8lQo2gZChEfY2zFCZg9nM/jiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.2.0",
+        "react": "*",
+        "react-native": "0.86.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.0.tgz",
+      "integrity": "sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-parser": "0.36.0"
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/hermes-estree": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.0.tgz",
+      "integrity": "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/hermes-parser": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.0.tgz",
+      "integrity": "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.36.0"
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/metro-runtime": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/metro-source-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.4",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-native/node_modules/react-native/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native/node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -11520,12 +12402,28 @@
       }
     },
     "node_modules/react-native/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+      "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/react-refresh": {
@@ -11798,14 +12696,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -11814,21 +12712,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/run-parallel": {
@@ -12484,9 +13382,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -12651,9 +13549,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -13108,17 +14006,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -13134,7 +14032,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -13199,9 +14097,9 @@
       }
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -13219,7 +14117,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -13518,9 +14416,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"


### PR DESCRIPTION
## Summary

The sales-order admin surface gains a status-revert flow, a free-text `order_origin` label, and a set of edit-modal refinements, across the commits on this branch:

- `feat(sales-orders): tracking # field + addresses inside main edit modal` -- `tracking_number` joins the SO view + edit modals (GET now returns `carrier` + `tracking_number`); address editing moves out of its standalone modal into the main edit form so header + addresses save under one click (PUT, then a conditional PATCH `/address`), with a client-side `addressEditable` gate mirroring the backend status rule.
- `feat(sales-orders): revert-status flow + Release Picked Quantities` -- `POST /admin/sales-orders/<id>/revert-status` demotes an SO from PICKED/PACKED/SHIPPED to any earlier status, composing the unwind per effect (per-pick_task release back to source bin, unpack, unship) under one transaction and one audit shape; a release-only mode (`new_status == current`) releases picks without flipping status; cancel-batch now does a full revert across PENDING/PICKED/SHORT through a shared `full_revert_batch` helper, so a cancelled batch leaves the SO indistinguishable from "never started picking". New audit actions SO_STATUS_REVERTED / SO_PICK_RELEASED / SO_UNPACKED / SO_UNSHIPPED; new pick_task terminal status RELEASED.
- `feat(admin-ui): modal text scale + line items polish` -- a `.modal`-scoped type-scale bump (labels/inputs/titles step up one size inside popups) and the line-items item-name column reverts from muted grey to default text for legibility.
- `fix(sales-orders): release-only / revert modal default-to-keep-all` -- the two modal modes seed their keep-set sensibly: release-only keeps every pick by default (uncheck to release), the status-revert mode releases all by default (check to keep PICKED).
- `feat(sales-orders): $ prefix on Order Total + Shipping Paid` -- the view-modal money fields render with a `$` prefix.
- `feat(sales-orders): free-text Source field (order_origin, mig 063)` -- `sales_orders.order_origin` VARCHAR(64), a free-text upstream-origin label populated by the inbound payload (no FK / enum, so any connector value lands without a deploy), surfaced read/write in the modals; distinct from `source_system` (which connector pushed) and `order_source` (the web/pos enum).
- `test(sales-orders): cover revert flow + order_origin + mig 058 FK` -- service + HTTP coverage for the revert flow (every backward pair, release-only, the picked_qty_remaining guard, all RevertNotAllowed kinds, per-effect audit shapes), order_origin, the `pick_tasks` detail field, and the pick_tasks line-FK SET NULL behavior.
- `docs(schema)` / `docs(mappings)` -- document the RELEASED pick_task status and add an `order_origin` example to the inbound mapping template.

## Mobile

Zero mobile/ diffs.

## Pre-merge gate

- [x] Full api suite green locally (2429 passed, 9 skipped; the 2 psql-host migration suites run in CI); admin vitest 74/74; fresh `schema.sql` load verified (`order_origin` column resolves)
- [ ] CI green

## Dependency audit

Ambient advisories published 2026-06-15 turned the pip-audit / npm-audit gates red repo-wide, independent of this branch. A `chore(deps)` commit here clears the blocking set -- cryptography 48.0.1 and transitive npm lockfile bumps for the HIGH advisories (vite, ws, node-tar, form-data); lockfile-only, package.json unchanged. Remaining moderate-tier mobile advisories sit below the `--audit-level=high` gate.
