### PR TITLE
feat(picking): wave-validate accepts transfer-order scans

### DIFF
--- a/api/routes/picking.py
+++ b/api/routes/picking.py
@@ -128,15 +128,16 @@ def create_batch(validated):
 @validate_body(WaveValidateRequest)
 @with_db
 def validate_so(validated):
-    result = wave_validate(g.db, validated.so_barcode, validated.warehouse_id)
+    result = wave_validate(
+        g.db,
+        validated.barcode,
+        validated.warehouse_id,
+        username=g.current_user["username"],
+    )
     if result.get("valid"):
         return jsonify(result)
-    # Determine status code based on error type
-    if "already in active pick batch" in result.get("error", ""):
-        return jsonify(result), 409
-    if "not found" in result.get("error", ""):
-        return jsonify(result), 404
-    return jsonify(result), 400
+    status = result.get("status_code", 400)
+    return jsonify(result), status
 
 
 @picking_bp.route("/wave-create", methods=["POST"])

--- a/api/schemas/pick_walks.py
+++ b/api/schemas/pick_walks.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class CreateBatchRequest(BaseModel):
@@ -14,7 +14,13 @@ class CreateBatchRequest(BaseModel):
 
 
 class WaveValidateRequest(BaseModel):
-    so_barcode: str = Field(..., min_length=1, max_length=128)
+    # The scan input is barcode-shaped (could be SO number, SO barcode,
+    # or transfer-order number), so the field is named `barcode`. The
+    # original `so_barcode` name stays accepted via alias for older
+    # mobile builds still in the field.
+    model_config = ConfigDict(populate_by_name=True)
+
+    barcode: str = Field(..., min_length=1, max_length=128, alias="so_barcode")
     warehouse_id: int = Field(..., gt=0)
 
 

--- a/api/services/picking_service.py
+++ b/api/services/picking_service.py
@@ -1055,8 +1055,17 @@ def complete_batch(db, batch_id, username):
 # --- Wave Picking ---
 
 
-def wave_validate(db, so_barcode, warehouse_id):
-    """Validate an SO barcode for wave picking. Lightweight check, no allocation."""
+def wave_validate(db, barcode, warehouse_id, username=None):
+    """Validate a scanned barcode for the pick screen. Lightweight check,
+    no allocation. Recognizes both sales-order numbers/barcodes and
+    transfer-order numbers; the response carries a `kind` discriminator
+    ('SO' or 'TO') so the caller can route appropriately.
+
+    `username` is required to resolve the TO assignment check; SO paths
+    ignore it. Returns `{valid, ...}` on success and
+    `{valid: False, error, status_code}` on failure (the route honors
+    `status_code` for the HTTP response).
+    """
     so = db.execute(
         text(
             """
@@ -1067,20 +1076,27 @@ def wave_validate(db, so_barcode, warehouse_id):
             LIMIT 1
             """
         ),
-        {"barcode": so_barcode, "wh": warehouse_id},
+        {"barcode": barcode, "wh": warehouse_id},
     ).fetchone()
 
-    if not so:
-        # --- FUTURE: ERP Connector Hook ---
-        # If a connector is configured, attempt to pull the SO:
-        #   result = enrich_order(so_barcode, warehouse_id)
-        #   if result: re-query DB and continue
-        # For now, return "Order not found" immediately.
-        # --- END FUTURE HOOK ---
-        return {"valid": False, "error": "Order not found"}
+    if so:
+        return _validate_so(db, so)
 
