### PR TITLE
feat(picking): under-allocation pre-flight + line-level fulfillment guards across batch/pack/ship

### DIFF
--- a/api/routes/dockd.py
+++ b/api/routes/dockd.py
@@ -510,21 +510,28 @@ def ship_order(so_number):
             "l": float(body.dims.l), "w": float(body.dims.w), "h": float(body.dims.h),
         }
 
-    result = record_ship(
-        g.db,
-        so_id=so.so_id,
-        so_number=so.so_number,
-        so_external_id=so.external_id,
-        warehouse_id=so.warehouse_id,
-        tracking_number=body.tracking,
-        carrier=body.carrier,
-        ship_method=body.ship_method,
-        username=body.operator_username,
-        source_txn_id=idempotency_key_str,
-        pre_ship_status=so.status,
-        shipping_cost=body.shipping_cost,
-        audit_details_extra=audit_extra,
-    )
+    try:
+        result = record_ship(
+            g.db,
+            so_id=so.so_id,
+            so_number=so.so_number,
+            so_external_id=so.external_id,
+            warehouse_id=so.warehouse_id,
+            tracking_number=body.tracking,
+            carrier=body.carrier,
+            ship_method=body.ship_method,
+            username=body.operator_username,
+            source_txn_id=idempotency_key_str,
+            pre_ship_status=so.status,
+            shipping_cost=body.shipping_cost,
+            audit_details_extra=audit_extra,
+        )
+    except ValueError as e:
+        # Layer 2C: lines short-picked without an operator-confirmed
+        # short-close marker. Refuse the ship rather than silently
+        # omitting the unpicked lines as record_ship historically did.
+        g.db.rollback()
+        return _err("line_under_picked", str(e), 400)
 
     response_body_dict = {
         "status": SO_SHIPPED,

--- a/api/routes/packing.py
+++ b/api/routes/packing.py
@@ -12,7 +12,7 @@ from middleware.db import with_db
 from schemas.pack_verification import CompletePackingRequest, VerifyPackItemRequest
 from services.audit_service import write_audit_log
 from services.events_service import emit_event, get_user_external_id
-from constants import SO_PICKED, SO_PACKED, ACTION_PACK
+from constants import SO_PICKED, SO_PACKED, ACTION_PACK, TASK_SHORT
 from utils.validation import validate_body
 
 packing_bp = Blueprint("packing", __name__)
@@ -253,6 +253,47 @@ def complete_packing(validated):
 
     if unverified > 0:
         return jsonify({"error": f"Cannot complete packing - {unverified} items not yet verified"}), 400
+
+    # Layer 2B: line-level fulfillment guard. The unverified check above
+    # only catches packed < picked - a line with picked=0 (because the
+    # historical under-allocation bug never created a pick_task for it)
+    # has packed=0 too and trivially passes. Guard separately: refuse to
+    # pack any line whose quantity_picked < quantity_ordered unless an
+    # explicit operator-confirmed shortfall marker exists (mirrors the
+    # Layer 2A logic in complete_batch).
+    silently_short = g.db.execute(
+        text(
+            """
+            SELECT sol.so_line_id, i.sku, sol.quantity_ordered, sol.quantity_picked
+              FROM sales_order_lines sol
+              JOIN items i ON i.item_id = sol.item_id
+             WHERE sol.so_id = :so_id
+               AND sol.quantity_picked < sol.quantity_ordered
+               AND NOT EXISTS (
+                   SELECT 1 FROM pick_tasks pt
+                    WHERE pt.so_line_id = sol.so_line_id
+                      AND pt.status = :short
+               )
+               AND NOT EXISTS (
+                   SELECT 1 FROM wave_pick_breakdown wb
+                    WHERE wb.so_line_id = sol.so_line_id
+                      AND wb.short_quantity > 0
+               )
+             ORDER BY sol.so_line_id
+            """
+        ),
+        {"so_id": so_id, "short": TASK_SHORT},
+    ).fetchall()
+
+    if silently_short:
+        first = silently_short[0]
+        more = "" if len(silently_short) == 1 else f" (+{len(silently_short) - 1} more)"
+        return jsonify({
+            "error": (
+                f"Cannot complete packing - line under-picked with no short-close marker: "
+                f"sku={first.sku} ordered={first.quantity_ordered} picked={first.quantity_picked}{more}"
+            )
+        }), 400
 
     # Update SO
     g.db.execute(

--- a/api/routes/picking.py
+++ b/api/routes/picking.py
@@ -23,6 +23,7 @@ from schemas.pick_walks import (
 from services.picking_service import (
     AlreadyInBatchError,
     BarcodeError,
+    InsufficientCoverageError,
     complete_batch,
     confirm_pick,
     create_pick_batch,
@@ -108,8 +109,15 @@ def create_batch(validated):
             so_identifiers=validated.so_identifiers,
             warehouse_id=validated.warehouse_id,
             username=g.current_user["username"],
+            exclude_so_ids=validated.exclude_so_ids,
         )
         return jsonify(result)
+    except InsufficientCoverageError as e:
+        return jsonify({
+            "error_type": "insufficient_coverage",
+            "error": str(e),
+            "unpickable": e.unpickable,
+        }), 409
     except ValueError as e:
         g.db.rollback()
         return jsonify({"error": str(e)}), 400
@@ -142,11 +150,26 @@ def create_wave(validated):
             so_ids=validated.so_ids,
             warehouse_id=validated.warehouse_id,
             username=g.current_user["username"],
+            exclude_so_ids=validated.exclude_so_ids,
         )
         return jsonify(result)
+    except InsufficientCoverageError as e:
+        # error_type distinguishes this 409 from already_in_batch so the
+        # mobile client knows to render the per-SKU shortfall modal rather
+        # than a one-line error popup.
+        return jsonify({
+            "error_type": "insufficient_coverage",
+            "error": str(e),
+            "unpickable": e.unpickable,
+        }), 409
     except AlreadyInBatchError as e:
         g.db.rollback()
-        return jsonify({"error": str(e), "so_number": e.so_number, "batch_id": e.batch_id}), 409
+        return jsonify({
+            "error_type": "already_in_batch",
+            "error": str(e),
+            "so_number": e.so_number,
+            "batch_id": e.batch_id,
+        }), 409
     except ValueError as e:
         g.db.rollback()
         return jsonify({"error": str(e)}), 400

--- a/api/routes/shipping.py
+++ b/api/routes/shipping.py
@@ -143,18 +143,23 @@ def fulfill(validated):
             return jsonify({"error": f"Order must be packed before shipping. Current status: {so.status}"}), 400
         return jsonify({"error": f"Order is not ready for shipping. Current status: {so.status}"}), 400
 
-    result = record_ship(
-        g.db,
-        so_id=so_id,
-        so_number=so.so_number,
-        so_external_id=so.external_id,
-        warehouse_id=so.warehouse_id,
-        tracking_number=tracking_number,
-        carrier=carrier,
-        ship_method=ship_method,
-        username=username,
-        source_txn_id=g.source_txn_id,
-    )
+    try:
+        result = record_ship(
+            g.db,
+            so_id=so_id,
+            so_number=so.so_number,
+            so_external_id=so.external_id,
+            warehouse_id=so.warehouse_id,
+            tracking_number=tracking_number,
+            carrier=carrier,
+            ship_method=ship_method,
+            username=username,
+            source_txn_id=g.source_txn_id,
+        )
+    except ValueError as e:
+        # Layer 2C guard rejected the ship (silently under-picked lines).
+        g.db.rollback()
+        return jsonify({"error": str(e)}), 400
 
     g.db.commit()
 

--- a/api/schemas/pick_walks.py
+++ b/api/schemas/pick_walks.py
@@ -1,6 +1,6 @@
 """Picking / pick walk request schemas."""
 
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -8,6 +8,9 @@ from pydantic import BaseModel, Field
 class CreateBatchRequest(BaseModel):
     so_identifiers: List[str] = Field(..., min_length=1)
     warehouse_id: int = Field(..., gt=0)
+    # SOs the picker explicitly chose to drop after a prior 409
+    # insufficient_coverage response. Empty/omitted on the first call.
+    exclude_so_ids: Optional[List[int]] = Field(default=None)
 
 
 class WaveValidateRequest(BaseModel):
@@ -18,6 +21,7 @@ class WaveValidateRequest(BaseModel):
 class WaveCreateRequest(BaseModel):
     so_ids: List[int] = Field(..., min_length=1)
     warehouse_id: int = Field(..., gt=0)
+    exclude_so_ids: Optional[List[int]] = Field(default=None)
 
 
 class ConfirmPickRequest(BaseModel):

--- a/api/services/picking_service.py
+++ b/api/services/picking_service.py
@@ -22,8 +22,102 @@ from constants import (
 )
 
 
-def create_pick_batch(db, so_identifiers, warehouse_id, username):
-    # 1. Resolve SOs
+class InsufficientCoverageError(Exception):
+    """Raised at batch creation when one or more SOs cannot be fully covered
+    by pickable inventory in the target warehouse. Carries a structured list
+    of unpickable SOs so the picker UI can surface a per-SKU shortfall modal
+    and offer to drop those SOs from the batch.
+
+    The historical bug this guards against: the inner allocation loop in
+    create_pick_batch / wave_create would exit silently with remaining > 0
+    when inventory was exhausted, creating fewer pick_tasks than the SO
+    needed. complete_batch's pending-task count would then read zero, the
+    SO would flip through PICKED -> PACKED -> SHIPPED, and the customer
+    would receive a short shipment with no in-system trace.
+    """
+    def __init__(self, unpickable):
+        self.unpickable = unpickable
+        super().__init__(
+            f"{len(unpickable)} sales order(s) cannot be fully picked from current inventory"
+        )
+
+
+def _plan_coverage(db, so_lines_by_item, warehouse_id):
+    """Given a map of item_id -> list of {so_id, so_number, so_line_id, needed},
+    lock the candidate inventory rows FOR UPDATE and walk contributors in
+    FIFO order (by so_id then so_line_id) to decide which SOs can be fully
+    covered. Returns (unpickable_by_so, inv_rows_by_item) where:
+
+      unpickable_by_so: dict[so_id, {so_number, lines: [...]}]
+      inv_rows_by_item: dict[item_id, fetched inventory rows] - returned so
+                       callers reuse the same locked snapshot for the real
+                       allocation pass without re-querying (which would
+                       re-lock the same rows in the same transaction; cheap
+                       but redundant).
+
+    FIFO-by-so_id was chosen so two callers running back-to-back from the
+    same input list make the same drop decisions. Any deterministic order
+    works; so_id is stable and obvious in the audit trail.
+    """
+    unpickable_by_so = {}
+    inv_rows_by_item = {}
+
+    for item_id, contributions in so_lines_by_item.items():
+        inv_rows = db.execute(
+            text(
+                """
+                SELECT inv.inventory_id, inv.bin_id, inv.quantity_on_hand, inv.quantity_allocated,
+                       (inv.quantity_on_hand - inv.quantity_allocated) AS available,
+                       b.pick_sequence, b.bin_type, inv.lot_number, inv.updated_at
+                FROM inventory inv
+                JOIN bins b ON b.bin_id = inv.bin_id
+                WHERE inv.item_id = :item_id
+                  AND inv.warehouse_id = :wh
+                  AND (inv.quantity_on_hand - inv.quantity_allocated) > 0
+                  AND b.bin_type IN (:bin_pickable, :bin_pickable_staging)
+                ORDER BY
+                  b.pick_sequence ASC,
+                  inv.updated_at ASC
+                FOR UPDATE OF inv
+                """
+            ),
+            {"item_id": item_id, "wh": warehouse_id, "bin_pickable": BIN_PICKABLE, "bin_pickable_staging": BIN_PICKABLE_STAGING},
+        ).fetchall()
+        inv_rows_by_item[item_id] = inv_rows
+
+        total_available = sum(r.available for r in inv_rows)
+
+        item_info = db.execute(
+            text("SELECT sku, item_name FROM items WHERE item_id = :iid"),
+            {"iid": item_id},
+        ).fetchone()
+
+        sorted_contribs = sorted(contributions, key=lambda c: (c["so_id"], c["so_line_id"]))
+        cumulative = 0
+        for c in sorted_contribs:
+            if cumulative + c["needed"] <= total_available:
+                cumulative += c["needed"]
+                continue
+            so_id = c["so_id"]
+            entry = unpickable_by_so.setdefault(
+                so_id, {"so_id": so_id, "so_number": c["so_number"], "lines": []}
+            )
+            entry["lines"].append({
+                "sku": item_info.sku if item_info else None,
+                "item_name": item_info.item_name if item_info else None,
+                "ordered": c["needed"],
+                "available": max(0, total_available - cumulative),
+            })
+
+    return unpickable_by_so, inv_rows_by_item
+
+
+def create_pick_batch(db, so_identifiers, warehouse_id, username, exclude_so_ids=None):
+    exclude_set = set(exclude_so_ids or [])
+
+    # 1. Resolve SOs (excluded identifiers are silently dropped here; the
+    # picker UI already collected them in a prior 409 response, so we don't
+    # re-error on them).
     sales_orders = []
     for ident in so_identifiers:
         so = db.execute(
@@ -41,6 +135,8 @@ def create_pick_batch(db, so_identifiers, warehouse_id, username):
 
         if not so:
             raise ValueError(f"Sales order '{ident}' not found")
+        if so.so_id in exclude_set:
+            continue
         if so.status != SO_OPEN:
             raise ValueError(f"Sales order '{ident}' status is {so.status}, must be OPEN")
 
@@ -65,6 +161,45 @@ def create_pick_batch(db, so_identifiers, warehouse_id, username):
             )
 
         sales_orders.append(so)
+
+    if not sales_orders:
+        raise ValueError("No sales orders to pick (all excluded or empty input)")
+
+    # 1.5 Coverage pre-flight. Build the item -> contributors map FIRST so
+    # we can decide which SOs are unpickable BEFORE we insert any
+    # pick_batches / pick_batch_orders / inventory allocation rows. The
+    # FOR UPDATE locks acquired by _plan_coverage persist through the
+    # rest of this transaction so the real allocation loop below sees
+    # the same inventory snapshot.
+    coverage_map = {}
+    for so in sales_orders:
+        lines = db.execute(
+            text(
+                """
+                SELECT so_line_id, item_id, quantity_ordered, quantity_allocated
+                FROM sales_order_lines
+                WHERE so_id = :so_id AND quantity_ordered > quantity_allocated
+                """
+            ),
+            {"so_id": so.so_id},
+        ).fetchall()
+        for line in lines:
+            needed = line.quantity_ordered - line.quantity_allocated
+            if needed <= 0:
+                continue
+            coverage_map.setdefault(line.item_id, []).append({
+                "so_id": so.so_id,
+                "so_number": so.so_number,
+                "so_line_id": line.so_line_id,
+                "needed": needed,
+            })
+
+    unpickable, _ = _plan_coverage(db, coverage_map, warehouse_id)
+    if unpickable:
+        # Drop any locks + partial state. The route layer translates the
+        # raised exception into a 409 with the structured unpickable list.
+        db.rollback()
+        raise InsufficientCoverageError(list(unpickable.values()))
 
     # 2. Generate batch number
     now = datetime.now(timezone.utc)
@@ -912,10 +1047,21 @@ def wave_validate(db, so_barcode, warehouse_id):
     }
 
 
-def wave_create(db, so_ids, warehouse_id, username):
-    """Create a wave pick batch from multiple SOs with combined item picks."""
+def wave_create(db, so_ids, warehouse_id, username, exclude_so_ids=None):
+    """Create a wave pick batch from multiple SOs with combined item picks.
+
+    `exclude_so_ids` is populated by the picker UI on the second call after
+    a 409 InsufficientCoverageError - SOs the picker chose to drop are
+    filtered out before validation + coverage checks. SOs in the input list
+    that appear in exclude_so_ids are silently skipped (no error).
+    """
     if len(so_ids) != len(set(so_ids)):
         raise ValueError("Duplicate SO IDs in request")
+
+    exclude_set = set(exclude_so_ids or [])
+    so_ids = [s for s in so_ids if s not in exclude_set]
+    if not so_ids:
+        raise ValueError("No sales orders to pick (all excluded or empty input)")
 
     # 1. Validate all SOs
     sales_orders = []
@@ -958,6 +1104,37 @@ def wave_create(db, so_ids, warehouse_id, username):
             raise ValueError(f"SO {so.so_number} has no items")
 
         sales_orders.append(so)
+
+    # 1.5 Coverage pre-flight. Build line_map BEFORE creating the batch row
+    # so an InsufficientCoverageError leaves no half-written batch behind.
+    # See create_pick_batch for the same pattern + rationale.
+    line_map = {}
+    for so in sales_orders:
+        lines = db.execute(
+            text(
+                """
+                SELECT so_line_id, item_id, quantity_ordered, quantity_allocated
+                FROM sales_order_lines
+                WHERE so_id = :so_id AND quantity_ordered > quantity_allocated
+                """
+            ),
+            {"so_id": so.so_id},
+        ).fetchall()
+        for line in lines:
+            needed = line.quantity_ordered - line.quantity_allocated
+            if needed <= 0:
+                continue
+            line_map.setdefault(line.item_id, []).append({
+                "so_id": so.so_id,
+                "so_number": so.so_number,
+                "so_line_id": line.so_line_id,
+                "needed": needed,
+            })
+
+    unpickable, _ = _plan_coverage(db, line_map, warehouse_id)
+    if unpickable:
+        db.rollback()
+        raise InsufficientCoverageError(list(unpickable.values()))
 
     # 2. Generate batch
     now = datetime.now(timezone.utc)

--- a/api/services/picking_service.py
+++ b/api/services/picking_service.py
@@ -835,6 +835,58 @@ def complete_batch(db, batch_id, username):
     if pending_count > 0:
         raise ValueError(f"Cannot complete batch - {pending_count} tasks still pending")
 
+    # Layer 2A: line-level fulfillment guard. The pending-task count above
+    # only checks that pick_tasks reached a terminal state; it does NOT
+    # check that every SO line was actually covered. Under-allocation at
+    # batch creation (now blocked by InsufficientCoverageError pre-flight,
+    # but historically silent) leaves lines with no pick_task at all -
+    # zero PENDING tasks for them, zero PICKED tasks, and quantity_picked
+    # never moves off 0. Without this guard, those lines silently advance
+    # through PICKED -> PACKED -> SHIPPED.
+    #
+    # A line is considered legitimately closed when EITHER
+    #   - quantity_picked >= quantity_ordered (fully picked), OR
+    #   - an explicit operator-confirmed shortfall marker exists:
+    #       * pick_tasks.status = SHORT on a task for this so_line_id, OR
+    #       * wave_pick_breakdown.short_quantity > 0 for this so_line_id
+    #         (wave picks distribute one pick_task across many SO lines).
+    silently_short = db.execute(
+        text(
+            """
+            SELECT sol.so_id, sol.so_line_id, i.sku,
+                   sol.quantity_ordered, sol.quantity_picked
+              FROM sales_order_lines sol
+              JOIN pick_batch_orders pbo ON pbo.so_id = sol.so_id
+              JOIN items i ON i.item_id = sol.item_id
+             WHERE pbo.batch_id = :bid
+               AND sol.quantity_picked < sol.quantity_ordered
+               AND NOT EXISTS (
+                   SELECT 1 FROM pick_tasks pt
+                    WHERE pt.so_line_id = sol.so_line_id
+                      AND pt.status = :short
+               )
+               AND NOT EXISTS (
+                   SELECT 1 FROM wave_pick_breakdown wb
+                    WHERE wb.so_line_id = sol.so_line_id
+                      AND wb.short_quantity > 0
+               )
+             ORDER BY sol.so_id, sol.so_line_id
+            """
+        ),
+        {"bid": batch_id, "short": TASK_SHORT},
+    ).fetchall()
+
+    if silently_short:
+        offenders = [
+            f"so_id={r.so_id} sku={r.sku} ordered={r.quantity_ordered} picked={r.quantity_picked}"
+            for r in silently_short[:5]
+        ]
+        more = "" if len(silently_short) <= 5 else f" (+{len(silently_short) - 5} more)"
+        raise ValueError(
+            "Cannot complete batch - lines under-picked with no short-close marker: "
+            + "; ".join(offenders) + more
+        )
+
     # 2. Update batch
     db.execute(
         text(

--- a/api/services/shipping_service.py
+++ b/api/services/shipping_service.py
@@ -77,7 +77,48 @@ def record_ship(
 
     Returns dict with fulfillment_id, shipped_at, lines_shipped,
     total_quantity, audit_log_id.
+
+    Raises ValueError when any SO line is silently under-picked - that is,
+    quantity_picked < quantity_ordered AND no explicit shortfall marker
+    (pick_tasks.status = SHORT or wave_pick_breakdown.short_quantity > 0)
+    exists for the line. Historically this function silently omitted lines
+    where quantity_picked = 0, letting the SO ship without the customer's
+    full order; the guard makes that impossible.
     """
+    # Layer 2C: line-level fulfillment guard. Mirrors complete_batch
+    # (Layer 2A) and complete_packing (Layer 2B). Runs before the
+    # fulfillment INSERT so a refused ship leaves no fulfillment row.
+    silently_short = db.execute(
+        text(
+            """
+            SELECT sol.so_line_id, i.sku, sol.quantity_ordered, sol.quantity_picked
+              FROM sales_order_lines sol
+              JOIN items i ON i.item_id = sol.item_id
+             WHERE sol.so_id = :so_id
+               AND sol.quantity_picked < sol.quantity_ordered
+               AND NOT EXISTS (
+                   SELECT 1 FROM pick_tasks pt
+                    WHERE pt.so_line_id = sol.so_line_id
+                      AND pt.status = :short
+               )
+               AND NOT EXISTS (
+                   SELECT 1 FROM wave_pick_breakdown wb
+                    WHERE wb.so_line_id = sol.so_line_id
+                      AND wb.short_quantity > 0
+               )
+             ORDER BY sol.so_line_id
+            """
+        ),
+        {"so_id": so_id, "short": TASK_SHORT},
+    ).fetchall()
+    if silently_short:
+        first = silently_short[0]
+        more = "" if len(silently_short) == 1 else f" (+{len(silently_short) - 1} more)"
+        raise ValueError(
+            "Cannot ship - line under-picked with no short-close marker: "
+            f"sku={first.sku} ordered={first.quantity_ordered} picked={first.quantity_picked}{more}"
+        )
+
     # 1. Create item_fulfillments record
     result = db.execute(
         text(

--- a/api/tests/test_packing.py
+++ b/api/tests/test_packing.py
@@ -189,3 +189,30 @@ class TestCompletePacking:
     def test_packing_requires_auth(self, client):
         resp = client.get("/api/packing/order/SO-2026-001")
         assert resp.status_code == 401
+
+    def test_complete_packing_refuses_silently_under_picked(self, client, auth_headers):
+        """Layer 2B: refuses to flip SO to PACKED when any line has
+        quantity_picked < quantity_ordered without a short-close marker.
+        The existing unverified-items guard only compares packed vs picked
+        and trivially passes when picked=0; the new guard catches that gap."""
+        _advance_so_to_picked(client, auth_headers, ["SO-2026-001"])
+
+        # Simulate the under-allocation state: a line whose quantity_picked
+        # was never incremented (no pick_task, no SHORT marker). Verify the
+        # remaining (still-picked) line so the unverified guard would pass.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_order_lines SET quantity_picked = 0, quantity_packed = 0 "
+            "WHERE so_line_id = (SELECT MIN(so_line_id) FROM sales_order_lines WHERE so_id = 1)"
+        )
+        cur.close()
+
+        resp = client.post(
+            "/api/packing/complete",
+            json={"so_id": 1},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        err = resp.get_json()["error"].lower()
+        assert "under-picked" in err or "short-close marker" in err

--- a/api/tests/test_picking.py
+++ b/api/tests/test_picking.py
@@ -354,6 +354,123 @@ class TestCompleteBatch:
         )
         assert resp.status_code == 401
 
+    def test_complete_batch_refuses_silently_under_picked(self, client, auth_headers):
+        """Layer 2A: refuses to complete a batch when any line has
+        quantity_picked < quantity_ordered without an explicit short-close
+        marker. Simulates the historical under-allocation bug state via
+        direct DB mutation; the new Layer 1 pre-flight makes this state
+        unreachable through the API, but the guard must still catch it
+        defensively (e.g., manual DB intervention, future bugs)."""
+        create_resp = _create_batch(client, auth_headers)
+        batch_id = create_resp.get_json()["batch_id"]
+        self._pick_all_tasks(client, auth_headers, batch_id)
+
+        # Knock one line back to picked=0 without leaving a SHORT marker.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_order_lines SET quantity_picked = 0 "
+            "WHERE so_line_id = (SELECT MIN(so_line_id) FROM sales_order_lines WHERE so_id = 1)"
+        )
+        cur.close()
+
+        resp = client.post(
+            "/api/picking/complete-batch",
+            json={"batch_id": batch_id},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        err = resp.get_json()["error"].lower()
+        assert "under-picked" in err or "short-close marker" in err
+
+    def test_complete_batch_allows_legitimate_short(self, client, auth_headers):
+        """Layer 2A: explicit SHORT picks (via /api/picking/short) are a
+        legitimate close-out path and must still allow batch completion."""
+        create_resp = _create_batch(client, auth_headers)
+        batch_id = create_resp.get_json()["batch_id"]
+
+        # Short the first pending task; pick the rest.
+        first = client.get(f"/api/picking/batch/{batch_id}/next", headers=auth_headers).get_json()
+        client.post(
+            "/api/picking/short",
+            json={"pick_task_id": first["pick_task_id"], "quantity_available": 0},
+            headers=auth_headers,
+        )
+        # Pick remaining tasks normally
+        while True:
+            nx = client.get(f"/api/picking/batch/{batch_id}/next", headers=auth_headers).get_json()
+            if "message" in nx:
+                break
+            client.post(
+                "/api/picking/confirm",
+                json={
+                    "pick_task_id": nx["pick_task_id"],
+                    "scanned_barcode": nx["upc"],
+                    "quantity_picked": nx["quantity_to_pick"],
+                },
+                headers=auth_headers,
+            )
+
+        resp = client.post(
+            "/api/picking/complete-batch",
+            json={"batch_id": batch_id},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+
+class TestInsufficientCoverage:
+    """Layer 1: refuses to create a batch when any SO can't be fully
+    allocated from pickable inventory; second call with exclude_so_ids
+    drops those SOs and commits the remainder."""
+
+    def _create_so_with_unmet_demand(self, so_number, item_id, qty):
+        """Insert an OPEN SO whose single line orders more units of `item_id`
+        than the warehouse has in pickable bins. Returns the new so_id."""
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """INSERT INTO sales_orders (so_number, so_barcode, customer_name, status, warehouse_id, created_by, external_id)
+               VALUES (%s, %s, %s, 'OPEN', 1, 'admin', gen_random_uuid()) RETURNING so_id""",
+            (so_number, so_number, "Coverage Test Customer"),
+        )
+        so_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO sales_order_lines (so_id, item_id, quantity_ordered, line_number) VALUES (%s, %s, %s, 1)",
+            (so_id, item_id, qty),
+        )
+        cur.close()
+        return so_id
+
+    def test_create_batch_409_when_inventory_insufficient(self, client, auth_headers):
+        so_id = self._create_so_with_unmet_demand("SO-SHORT-1", item_id=5, qty=9999)
+        resp = client.post(
+            "/api/picking/create-batch",
+            json={"so_identifiers": ["SO-SHORT-1"], "warehouse_id": 1},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 409
+        data = resp.get_json()
+        assert data["error_type"] == "insufficient_coverage"
+        assert any(e["so_id"] == so_id for e in data["unpickable"])
+
+    def test_create_batch_exclude_drops_unpickable(self, client, auth_headers):
+        unpickable_so = self._create_so_with_unmet_demand("SO-SHORT-2", item_id=5, qty=9999)
+        resp = client.post(
+            "/api/picking/create-batch",
+            json={
+                "so_identifiers": ["SO-2026-001", "SO-SHORT-2"],
+                "warehouse_id": 1,
+                "exclude_so_ids": [unpickable_so],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # Only the pickable seed SO survives in the committed batch.
+        assert data["total_orders"] == 1
+        assert all(o["so_number"] == "SO-2026-001" for o in data["orders"])
+
 
 # --- Zone/Aisle Conditional Display Tests ---
 

--- a/api/tests/test_shipping.py
+++ b/api/tests/test_shipping.py
@@ -287,6 +287,44 @@ class TestFulfill:
         assert resp.status_code == 400
         assert resp.get_json()["error"] == "validation_error"
 
+    def test_fulfill_refuses_silently_under_picked(self, client, auth_headers):
+        """Layer 2C: refuses to ship when any SO line has quantity_picked <
+        quantity_ordered without a short-close marker. The historical
+        record_ship() silently omitted unpicked lines (filtered
+        quantity_picked > 0), letting customers receive short shipments
+        with no in-system trace."""
+        so_id = _advance_so_to_packed(client, auth_headers, "SO-2026-001")
+
+        # Simulate the under-allocation residue: a line stuck at picked=0
+        # with no SHORT pick_task and no wave_pick_breakdown.short_quantity.
+        # We also reset quantity_packed = 0 so the (independent) pack-side
+        # state doesn't matter; only the ship guard is on trial here.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_order_lines SET quantity_picked = 0, quantity_packed = 0 "
+            "WHERE so_line_id = (SELECT MIN(so_line_id) FROM sales_order_lines WHERE so_id = %s)",
+            (so_id,),
+        )
+        cur.close()
+
+        resp = client.post(
+            "/api/shipping/fulfill",
+            json={
+                "so_id": so_id,
+                "tracking_number": "1ZNOSHIP",
+                "carrier": "UPS",
+                "ship_method": "GROUND",
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        err = resp.get_json()["error"].lower()
+        assert "under-picked" in err or "short-close marker" in err
+        # SO must not have been promoted to SHIPPED.
+        status = _query_val("SELECT status FROM sales_orders WHERE so_id = %s", (so_id,))
+        assert status != "SHIPPED"
+
 
 # ── Order Lookup Validation ──────────────────────────────────────────────────
 

--- a/api/tests/test_wave_picking.py
+++ b/api/tests/test_wave_picking.py
@@ -208,8 +208,12 @@ def test_wave_create_allocation(client, auth_headers, seed_data):
 
 
 def test_wave_create_partial_inventory(client, auth_headers):
-    """Insufficient inventory creates warning but batch still proceeds."""
-    # Create SO needing more than available
+    """Insufficient inventory blocks batch creation with 409 insufficient_coverage.
+
+    Replaces the prior "warning + proceed" behaviour that silently
+    under-allocated lines, letting SOs ship short. See picking-optimization
+    PR + InsufficientCoverageError docstring.
+    """
     so_id = _create_extra_so("SO-BIG", "Big Customer", [(5, 999)])  # item 5 only has 25 in stock
 
     resp = client.post(
@@ -217,11 +221,47 @@ def test_wave_create_partial_inventory(client, auth_headers):
         json={"so_ids": [so_id], "warehouse_id": 1},
         headers=auth_headers,
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 409
     data = resp.get_json()
-    assert "warnings" in data
-    assert data["warnings"][0]["needed"] == 999
-    assert data["warnings"][0]["available"] < 999
+    assert data["error_type"] == "insufficient_coverage"
+    assert len(data["unpickable"]) == 1
+    entry = data["unpickable"][0]
+    assert entry["so_id"] == so_id
+    assert entry["so_number"] == "SO-BIG"
+    assert any(ln["ordered"] == 999 for ln in entry["lines"])
+
+
+def test_wave_create_exclude_so_ids_drops_unpickable(client, auth_headers, seed_data):
+    """Picker accepts the modal: second call with exclude_so_ids commits the
+    pickable subset and returns 200."""
+    # Mix one pickable (seed SO) + one unpickable SO
+    pickable_so = seed_data["so_ids"][0]
+    unpickable_so = _create_extra_so("SO-DROPME", "Drop Customer", [(5, 999)])
+
+    # First call: should 409
+    resp = client.post(
+        "/api/picking/wave-create",
+        json={"so_ids": [pickable_so, unpickable_so], "warehouse_id": 1},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 409
+    assert resp.get_json()["error_type"] == "insufficient_coverage"
+
+    # Second call with the unpickable SO excluded: should 200
+    resp2 = client.post(
+        "/api/picking/wave-create",
+        json={
+            "so_ids": [pickable_so, unpickable_so],
+            "warehouse_id": 1,
+            "exclude_so_ids": [unpickable_so],
+        },
+        headers=auth_headers,
+    )
+    assert resp2.status_code == 200
+    data = resp2.get_json()
+    assert data["total_orders"] == 1
+    # The committed batch contains only the pickable SO
+    assert all(o["so_id"] != unpickable_so for o in data["orders"])
 
 
 def test_wave_create_duplicate_so(client, auth_headers, seed_data):
@@ -516,9 +556,13 @@ def test_wave_pick_to_pack_flow(client, auth_headers):
 
 
 def test_wave_pick_with_shorts_to_pack(client, auth_headers):
-    """Wave pick with short picks still allows packing with adjusted quantities."""
-    so1 = _create_extra_so("SO-SHRT-1", "Cust 1", [(5, 10)])  # item 5, only 25 in stock
-    so2 = _create_extra_so("SO-SHRT-2", "Cust 2", [(5, 20)])  # needs 20 more, total 30 > 25
+    """Wave pick with operator-confirmed short picks still completes the
+    batch. The short_pick path leaves a wave_pick_breakdown.short_quantity
+    marker that the complete_batch Layer 2A guard recognises as a
+    legitimate close-out, so the SO can still move to PICKED."""
+    # Two SOs that fully fit (item 5 has 25 in stock; demand totals 10).
+    so1 = _create_extra_so("SO-SHRT-1", "Cust 1", [(5, 6)])
+    so2 = _create_extra_so("SO-SHRT-2", "Cust 2", [(5, 4)])
 
     resp = client.post(
         "/api/picking/wave-create",
@@ -529,35 +573,39 @@ def test_wave_pick_with_shorts_to_pack(client, auth_headers):
     data = resp.get_json()
     batch_id = data["batch_id"]
 
-    # There should be a warning about insufficient inventory
-    assert "warnings" in data
+    # First wave task: short-pick at half the requested quantity. This
+    # leaves wave_pick_breakdown rows with short_quantity > 0 - the
+    # explicit operator-confirmed shortfall marker.
+    first = client.get(f"/api/picking/batch/{batch_id}/next", headers=auth_headers).get_json()
+    short_resp = client.post(
+        "/api/picking/short",
+        json={"pick_task_id": first["pick_task_id"], "quantity_available": first["quantity_to_pick"] // 2},
+        headers=auth_headers,
+    )
+    assert short_resp.status_code == 200
 
-    # Pick what's available (with short)
+    # Pick everything else normally.
     while True:
-        next_resp = client.get(f"/api/picking/batch/{batch_id}/next", headers=auth_headers)
-        next_data = next_resp.get_json()
-        if "message" in next_data:
+        nx = client.get(f"/api/picking/batch/{batch_id}/next", headers=auth_headers).get_json()
+        if "message" in nx:
             break
-        # Confirm with actual quantity (may be less than needed due to allocation cap)
         client.post(
             "/api/picking/confirm",
             json={
-                "pick_task_id": next_data["pick_task_id"],
-                "scanned_barcode": next_data["upc"],
-                "quantity_picked": next_data["quantity_to_pick"],
+                "pick_task_id": nx["pick_task_id"],
+                "scanned_barcode": nx["upc"],
+                "quantity_picked": nx["quantity_to_pick"],
             },
             headers=auth_headers,
         )
 
-    # Complete batch
-    resp = client.post(
+    complete_resp = client.post(
         "/api/picking/complete-batch",
         json={"batch_id": batch_id},
         headers=auth_headers,
     )
-    assert resp.status_code == 200
+    assert complete_resp.status_code == 200, complete_resp.get_json()
 
-    # Both SOs should be PICKED status (ready for packing)
     conn = get_raw_connection()
     cur = conn.cursor()
     cur.execute("SELECT status FROM sales_orders WHERE so_id = %s", (so1,))

--- a/mobile/src/components/UnpickableOrdersModal.js
+++ b/mobile/src/components/UnpickableOrdersModal.js
@@ -1,0 +1,137 @@
+import React from 'react';
+import { Modal, View, Text, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
+import { colors, fonts, radii } from '../theme/styles';
+
+export default function UnpickableOrdersModal({ visible, unpickable, onCancel, onContinue }) {
+  const count = unpickable?.length || 0;
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={styles.overlay}>
+        <View style={styles.card}>
+          <Text style={styles.title}>INSUFFICIENT STOCK</Text>
+          <Text style={styles.body}>
+            {count === 1 ? '1 order does' : `${count} orders do`} not have pickable
+            stock in this warehouse. Continue to pick the orders that are ready to
+            be fulfilled, or cancel to adjust the batch.
+          </Text>
+
+          <ScrollView style={styles.list} contentContainerStyle={{ paddingBottom: 8 }}>
+            {(unpickable || []).map((so) => (
+              <View key={so.so_id} style={styles.soBlock}>
+                <Text style={styles.soNumber}>{so.so_number}</Text>
+                {(so.lines || []).map((ln, idx) => (
+                  <Text key={`${so.so_id}-${idx}`} style={styles.lineRow}>
+                    {ln.sku} · ordered {ln.ordered} · available {ln.available}
+                  </Text>
+                ))}
+              </View>
+            ))}
+          </ScrollView>
+
+          <View style={styles.buttonRow}>
+            <TouchableOpacity style={[styles.button, styles.buttonCancel]} onPress={onCancel}>
+              <Text style={styles.buttonCancelText}>CANCEL</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.button, styles.buttonContinue]} onPress={onContinue}>
+              <Text style={styles.buttonContinueText}>CONTINUE</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: colors.overlay,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  card: {
+    backgroundColor: colors.background,
+    borderRadius: radii.card,
+    borderWidth: 1.5,
+    borderColor: colors.accentRed,
+    padding: 20,
+    width: '100%',
+    maxWidth: 420,
+    maxHeight: '85%',
+  },
+  title: {
+    fontFamily: fonts.mono,
+    fontSize: 14,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    color: colors.accentRed,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 13,
+    color: colors.textPrimary,
+    textAlign: 'center',
+    lineHeight: 19,
+    marginBottom: 12,
+  },
+  list: {
+    maxHeight: 320,
+    marginBottom: 12,
+  },
+  soBlock: {
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border || '#333',
+  },
+  soNumber: {
+    fontFamily: fonts.mono,
+    fontSize: 13,
+    fontWeight: '700',
+    color: colors.textPrimary,
+    marginBottom: 4,
+  },
+  lineRow: {
+    fontFamily: fonts.mono,
+    fontSize: 12,
+    color: colors.textMuted,
+    paddingLeft: 8,
+    lineHeight: 17,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  button: {
+    flex: 1,
+    borderRadius: radii.button,
+    paddingVertical: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
+  },
+  buttonCancel: {
+    backgroundColor: 'transparent',
+    borderWidth: 1.5,
+    borderColor: colors.textMuted,
+  },
+  buttonCancelText: {
+    color: colors.textMuted,
+    fontFamily: fonts.mono,
+    fontSize: 13,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+  buttonContinue: {
+    backgroundColor: colors.accentRed,
+  },
+  buttonContinueText: {
+    color: colors.cream,
+    fontFamily: fonts.mono,
+    fontSize: 13,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+});

--- a/mobile/src/screens/PickScanScreen.js
+++ b/mobile/src/screens/PickScanScreen.js
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, ActivityIndicator, StyleSheet } from 'rea
 import ScanInput from '../components/ScanInput';
 import ErrorPopup from '../components/ErrorPopup';
 import PagedList from '../components/PagedList';
+import UnpickableOrdersModal from '../components/UnpickableOrdersModal';
 import useScreenError from '../hooks/useScreenError';
 import { useAuth } from '../auth/AuthContext';
 import client from '../api/client';
@@ -14,6 +15,9 @@ export default function PickScanScreen({ navigation }) {
   const [orders, setOrders] = useState([]);
   const { error, scanDisabled, showError, clearError } = useScreenError();
   const [loading, setLoading] = useState(false);
+  // Unpickable list returned by the backend's 409 insufficient_coverage
+  // response. Non-null while the modal is visible.
+  const [unpickable, setUnpickable] = useState(null);
 
   const handleScan = async (barcode) => {
     // Client-side duplicate check
@@ -52,22 +56,65 @@ export default function PickScanScreen({ navigation }) {
     setOrders((prev) => prev.filter((o) => o.so_id !== so_id));
   };
 
+  const submitBatch = async (excludeSoIds = []) => {
+    const resp = await client.post('/api/picking/wave-create', {
+      so_ids: orders.map((o) => o.so_id),
+      warehouse_id: warehouseId,
+      exclude_so_ids: excludeSoIds.length ? excludeSoIds : undefined,
+    });
+    return resp;
+  };
+
   const handleLoadAll = async () => {
     if (orders.length === 0) return;
     setLoading(true);
     try {
-      const resp = await client.post('/api/picking/wave-create', {
-        so_ids: orders.map((o) => o.so_id),
-        warehouse_id: warehouseId,
-      });
+      const resp = await submitBatch();
       navigation.replace('PickWalk', {
         batch_id: resp.data.batch_id,
         batch: resp.data,
       });
     } catch (err) {
-      showError(err.response?.data?.error || 'Failed to create batch');
+      const data = err.response?.data;
+      if (err.response?.status === 409 && data?.error_type === 'insufficient_coverage') {
+        setUnpickable(data.unpickable || []);
+        setLoading(false);
+        return;
+      }
+      showError(data?.error || 'Failed to create batch');
       setLoading(false);
     }
+  };
+
+  const handleContinueDrop = async () => {
+    const excluded = (unpickable || []).map((so) => so.so_id);
+    const excludedSet = new Set(excluded);
+    setUnpickable(null);
+    setLoading(true);
+    try {
+      const resp = await submitBatch(excluded);
+      // Drop the excluded SOs from the local picker list so the user
+      // doesn't see them as still-scanned on a back-navigation.
+      setOrders((prev) => prev.filter((o) => !excludedSet.has(o.so_id)));
+      navigation.replace('PickWalk', {
+        batch_id: resp.data.batch_id,
+        batch: resp.data,
+      });
+    } catch (err) {
+      const data = err.response?.data;
+      if (err.response?.status === 409 && data?.error_type === 'insufficient_coverage') {
+        // Another batch took more stock between calls; surface the new list.
+        setUnpickable(data.unpickable || []);
+        setLoading(false);
+        return;
+      }
+      showError(data?.error || 'Failed to create batch');
+      setLoading(false);
+    }
+  };
+
+  const handleCancelDrop = () => {
+    setUnpickable(null);
   };
 
   if (loading) {
@@ -138,6 +185,13 @@ export default function PickScanScreen({ navigation }) {
         visible={!!error}
         message={error}
         onDismiss={clearError}
+      />
+
+      <UnpickableOrdersModal
+        visible={!!unpickable}
+        unpickable={unpickable}
+        onCancel={handleCancelDrop}
+        onContinue={handleContinueDrop}
       />
     </View>
   );


### PR DESCRIPTION
## Summary

The picking flow gains a layered defense against the historical under-allocation bug, where a sales order could be batched, picked, packed, and shipped with `quantity_picked < quantity_ordered` and no in-system trace -- a line that never got a `pick_task` had zero pending tasks, zero picked tasks, and a `quantity_picked` stuck at 0, yet rode the SO header through PICKED -> PACKED -> SHIPPED. Four guards now make that impossible, and the mobile picker surfaces the pre-flight rejection so the operator can drop the unpickable orders and continue with the rest.

- `feat(picking): refuse under-allocated batch creation` -- a pre-flight coverage check in `create_pick_batch` and `wave_create` runs inside the same transaction as the `FOR UPDATE` inventory locks. If any SO in the input cannot be fully covered by pickable inventory, the helper walks contributors FIFO (by `so_id`, `so_line_id`) to identify which SOs would be short, rolls back any partial state, and raises `InsufficientCoverageError` carrying a structured per-SO shortfall list. The routes translate that into HTTP 409 `error_type: insufficient_coverage` with an `unpickable[]` payload of `{so_id, so_number, lines:[{sku, item_name, ordered, available}]}`. Both endpoints accept an optional `exclude_so_ids` list so the client's second call (after the operator accepts the modal) commits the pickable subset. Replaces the historical "log a warning and proceed" path in `wave_create` that let SOs ship under-allocated.
- `feat(picking): line-level fulfillment guard at batch complete` -- Layer 2A. `complete_batch`'s existing pending-task count only verifies that `pick_tasks` reached a terminal state, not that every line was covered; a line with no `pick_task` at all has zero pending tasks and trivially passes. A second guard refuses to flip the batch's SOs to PICKED if any line has `quantity_picked < quantity_ordered` without an operator-confirmed shortfall marker -- `pick_tasks.status = SHORT` on a task for the line, or `wave_pick_breakdown.short_quantity > 0` (wave picks fan one task across many SO lines). Legitimate shorts via `/api/picking/short` still complete normally.
- `feat(pack+ship): refuse under-picked lines at status promotion` -- Layers 2B and 2C mirror 2A at the next two promotions. `complete_packing`'s unverified-items check only catches `packed < picked`, so a `picked = 0` line passes trivially; it now runs the same silently-short query before promoting to PACKED. `record_ship` runs it before the fulfillment INSERT and raises `ValueError`, which the `ship_order` (dockd) and `fulfill` (shipping) routes catch and return as 400 `line_under_picked` after a rollback, so a refused ship leaves no fulfillment row.
- `feat(mobile): surface unpickable orders modal in picker flow` -- the picker's wave-validate call now handles the 409 by presenting `UnpickableOrdersModal` (per-SO short lines with sku / ordered / available); accepting re-submits with the unpickable `so_id`s in `exclude_so_ids` so the coverable subset proceeds.
- `test(picking,pack,ship): cover under-allocation prevention layers` -- coverage across all four layers: the pre-flight 409 plus the `exclude_so_ids` retry, the batch / pack / ship guards rejecting silently-short lines, and the SHORT / `wave_pick_breakdown` markers letting legitimate shorts through.

## Mobile

`UnpickableOrdersModal.js` (new) and `PickScanScreen.js`. No native module changes, but the modal ships in the JS bundle, so this release needs an APK rebuild.

## Pre-merge gate

- [x] Full api suite green locally (2438 passed, 9 skipped; the 2 psql-host suites run only in CI); mobile vitest 32/32; no admin diffs
- [ ] CI green
