### PR TITLE
docs: v1.13.0 postmerge catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
   
   <p><em>Open-source warehouse management system built for barcode scanners</em></p>
 
-  ![Version](https://img.shields.io/badge/version-1.12.0-8e2716)
-  ![Tests](https://img.shields.io/badge/tests-2381%20passing-34a853)
+  ![Version](https://img.shields.io/badge/version-1.13.0-8e2716)
+  ![Tests](https://img.shields.io/badge/tests-2449%20passing-34a853)
   ![License](https://img.shields.io/badge/license-Apache_2.0-blue)
   
   **[Documentation](https://hightower-systems.github.io/sentry-wms)** | **[API Reference](https://hightower-systems.github.io/sentry-wms/api-reference/)** | **[Releases](https://github.com/hightower-systems/sentry-wms/releases)**
@@ -276,7 +276,7 @@ docker compose exec api python -m pytest tests/ -v --tb=short
 
 ## Project Status
 
-**v1.12.0 - Admin permissions and SO editing release. Web-admin USERs gain per-page permission grants (`user_page_permissions`, mig 061) enforced by `@require_admin_or_page_permission` across every admin endpoint, with sidebar filtering, a permission grid on the Users form, and a single clean Permissions Error popup. The admin SO surface gains line-level CRUD with an allocation-release pass, shipment-state backfill fields, a company-local Shipped Date (`SENTRY_COMPANY_TIMEZONE`, default UTC, noon-anchored across DST), the so-full-edit override for non-admin operators, and a denormalised `sales_orders.source_system` (mig 062, FK to the inbound allowlist) so a mis-tagged order can be repointed without rewriting inbound history.**
+**v1.13.0 - SO status revert and editing refinements release. The admin sales-order surface gains a status-revert flow that demotes a PICKED / PACKED / SHIPPED order to any earlier status -- releasing each picked task's inventory back to its source bin, unpacking, and unshipping under one transaction and audit shape, with a release-only mode and a shared `full_revert_batch` that gives cancel-batch the same unwind across PENDING / PICKED / SHORT. Adds a free-text `sales_orders.order_origin` label (mig 063) populated by the inbound payload, tracking-number and inline address editing inside the main SO edit modal, and a `.modal`-scoped type-scale pass. `cryptography` 48.0.1 plus npm transitive bumps clear the 2026-06-15 audit advisories.**
 
 | Version | Milestone | Status |
 |---------|-----------|--------|
@@ -323,6 +323,7 @@ docker compose exec api python -m pytest tests/ -v --tb=short
 | **v1.10.4** | **API-reliability patch - POS cash tenders accept `external_txn_ref=None` (cash carries no processor reference; dedup rides `idempotency_key`). SQLAlchemy `pool_pre_ping` + `pool_recycle` eliminate first-request-after-idle 500s. SO detail GET returns `customer_phone` + `customer_address` so saved values survive the edit-modal round-trip. No migrations.** | ✅ **Released** |
 | **v1.11.0** | **Status simplification - PICKING / PACKING / ALLOCATED retired from the SO lifecycle (OPEN -> PICKED -> PACKED -> SHIPPED, CANCELLED off-ramp). "In picking" derives from `pick_batch_orders` + `pick_batches.status`; `create_pick_batch` refuses an OPEN SO already in an active batch; `cancel_sales_order` folds the former PICKING branch into OPEN with allocated quantity driving the unwind. Migration 060 runs the backfill and updates column comments. Breaking for external automation keying on retired statuses.** | ✅ **Released** |
 | **v1.12.0** | **Admin permissions + SO editing - per-page USER grants (mig 061) wired across every admin endpoint + sidebar/grid UI; SO line CRUD with allocation-release; shipment-state backfill fields; company-local Shipped Date via `SENTRY_COMPANY_TIMEZONE`; so-full-edit override; `sales_orders.source_system` (mig 062) with allowlist FK + backfill; per-field edit audit rows + `edited_fields` on PUT.** | ✅ **Released** |
+| **v1.13.0** | **SO status revert + editing refinements - `revert-status` flow demoting PICKED / PACKED / SHIPPED with per-pick_task release, unpack, and unship + a release-only mode; shared `full_revert_batch` so cancel-batch does the same unwind across PENDING / PICKED / SHORT; free-text `sales_orders.order_origin` (mig 063); tracking-number + inline address editing in the SO modal; `.modal` type-scale pass; `cryptography` 48.0.1 + npm audit catch-up.** | ✅ **Released** |
 | v2.0.0 | First-party ERP + commerce connectors (NetSuite, QuickBooks, Shopify, Fabric) on top of the v1.3 connector framework | Planned |
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
@@ -335,4 +336,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 Apache License 2.0 - see [LICENSE](LICENSE) and [NOTICE](NOTICE) for details. Pre-v1.7.0 tagged releases remain MIT-licensed; v1.7.0 and later are Apache 2.0.
 
-Built by [Hightower Systems L.L.C.](https://github.com/hightower-systems) · v1.12.0
+Built by [Hightower Systems L.L.C.](https://github.com/hightower-systems) · v1.13.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,26 @@ is a shorter, docs-site-friendly summary.
 
 ---
 
+## v1.13.0 -- SO status revert + editing refinements
+
+*2026-06-15.* [Full notes](https://github.com/hightower-systems/sentry-wms/releases/tag/v1.13.0).
+
+The admin sales-order surface gains a status-revert flow:
+`POST /admin/sales-orders/<id>/revert-status` demotes a PICKED / PACKED /
+SHIPPED order to any earlier status, releasing each picked task's
+inventory back to its source bin, unpacking, and unshipping under one
+transaction and one audit shape (`SO_STATUS_REVERTED` /
+`SO_PICK_RELEASED` / `SO_UNPACKED` / `SO_UNSHIPPED`). A release-only mode
+releases picks without flipping status, and a shared `full_revert_batch`
+gives cancel-batch the same unwind across PENDING / PICKED / SHORT.
+
+Also: a free-text `sales_orders.order_origin` label (mig 063) populated
+by the inbound payload and surfaced in the SO modals; tracking-number
+and inline address editing in the main SO edit modal; a `.modal`-scoped
+type-scale pass; and a dependency audit catch-up (`cryptography` 48.0.1
+plus npm transitive bumps) clearing the 2026-06-15 advisories. No mobile
+diffs; no new APK.
+
 ## v1.12.0 -- per-page admin permissions + SO line editing
 
 *2026-06-12.* [Full notes](https://github.com/hightower-systems/sentry-wms/releases/tag/v1.12.0).

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 
 ## Current Version
 
-v1.12.0 -- Admin permissions and SO editing: per-page permission grants for web-admin USERs (mig 061) enforced across every admin endpoint with sidebar/grid UI; SO line CRUD with allocation-release; shipment-state backfill fields; a company-local Shipped Date driven by `SENTRY_COMPANY_TIMEZONE` (IANA zone, default UTC); the so-full-edit override; and `sales_orders.source_system` (mig 062). No mobile diffs; no new APK. See the [v1.12.0 release](https://github.com/hightower-systems/sentry-wms/releases/tag/v1.12.0).
+v1.13.0 -- SO status revert and editing refinements: a `revert-status` flow that demotes a PICKED / PACKED / SHIPPED order to any earlier status (per-pick_task release, unpack, unship, plus a release-only mode and a shared `full_revert_batch` cancel-batch unwind); a free-text `sales_orders.order_origin` label (mig 063); tracking-number and inline address editing in the SO edit modal; and a `.modal` type-scale pass. `cryptography` 48.0.1 + npm transitive bumps clear the 2026-06-15 audit advisories. No mobile diffs; no new APK. See the [v1.13.0 release](https://github.com/hightower-systems/sentry-wms/releases/tag/v1.13.0).
 
 v1.11.0 -- Status simplification: PICKING, PACKING, and ALLOCATED are retired from the SO lifecycle (now OPEN -> PICKED -> PACKED -> SHIPPED, with CANCELLED as the off-ramp). Breaking for automation keying on the retired statuses; the derived signal is a `pick_batch_orders` row whose batch is OPEN or IN_PROGRESS. Migration 060 runs the backfill. No mobile diffs; no new APK. See the [v1.11.0 release](https://github.com/hightower-systems/sentry-wms/releases/tag/v1.11.0).
 


### PR DESCRIPTION
## Summary

Postmerge docs catch-up for v1.13.0: README version + tests badges (2381 -> 2449), banner, milestone row, footer; docs/index Current Version lead; docs/changelog summary. The api-reference sweep for the revert-status endpoint + new audit actions is deferred to the next reference pass.

## Pre-merge gate

- [x] Docs-only; MkDocs build is the gate