-    if so.status not in (SO_OPEN,):
-        # Check if already in an active pick batch
+    to_result = _validate_to(db, barcode, warehouse_id, username)
+    if to_result is not None:
+        return to_result
+
+    # --- FUTURE: ERP Connector Hook ---
+    # If a connector is configured, attempt to pull the SO:
+    #   result = enrich_order(barcode, warehouse_id)
+    #   if result: re-query DB and continue
+    # For now, return "Order not found" immediately.
+    # --- END FUTURE HOOK ---
+    return {"valid": False, "error": "Order not found", "status_code": 404}
+
+
+def _validate_so(db, so):
+    if so.status != SO_OPEN:
         active_batch = db.execute(
             text(
                 """
@@ -1093,13 +1109,19 @@ def wave_validate(db, so_barcode, warehouse_id):
             ),
             {"so_id": so.so_id, "batch_open": BATCH_OPEN, "batch_in_progress": BATCH_IN_PROGRESS},
         ).fetchone()
-
         if active_batch:
-            return {"valid": False, "error": "Order already in active pick batch", "batch_id": active_batch.batch_id}
+            return {
+                "valid": False,
+                "error": "Order already in active pick batch",
+                "batch_id": active_batch.batch_id,
+                "status_code": 409,
+            }
+        return {
+            "valid": False,
+            "error": f"Order status is {so.status}, must be OPEN",
+            "status_code": 400,
+        }
 
-        return {"valid": False, "error": f"Order status is {so.status}, must be OPEN"}
-
-    # Check if already in an active batch even if OPEN (edge case)
     active_batch = db.execute(
         text(
             """
@@ -1112,11 +1134,14 @@ def wave_validate(db, so_barcode, warehouse_id):
         ),
         {"so_id": so.so_id, "batch_open": BATCH_OPEN, "batch_in_progress": BATCH_IN_PROGRESS},
     ).fetchone()
-
     if active_batch:
-        return {"valid": False, "error": "Order already in active pick batch", "batch_id": active_batch.batch_id}
+        return {
+            "valid": False,
+            "error": "Order already in active pick batch",
+            "batch_id": active_batch.batch_id,
+            "status_code": 409,
+        }
 
-    # Get line count and total units
     line_stats = db.execute(
         text(
             """
@@ -1128,12 +1153,106 @@ def wave_validate(db, so_barcode, warehouse_id):
     ).fetchone()
 
     if line_stats.line_count == 0:
-        return {"valid": False, "error": "Order has no items"}
+        return {"valid": False, "error": "Order has no items", "status_code": 400}
 
     return {
         "valid": True,
+        "kind": "SO",
         "so_id": so.so_id,
         "so_number": so.so_number,
+        "line_count": line_stats.line_count,
+        "total_units": line_stats.total_units,
+    }
+
+
+def _validate_to(db, barcode, warehouse_id, username):
+    """Resolve a scanned barcode against transfer_orders. Returns None
+    when the barcode is not a known TO at this warehouse so the caller
+    can fall through to "not found". Returns a result dict otherwise.
+
+    A TO is scannable from the pick screen only when:
+      - status is OPEN or PARTIALLY_PICKED (other statuses are explicit)
+      - a pick_batch has been provisioned via start-picking
+      - the batch is assigned to the caller (username), so two pickers
+        cannot stomp on the same batch
+    """
+    to = db.execute(
+        text(
+            """
+            SELECT to_id, to_number, status, source_warehouse_id
+              FROM transfer_orders
+             WHERE to_number = :barcode
+               AND source_warehouse_id = :wh
+             LIMIT 1
+            """
+        ),
+        {"barcode": barcode, "wh": warehouse_id},
+    ).fetchone()
+    if not to:
+        return None
+
+    if to.status not in ("OPEN", "PARTIALLY_PICKED"):
+        return {
+            "valid": False,
+            "error": f"Transfer order status is {to.status}",
+            "to_number": to.to_number,
+            "to_status": to.status,
+            "status_code": 409,
+        }
+
+    batch = db.execute(
+        text(
+            """
+            SELECT DISTINCT pb.batch_id, pb.batch_number, pb.assigned_to,
+                            pb.status AS batch_status
+              FROM pick_tasks pt
+              JOIN pick_batches pb ON pb.batch_id = pt.batch_id
+             WHERE pt.to_id = :tid
+               AND pb.status IN (:b_open, :b_inprog)
+             ORDER BY pb.batch_id DESC
+             LIMIT 1
+            """
+        ),
+        {"tid": to.to_id, "b_open": BATCH_OPEN, "b_inprog": BATCH_IN_PROGRESS},
+    ).fetchone()
+    if not batch:
+        return {
+            "valid": False,
+            "error": "Transfer order not started -- ask admin to start picking",
+            "to_number": to.to_number,
+            "status_code": 409,
+        }
+
+    if username is not None and batch.assigned_to != username:
+        return {
+            "valid": False,
+            "error": f"Transfer order is assigned to {batch.assigned_to}",
+            "to_number": to.to_number,
+            "batch_id": batch.batch_id,
+            "assigned_to": batch.assigned_to,
+            "status_code": 409,
+        }
+
+    line_stats = db.execute(
+        text(
+            """
+            SELECT COUNT(*) AS line_count,
+                   COALESCE(SUM(committed_qty), 0) AS total_units
+              FROM transfer_order_lines
+             WHERE to_id = :tid
+               AND status IN ('PENDING', 'PARTIALLY_PICKED')
+            """
+        ),
+        {"tid": to.to_id},
+    ).fetchone()
+
+    return {
+        "valid": True,
+        "kind": "TO",
+        "to_id": to.to_id,
+        "to_number": to.to_number,
+        "batch_id": batch.batch_id,
+        "batch_number": batch.batch_number,
         "line_count": line_stats.line_count,
         "total_units": line_stats.total_units,
     }

--- a/api/tests/test_wave_picking.py
+++ b/api/tests/test_wave_picking.py
@@ -134,6 +134,176 @@ def test_validate_so_no_items(client, auth_headers):
     assert "no items" in data["error"].lower()
 
 
+def test_validate_accepts_new_barcode_field(client, auth_headers):
+    """The renamed `barcode` field works alongside the legacy `so_barcode`
+    alias. Mobile builds shipped after the rename use `barcode`."""
+    resp = client.post(
+        "/api/picking/wave-validate",
+        json={"barcode": "SO-2026-001", "warehouse_id": 1},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is True
+    assert data["kind"] == "SO"
+    assert data["so_number"] == "SO-2026-001"
+
+
+# --- TO Validation Tests ---
+
+
+def _create_to(to_number, source_warehouse_id=1, dest_warehouse_id=2,
+               status="OPEN", lines=None):
+    """Insert a transfer_orders header + lines. `lines` is a list of
+    (item_id, committed_qty) tuples; default = [(1, 2)]."""
+    if lines is None:
+        lines = [(1, 2)]
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """INSERT INTO transfer_orders
+              (to_number, source_warehouse_id, destination_warehouse_id,
+               status, created_by, external_id)
+           VALUES (%s, %s, %s, %s, 'admin', gen_random_uuid())
+           RETURNING to_id""",
+        (to_number, source_warehouse_id, dest_warehouse_id, status),
+    )
+    to_id = cur.fetchone()[0]
+    line_ids = []
+    for idx, (item_id, committed_qty) in enumerate(lines, 1):
+        cur.execute(
+            """INSERT INTO transfer_order_lines
+                  (to_id, item_id, line_number, requested_qty,
+                   committed_qty, status)
+               VALUES (%s, %s, %s, %s, %s, 'PENDING')
+               RETURNING to_line_id""",
+            (to_id, item_id, idx, committed_qty, committed_qty),
+        )
+        line_ids.append(cur.fetchone()[0])
+    cur.close()
+    return to_id, line_ids
+
+
+def _provision_to_batch(to_id, to_line_ids, assigned_to="admin",
+                        warehouse_id=1, bin_id=2):
+    """Create a pick_batches row + pick_tasks for a TO, matching what
+    admin start-picking would do."""
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """INSERT INTO pick_batches
+              (batch_number, warehouse_id, status, assigned_to)
+           VALUES (%s, %s, 'OPEN', %s) RETURNING batch_id""",
+        (f"BATCH-TO-TEST-{to_id}", warehouse_id, assigned_to),
+    )
+    batch_id = cur.fetchone()[0]
+    for seq, to_line_id in enumerate(to_line_ids, 1):
+        cur.execute(
+            """SELECT item_id, committed_qty FROM transfer_order_lines
+                WHERE to_line_id = %s""",
+            (to_line_id,),
+        )
+        item_id, qty = cur.fetchone()
+        cur.execute(
+            """INSERT INTO pick_tasks
+                  (batch_id, to_id, to_line_id, item_id, bin_id,
+                   quantity_to_pick, pick_sequence, status)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, 'PENDING')""",
+            (batch_id, to_id, to_line_id, item_id, bin_id, qty, seq),
+        )
+    cur.close()
+    return batch_id
+
+
+def test_validate_to_happy_path(client, auth_headers):
+    """A TO assigned to the caller with a provisioned batch returns
+    valid=true, kind=TO, with batch_id ready for PickWalk."""
+    to_id, line_ids = _create_to("TO-HAPPY-1", lines=[(1, 2)])
+    batch_id = _provision_to_batch(to_id, line_ids)
+
+    resp = client.post(
+        "/api/picking/wave-validate",
+        json={"barcode": "TO-HAPPY-1", "warehouse_id": 1},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is True
+    assert data["kind"] == "TO"
+    assert data["to_id"] == to_id
+    assert data["to_number"] == "TO-HAPPY-1"
+    assert data["batch_id"] == batch_id
+    assert data["line_count"] == 1
+    assert data["total_units"] == 2
+
+
+def test_validate_to_not_started(client, auth_headers):
+    """A TO with no pick_batch yet returns 409 with a clear error so the
+    operator knows to ask admin to start picking."""
+    _create_to("TO-NOTSTARTED")  # no batch provisioned
+
+    resp = client.post(
+        "/api/picking/wave-validate",
+        json={"barcode": "TO-NOTSTARTED", "warehouse_id": 1},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 409
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert "not started" in data["error"].lower()
+    assert data["to_number"] == "TO-NOTSTARTED"
+
+
+def test_validate_to_assigned_to_other_user(client, auth_headers):
+    """A TO whose batch is assigned to a different picker returns 409
+    naming that picker, so the scanner doesn't stomp on their work."""
+    to_id, line_ids = _create_to("TO-OTHERUSER")
+    _provision_to_batch(to_id, line_ids, assigned_to="someone_else")
+
+    resp = client.post(
+        "/api/picking/wave-validate",
+        json={"barcode": "TO-OTHERUSER", "warehouse_id": 1},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 409
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["assigned_to"] == "someone_else"
+
+
+def test_validate_to_wrong_warehouse(client, auth_headers):
+    """A TO at a different source warehouse is treated as not-found at
+    the scanner's warehouse (falls through to the 404 path)."""
+    to_id, line_ids = _create_to("TO-WRONGWH", source_warehouse_id=2,
+                                  dest_warehouse_id=1)
+    _provision_to_batch(to_id, line_ids, warehouse_id=2)
+
+    resp = client.post(
+        "/api/picking/wave-validate",
+        json={"barcode": "TO-WRONGWH", "warehouse_id": 1},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert "not found" in data["error"].lower()
+
+
+def test_validate_to_closed_status(client, auth_headers):
+    """A CLOSED TO returns 409 with the current status surfaced."""
+    _create_to("TO-CLOSED", status="CLOSED")
+
+    resp = client.post(
+        "/api/picking/wave-validate",
+        json={"barcode": "TO-CLOSED", "warehouse_id": 1},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 409
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["to_status"] == "CLOSED"
+
+
 # --- Wave Create Tests ---
 
 

--- a/mobile/src/screens/PickScanScreen.js
+++ b/mobile/src/screens/PickScanScreen.js
@@ -28,18 +28,35 @@ export default function PickScanScreen({ navigation }) {
 
     try {
       const resp = await client.post('/api/picking/wave-validate', {
-        so_barcode: barcode,
+        barcode,
         warehouse_id: warehouseId,
       });
-      if (resp.data.valid) {
-        setOrders((prev) => [...prev, {
-          so_id: resp.data.so_id,
-          so_number: resp.data.so_number,
-          so_barcode: barcode,
-          item_count: resp.data.line_count || resp.data.item_count || 0,
-          unit_count: resp.data.total_units || resp.data.unit_count || 0,
-        }]);
+      if (!resp.data.valid) return;
+
+      // Transfer orders are pre-provisioned single-shot batches (not
+      // wave-stackable with sales orders), so a TO scan jumps straight
+      // into PickWalk on the batch admin already started. Mixing types
+      // in one wave is not supported -- prompt the picker to drop any
+      // scanned SOs first.
+      if (resp.data.kind === 'TO') {
+        if (orders.length > 0) {
+          showError('Drop scanned sales orders before loading a transfer order');
+          return;
+        }
+        navigation.replace('PickWalk', {
+          batch_id: resp.data.batch_id,
+          batch: resp.data,
+        });
+        return;
       }
+
+      setOrders((prev) => [...prev, {
+        so_id: resp.data.so_id,
+        so_number: resp.data.so_number,
+        so_barcode: barcode,
+        item_count: resp.data.line_count || resp.data.item_count || 0,
+        unit_count: resp.data.total_units || resp.data.unit_count || 0,
+      }]);
     } catch (err) {
       const data = err.response?.data;
       if (err.response?.status === 409) {
@@ -144,7 +161,7 @@ export default function PickScanScreen({ navigation }) {
 
       <View style={screenStyles.content}>
         <View style={{ padding: 16, paddingBottom: 0 }}>
-          <ScanInput placeholder="SCAN SO" onScan={handleScan} disabled={scanDisabled} />
+          <ScanInput placeholder="SCAN SO OR TO" onScan={handleScan} disabled={scanDisabled} />
         </View>
 
         <View style={{ flex: 1, paddingHorizontal: 16 }}>


### PR DESCRIPTION
## Summary

The pick-screen scan input becomes polymorphic: it resolves sales orders and transfer orders through the same wave-validate call, with the caller routing on a returned `kind` discriminator.

- `feat(picking): wave-validate accepts transfer-order numbers` -- wave-validate looks up the scanned barcode against `sales_orders` first (existing behavior), then falls back to `transfer_orders`, and returns a `kind` discriminator (`SO` or `TO`) so the caller routes by type. A TO is scannable from the pick path only when its status is OPEN or PARTIALLY_PICKED, a `pick_batch` has been provisioned via admin start-picking, and that batch is `assigned_to` the caller (no cross-picker stomping); other states return 404 / 409 with a clear reason in the body. Error status codes are now driven by a `status_code` in the result dict rather than string-matching the error message. `WaveValidateRequest` renames `so_barcode` -> `barcode` with `populate_by_name` + `alias='so_barcode'`, so older mobile builds and the existing test suite keep working unchanged.
- `test(picking): wave-validate TO branches + back-compat coverage` -- TO happy path (assigned + provisioned returns valid, `kind=TO`, batch_id ready for PickWalk), TO with no `pick_batch` yet returns 409, TO assigned to a different picker returns 409 with that picker's name, TO at a different source warehouse returns 404 (no cross-warehouse leakage), TO in CLOSED status returns 409 with the current status, and the renamed `barcode` field works end to end alongside the legacy `so_barcode` alias the existing SO tests still use.
- `feat(mobile): pick screen accepts transfer-order scans` -- `PickScanScreen.handleScan` branches on the `kind` discriminator. SO scans behave exactly as before (added to the wave list); TO scans route straight into PickWalk on the batch admin already provisioned via start-picking, with no banner or separate screen. Transfer orders are not wave-stackable with sales orders, so a TO scan while SOs are already in the wave list prompts the picker to drop them first rather than silently overriding. The scan-input placeholder is now SCAN SO OR TO, and the request body uses the new `barcode` field.

## Mobile

`PickScanScreen.js` only. No native module changes, but the scan-handling change ships in the JS bundle, so this release needs an APK rebuild.

## Pre-merge gate

- [x] Full api suite green locally (2457 passed, 9 skipped; the 2 psql-host suites run only in CI); mobile vitest 32/32; no admin diffs
- [ ] CI green
