### PR TITLE
feat(admin): admin virtual pick for OPEN sales orders

### DIFF
--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -95,6 +95,15 @@ export default function SalesOrders() {
   const [editForm, setEditForm] = useState({});
   const [editError, setEditError] = useState('');
   const [confirmCancel, setConfirmCancel] = useState(false);
+  // Admin virtual-pick sub-modal: per-line list of {bin_id, quantity}
+  // entries. Two entries on the same line model a split-bin pick.
+  // adminPickBinsByLine caches the GET /available-bins response per
+  // so_line_id so the dropdowns render without a fetch on every keystroke.
+  const [adminPicking, setAdminPicking] = useState(null);
+  const [adminPickForm, setAdminPickForm] = useState({});
+  const [adminPickBinsByLine, setAdminPickBinsByLine] = useState({});
+  const [adminPickError, setAdminPickError] = useState('');
+  const [adminPickSubmitting, setAdminPickSubmitting] = useState(false);
   // so-refinement: backward status transition confirmation modal.
   // Carries { newStatus, pickTasks, keepIds, error, busy, mode }.
   // Checked rows (in keepIds) stay PICKED; unchecked rows release.
@@ -571,6 +580,117 @@ export default function SalesOrders() {
     else if (c.intent === 'delete') await commitRemoveLine(c.line);
   }
 
+  // Admin virtual pick. Seeds one empty entry per unpicked line so
+  // the operator only needs to fill the rows they want to pick now,
+  // then fetches available bins per line in parallel. The endpoint
+  // returns at most one entry per (line, bin) but the operator can
+  // add a second entry on the same line to split a pick across two
+  // bins -- bins remain reusable in the dropdown because the backend
+  // sums per-line + per-bin at submit time.
+  async function openAdminPick() {
+    const form = {};
+    const lineIds = [];
+    for (const line of editLines || []) {
+      const unpicked = (line.quantity_ordered || 0) - (line.quantity_picked || 0);
+      if (unpicked > 0) {
+        form[line.so_line_id] = [{ bin_id: '', quantity: '' }];
+        lineIds.push(line.so_line_id);
+      }
+    }
+    setAdminPickForm(form);
+    setAdminPickBinsByLine({});
+    setAdminPickError('');
+    setAdminPicking(editing);
+
+    const fetched = {};
+    await Promise.all(lineIds.map(async (solId) => {
+      const res = await api.get(
+        `/admin/sales-orders/${editing.so_id}/lines/${solId}/available-bins`,
+        { silentPermissionDenied: true },
+      );
+      if (res?.ok) {
+        const data = await res.json();
+        fetched[solId] = data.bins || [];
+      } else {
+        fetched[solId] = [];
+      }
+    }));
+    setAdminPickBinsByLine(fetched);
+  }
+
+  function closeAdminPick() {
+    setAdminPicking(null);
+    setAdminPickForm({});
+    setAdminPickBinsByLine({});
+    setAdminPickError('');
+    setAdminPickSubmitting(false);
+  }
+
+  function addAdminPickBin(solId) {
+    setAdminPickForm((prev) => ({
+      ...prev,
+      [solId]: [...(prev[solId] || []), { bin_id: '', quantity: '' }],
+    }));
+  }
+
+  function removeAdminPickBin(solId, idx) {
+    setAdminPickForm((prev) => {
+      const next = [...(prev[solId] || [])];
+      next.splice(idx, 1);
+      // Keep at least one row visible so the operator can re-add a
+      // bin without re-opening the modal; an empty row is harmless
+      // because the submit pass drops blanks before posting.
+      return { ...prev, [solId]: next.length ? next : [{ bin_id: '', quantity: '' }] };
+    });
+  }
+
+  function updateAdminPickField(solId, idx, field, value) {
+    setAdminPickForm((prev) => {
+      const next = [...(prev[solId] || [])];
+      next[idx] = { ...next[idx], [field]: value };
+      return { ...prev, [solId]: next };
+    });
+  }
+
+  async function submitAdminPick() {
+    setAdminPickError('');
+    const lines = [];
+    for (const [solId, entries] of Object.entries(adminPickForm)) {
+      for (const e of entries) {
+        const qty = parseInt(e.quantity, 10);
+        const binId = parseInt(e.bin_id, 10);
+        if (!e.bin_id || !binId || isNaN(qty) || qty <= 0) continue;
+        lines.push({
+          so_line_id: Number(solId),
+          bin_id: binId,
+          quantity: qty,
+        });
+      }
+    }
+    if (lines.length === 0) {
+      setAdminPickError('Pick at least one line: choose a bin and a quantity.');
+      return;
+    }
+    setAdminPickSubmitting(true);
+    try {
+      const res = await api.post(
+        `/admin/sales-orders/${adminPicking.so_id}/admin-pick`,
+        { lines },
+      );
+      if (!res?.ok) {
+        let data = null;
+        try { data = await res?.json(); } catch (_) { /* non-JSON */ }
+        setAdminPickError(formatApiError(data, 'Admin pick failed'));
+        return;
+      }
+      closeAdminPick();
+      closeEdit();
+      loadOrders();
+    } finally {
+      setAdminPickSubmitting(false);
+    }
+  }
+
   async function cancelSO() {
     setEditError('');
     const res = await api.post(`/admin/sales-orders/${editing.so_id}/cancel`, {});
@@ -766,6 +886,20 @@ export default function SalesOrders() {
               <>
                 {status === 'OPEN' && (
                   <button className="btn btn-danger" onClick={() => setConfirmCancel(true)}>Cancel Order</button>
+                )}
+                {/* Admin virtual pick: operator marks the SO picked
+                    without the handheld. Gated to OPEN + ADMIN-or-
+                    so-full-edit because the backend rejects every
+                    other shape. Mirrors the backend gate exactly so
+                    the button does not show when it would 403. */}
+                {status === 'OPEN' && (isAdmin || hasSOFullEdit) && (
+                  <button
+                    className="btn btn-warning"
+                    onClick={openAdminPick}
+                    title="Mark this order picked via admin (no handheld)"
+                  >
+                    Admin Pick
+                  </button>
                 )}
                 {/* so-refinement: shortcut to the release modal that
                     does not require flipping status first. Visible only
@@ -1116,6 +1250,139 @@ export default function SalesOrders() {
             Cancel this order? It will no longer appear in picking/shipping queues.
             This action cannot be undone from the UI.
           </p>
+        </Modal>
+      )}
+
+      {/* Admin virtual-pick sub-modal. Per-line bin dropdown + qty
+          input. The "+ bin" button adds a second {bin, qty} row to the
+          same line so the operator can split a pick across two bins in
+          one submit. Available-bins dropdown is sorted preferred-first
+          by the backend. Submit is all-or-nothing. */}
+      {adminPicking && (
+        <Modal
+          title={`Admin pick ${adminPicking.so_number}`}
+          onClose={closeAdminPick}
+          size="wide"
+          footer={
+            <>
+              <button className="btn" onClick={closeAdminPick} disabled={adminPickSubmitting}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-warning"
+                onClick={submitAdminPick}
+                disabled={adminPickSubmitting}
+              >
+                {adminPickSubmitting ? 'Picking...' : 'Pick'}
+              </button>
+            </>
+          }
+        >
+          {adminPickError && (
+            <div className="form-error" style={{ marginBottom: 12 }}>{adminPickError}</div>
+          )}
+          <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 12 }}>
+            Pick this order virtually -- the backend writes the same line
+            counters, inventory decrement, and audit row as a real pick.
+            Adds a synthetic pick task per entry so the existing Release
+            Picked Quantities modal can undo it later.
+          </p>
+          {Object.keys(adminPickForm).length === 0 ? (
+            <p style={{ fontSize: 13 }}>Every line is already fully picked.</p>
+          ) : (
+            <table className="data-table" style={{ marginBottom: 12 }}>
+              <thead>
+                <tr>
+                  <th>Line</th>
+                  <th>SKU</th>
+                  <th>Item</th>
+                  <th style={{ textAlign: 'right' }}>Ordered</th>
+                  <th style={{ textAlign: 'right' }}>Picked</th>
+                  <th>Bin</th>
+                  <th style={{ width: 100 }}>Qty</th>
+                  <th style={{ width: 100 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {(editLines || []).flatMap((line) => {
+                  const entries = adminPickForm[line.so_line_id];
+                  if (!entries) return [];
+                  const bins = adminPickBinsByLine[line.so_line_id] || [];
+                  const unpicked = (line.quantity_ordered || 0) - (line.quantity_picked || 0);
+                  return entries.map((entry, idx) => (
+                    <tr key={`${line.so_line_id}-${idx}`}>
+                      {idx === 0 ? (
+                        <>
+                          <td rowSpan={entries.length}>{line.line_number}</td>
+                          <td rowSpan={entries.length} className="mono">{line.sku}</td>
+                          <td rowSpan={entries.length}>{line.item_name}</td>
+                          <td rowSpan={entries.length} style={{ textAlign: 'right' }}>{line.quantity_ordered}</td>
+                          <td rowSpan={entries.length} style={{ textAlign: 'right' }}>{line.quantity_picked}</td>
+                        </>
+                      ) : null}
+                      <td>
+                        <select
+                          className="form-select"
+                          value={entry.bin_id}
+                          onChange={(e) => updateAdminPickField(
+                            line.so_line_id, idx, 'bin_id', e.target.value,
+                          )}
+                        >
+                          <option value="">- choose a bin -</option>
+                          {bins.map((b) => (
+                            <option key={b.bin_id} value={b.bin_id}>
+                              {b.bin_code}
+                              {b.zone_name ? ` (${b.zone_name})` : ''}
+                              {' '}- avail {b.quantity_available}
+                              {b.preferred_priority != null ? ' [pref]' : ''}
+                            </option>
+                          ))}
+                        </select>
+                        {bins.length === 0 && (
+                          <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginTop: 4 }}>
+                            No bins with available stock in this warehouse.
+                          </div>
+                        )}
+                      </td>
+                      <td>
+                        <input
+                          type="number"
+                          className="form-input"
+                          min={1}
+                          max={unpicked}
+                          step={1}
+                          value={entry.quantity}
+                          onChange={(e) => updateAdminPickField(
+                            line.so_line_id, idx, 'quantity', e.target.value,
+                          )}
+                          placeholder="0"
+                        />
+                      </td>
+                      <td>
+                        <div style={{ display: 'flex', gap: 4 }}>
+                          <button
+                            type="button"
+                            className="btn btn-sm"
+                            onClick={() => addAdminPickBin(line.so_line_id)}
+                            title="Pick remainder from a second bin"
+                          >+ bin</button>
+                          {entries.length > 1 && (
+                            <button
+                              type="button"
+                              className="btn btn-sm btn-danger"
+                              onClick={() => removeAdminPickBin(line.so_line_id, idx)}
+                              title="Drop this bin entry"
+                              aria-label="Remove entry"
+                            >&#10005;</button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ));
+                })}
+              </tbody>
+            </table>
+          )}
         </Modal>
       )}
 

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -881,6 +881,85 @@ def revert_sales_order_status(so_id, validated):
     })
 
 
+# Admin virtual pick: bin availability lookup for the admin-pick modal.
+#
+# Powers the per-line bin dropdown. Returns bins in the SO's warehouse
+# that hold the line's item with available stock (on_hand - allocated
+# > 0), sorted by preferred-bin priority first then bin_code. The
+# admin-pick POST also validates warehouse + availability on submit,
+# so a stale dropdown read doesn't corrupt the pick -- this endpoint
+# is purely for UX.
+
+
+@admin_bp.route(
+    "/sales-orders/<int:so_id>/lines/<int:so_line_id>/available-bins",
+    methods=["GET"],
+)
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@with_db
+def admin_pick_available_bins(so_id, so_line_id):
+    """List bins where the SO line's item has available stock.
+
+    Scope: bins in the same warehouse as the SO. Filter:
+    quantity_on_hand - quantity_allocated > 0. Order: preferred-bin
+    priority ascending (NULL LAST so non-preferred bins still appear),
+    then bin_code ascending for a stable tiebreaker.
+    """
+    so = g.db.execute(
+        text(
+            "SELECT s.warehouse_id, l.item_id "
+            "  FROM sales_orders s "
+            "  JOIN sales_order_lines l ON l.so_id = s.so_id "
+            " WHERE s.so_id = :sid AND l.so_line_id = :lid"
+        ),
+        {"sid": so_id, "lid": so_line_id},
+    ).fetchone()
+    if so is None:
+        return jsonify({
+            "error": "sales order line not found or not on this SO",
+        }), 404
+
+    rows = g.db.execute(
+        text(
+            """
+            SELECT b.bin_id, b.bin_code, z.zone_name,
+                   inv.quantity_on_hand, inv.quantity_allocated,
+                   (inv.quantity_on_hand - inv.quantity_allocated)
+                       AS quantity_available,
+                   pb.priority AS preferred_priority
+              FROM inventory inv
+              JOIN bins b   ON b.bin_id = inv.bin_id
+              JOIN zones z  ON z.zone_id = b.zone_id
+              LEFT JOIN preferred_bins pb
+                ON pb.item_id = inv.item_id AND pb.bin_id = inv.bin_id
+             WHERE inv.item_id = :iid
+               AND b.warehouse_id = :wh
+               AND inv.quantity_on_hand - inv.quantity_allocated > 0
+             ORDER BY pb.priority NULLS LAST, b.bin_code ASC
+            """
+        ),
+        {"iid": so.item_id, "wh": so.warehouse_id},
+    ).fetchall()
+
+    return jsonify({
+        "warehouse_id": so.warehouse_id,
+        "item_id": so.item_id,
+        "bins": [
+            {
+                "bin_id": r.bin_id,
+                "bin_code": r.bin_code,
+                "zone_name": r.zone_name,
+                "quantity_on_hand": r.quantity_on_hand,
+                "quantity_allocated": r.quantity_allocated,
+                "quantity_available": r.quantity_available,
+                "preferred_priority": r.preferred_priority,
+            }
+            for r in rows
+        ],
+    })
+
+
 # Admin virtual pick: operator-driven OPEN -> PICKED via real picks.
 #
 # The use case is the SO got picked physically but the digital pick never

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -34,6 +34,7 @@ from schemas.purchase_orders import CreatePurchaseOrderRequest, UpdatePurchaseOr
 from schemas.sales_orders import (
     ADDRESS_FIELD_NAMES,
     AddSalesOrderLineRequest,
+    AdminPickRequest,
     CreateSalesOrderRequest,
     RevertSalesOrderStatusRequest,
     UpdateSalesOrderAddressRequest,
@@ -42,9 +43,12 @@ from schemas.sales_orders import (
 )
 from services.audit_service import write_audit_log
 from services.sales_order_service import (
+    AdminPickError,
     CancelNotAllowed,
     RevertNotAllowed,
     cancel_sales_order as _cancel_so,
+    maybe_promote_so_to_picked,
+    record_admin_pick,
     revert_sales_order_status as _revert_so_status,
 )
 from utils.validation import validate_body
@@ -877,6 +881,67 @@ def revert_sales_order_status(so_id, validated):
     })
 
 
+# Admin virtual pick: operator-driven OPEN -> PICKED via real picks.
+#
+# The use case is the SO got picked physically but the digital pick never
+# landed (legacy bridge, stuck batch, fulfilled-on-arrival inbound). The
+# normal ship guard (quantity_picked > 0 per line) blocks the manual
+# OPEN -> SHIPPED flip until this fires. End state is indistinguishable
+# from a handheld pick: line counters bump, inventory decrements, audit
+# row per pick, pick.confirmed emits when the SO completes. Undo lives
+# in the existing release-pick-tasks UI -- the synthetic pick_tasks
+# created here slot in like real ones.
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/admin-pick", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@validate_body(AdminPickRequest)
+@with_db
+def admin_pick_sales_order(so_id, validated):
+    """Apply a batched admin virtual pick to an OPEN sales order.
+
+    Body shape: {lines: [{so_line_id, bin_id, quantity}, ...]}. Multiple
+    entries with the same so_line_id are allowed (split-bin). The
+    service layer is all-or-nothing in one transaction; any failure
+    rolls back every line in the batch.
+
+    Auth: ADMIN role OR so-full-edit override. The base sales-orders
+    page permission gates entry; the stricter check is here because
+    admin-pick mutates inventory.
+    """
+    role = g.current_user.get("role")
+    if role != ROLE_ADMIN and not has_override(OVERRIDE_SO_FULL_EDIT):
+        return jsonify({
+            "error": "admin-pick requires ADMIN or so-full-edit override",
+        }), 403
+
+    try:
+        result = record_admin_pick(
+            g.db,
+            so_id=so_id,
+            picks=[ln.model_dump() for ln in validated.lines],
+            username=g.current_user["username"],
+        )
+        promoted = maybe_promote_so_to_picked(
+            g.db,
+            so_id=so_id,
+            username=g.current_user["username"],
+        )
+    except AdminPickError as exc:
+        status_code = 409 if exc.kind == "insufficient_available" else 422
+        return jsonify({
+            "error": str(exc),
+            "kind": exc.kind,
+            **exc.context,
+        }), status_code
+
+    g.db.commit()
+    return jsonify({
+        "message": "Admin pick applied",
+        "promoted_to_picked": bool(promoted),
+        **result,
+    })
 # ── Sales Order Lines (add / update / remove) ────────────────────────────────
 #
 # Mirrors the PO line surface shape but layers an

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -26,6 +26,24 @@ class SOLineEntry(BaseModel):
     line_number: Optional[int] = Field(None, ge=1)
 
 
+class AdminPickLineEntry(BaseModel):
+    """One {line, bin, quantity} entry in an admin virtual-pick request.
+
+    Multiple entries may share the same so_line_id (split-bin pick:
+    line N drawn from bin A and bin B in one submit); the route layer
+    sums them per line for the over-pick guard.
+    """
+    so_line_id: int = Field(..., gt=0)
+    bin_id: int = Field(..., gt=0)
+    quantity: int = Field(..., gt=0, le=1000000)
+
+
+class AdminPickRequest(BaseModel):
+    """Batched admin virtual-pick payload. All-or-nothing: any failure
+    inside record_admin_pick rolls back every line in the batch."""
+    lines: List[AdminPickLineEntry] = Field(..., min_length=1)
+
+
 class CreateSalesOrderRequest(BaseModel):
     so_number: str = Field(..., min_length=1, max_length=128)
     warehouse_id: int = Field(..., gt=0)

--- a/api/services/sales_order_service.py
+++ b/api/services/sales_order_service.py
@@ -14,8 +14,10 @@ ERP for cancel; downstream consumers learn through their own ERP
 integration).
 """
 
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
+from flask import g, has_request_context
 from sqlalchemy import text
 
 from constants import (

--- a/api/services/sales_order_service.py
+++ b/api/services/sales_order_service.py
@@ -20,10 +20,12 @@ from sqlalchemy import text
 
 from constants import (
     ACTION_CANCEL,
+    ACTION_PICK,
     ACTION_SO_PICK_RELEASED,
     ACTION_SO_STATUS_REVERTED,
     ACTION_SO_UNPACKED,
     ACTION_SO_UNSHIPPED,
+    BATCH_COMPLETED,
     SO_CANCELLED,
     SO_OPEN,
     SO_PACKED,
@@ -34,6 +36,7 @@ from constants import (
     TASK_RELEASED,
 )
 from services.audit_service import write_audit_log
+from services.events_service import emit_event, get_user_external_id
 from services.inventory_service import add_inventory
 
 
@@ -586,3 +589,392 @@ def revert_sales_order_status(
         "unpacked": bool(need_unpack),
         "unshipped": bool(need_unship),
     }
+
+
+# ---------------------------------------------------------------------------
+# Admin virtual pick
+# ---------------------------------------------------------------------------
+#
+# Operator-driven shortcut: an admin marks a sales order picked through the
+# admin UI without the handheld going out on the floor. Used when the floor
+# work already happened but the digital pick never landed -- e.g. legacy
+# ShipRush bridge, a stuck batch, or an SO that arrived already-fulfilled.
+#
+# The end state must be indistinguishable from a real pick:
+#   * sales_order_lines.quantity_picked carries the picked qty per line
+#   * inventory.quantity_on_hand decrements at the chosen bin per pick
+#   * audit log carries one ACTION_PICK row per pick (entity_type='SO')
+#   * pick.confirmed integration event fires when the SO flips to PICKED
+#
+# Symmetry with handheld picks comes from synthesising a one-shot
+# pick_batch (status COMPLETED at insert) and one pick_task per pick
+# entry. The existing _revert_so_status path takes pick_task_ids as input
+# and walks the same release SQL regardless of how the task was created,
+# so a virtual pick can be undone through the same "Release Picked
+# Quantities" UI as a real pick. No second undo path needed.
+
+
+class AdminPickError(Exception):
+    """Operator submitted an admin-pick request that cannot be applied.
+
+    kind distinguishes the four shapes the route layer maps to HTTP
+    status codes:
+
+      * 'so_not_open'           422 -- SO must be OPEN to virtual-pick
+      * 'line_not_on_so'        422 -- so_line_id does not belong to so_id
+      * 'bin_wrong_warehouse'   422 -- bin is in a different warehouse
+      * 'over_pick'             422 -- summed pick qty > unpicked remaining
+      * 'insufficient_available' 409 -- bin has less available than asked
+    """
+
+    def __init__(self, message: str, kind: str, **context):
+        super().__init__(message)
+        self.kind = kind
+        self.context = context
+
+
+def record_admin_pick(db, *, so_id: int, picks, username: str) -> dict:
+    """Apply a batch of admin virtual picks atomically.
+
+    picks: iterable of {so_line_id, bin_id, quantity} entries. Multiple
+    entries with the same so_line_id are allowed (split-bin: line N
+    drawn from bin A and bin B in one submit) and sum into the line's
+    quantity_picked.
+
+    Caller owns the transaction boundary. This function performs no
+    commit; the route handler commits after also running
+    maybe_promote_so_to_picked. Raises AdminPickError on validation
+    failure; the caller does not need to roll back because no writes
+    happen ahead of the validation pass.
+
+    Implementation notes:
+      * One synthetic pick_batch row per call (status COMPLETED, marked
+        ADMIN-PICK-<so_id>-<microsecond timestamp>) so subsequent
+        release flows see one batch per admin action.
+      * One pick_task row per pick entry (status TASK_PICKED,
+        scan_confirmed=true, picked_by=username) so the existing
+        release-pick-tasks endpoint can undo individual entries.
+      * Inventory side: decrement quantity_on_hand at the bin by the
+        picked qty. quantity_allocated is NOT changed because the
+        bin was never pre-allocated against this SO -- the available
+        check (on_hand - allocated >= qty) is the safety against
+        stealing inventory promised to a different SO.
+      * Line side: bump quantity_picked. Bump quantity_allocated to
+        max(current, quantity_picked) to preserve the picked-floor
+        invariant that the handheld path's _normalize_so_reservations
+        enforces.
+    """
+    so = db.execute(
+        text(
+            "SELECT so_id, so_number, external_id, status, warehouse_id "
+            "  FROM sales_orders WHERE so_id = :sid FOR UPDATE"
+        ),
+        {"sid": so_id},
+    ).fetchone()
+    if so is None:
+        raise AdminPickError(
+            f"sales order {so_id} not found",
+            kind="so_not_found",
+        )
+    if so.status != SO_OPEN:
+        raise AdminPickError(
+            f"sales order must be OPEN to admin-pick (current: {so.status})",
+            kind="so_not_open",
+            current_status=so.status,
+        )
+
+    pick_entries = list(picks)
+    if not pick_entries:
+        raise AdminPickError("no picks supplied", kind="empty")
+
+    # Group by so_line_id so we can validate the over-pick guard against
+    # the line's remaining capacity in a single sum check per line.
+    by_line: dict[int, int] = {}
+    for p in pick_entries:
+        by_line[p["so_line_id"]] = by_line.get(p["so_line_id"], 0) + p["quantity"]
+
+    # Lock + load every involved line. ANY(:ids) keeps it one round trip
+    # whether the operator picks 1 or 50 lines.
+    line_rows = db.execute(
+        text(
+            "SELECT so_line_id, item_id, quantity_ordered, quantity_picked, "
+            "       quantity_allocated "
+            "  FROM sales_order_lines "
+            " WHERE so_line_id = ANY(:ids) AND so_id = :sid "
+            " FOR UPDATE"
+        ),
+        {"ids": list(by_line.keys()), "sid": so_id},
+    ).fetchall()
+    line_by_id = {ln.so_line_id: ln for ln in line_rows}
+    missing = [lid for lid in by_line if lid not in line_by_id]
+    if missing:
+        raise AdminPickError(
+            f"so_line_id(s) not on SO {so_id}: {missing}",
+            kind="line_not_on_so",
+            missing_line_ids=missing,
+        )
+    for lid, total in by_line.items():
+        ln = line_by_id[lid]
+        remaining = ln.quantity_ordered - ln.quantity_picked
+        if total > remaining:
+            raise AdminPickError(
+                f"line {lid} over-pick: requested {total}, remaining {remaining}",
+                kind="over_pick",
+                so_line_id=lid,
+                requested=total,
+                remaining=remaining,
+            )
+
+    # Bin-warehouse sanity. Loads every distinct bin in one query.
+    bin_ids = sorted({p["bin_id"] for p in pick_entries})
+    bin_rows = db.execute(
+        text("SELECT bin_id, warehouse_id FROM bins WHERE bin_id = ANY(:ids)"),
+        {"ids": bin_ids},
+    ).fetchall()
+    bin_warehouse = {b.bin_id: b.warehouse_id for b in bin_rows}
+    for bid in bin_ids:
+        if bid not in bin_warehouse:
+            raise AdminPickError(
+                f"bin {bid} not found", kind="bin_not_found", bin_id=bid,
+            )
+        if bin_warehouse[bid] != so.warehouse_id:
+            raise AdminPickError(
+                f"bin {bid} is in warehouse {bin_warehouse[bid]}, "
+                f"SO {so_id} is in warehouse {so.warehouse_id}",
+                kind="bin_wrong_warehouse",
+                bin_id=bid,
+                bin_warehouse=bin_warehouse[bid],
+                so_warehouse=so.warehouse_id,
+            )
+
+    # Synthesise the wrapper batch. Microsecond timestamp keeps the
+    # batch_number UNIQUE clean even when an operator double-submits.
+    batch_number = (
+        f"ADMIN-PICK-{so_id}-"
+        f"{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')}"
+    )
+    batch_id = db.execute(
+        text(
+            "INSERT INTO pick_batches "
+            "  (batch_number, warehouse_id, assigned_to, status, "
+            "   started_at, completed_at) "
+            "VALUES (:bn, :wh, :user, :st, NOW(), NOW()) "
+            "RETURNING batch_id"
+        ),
+        {
+            "bn": batch_number,
+            "wh": so.warehouse_id,
+            "user": username,
+            "st": BATCH_COMPLETED,
+        },
+    ).scalar()
+    db.execute(
+        text(
+            "INSERT INTO pick_batch_orders (batch_id, so_id) "
+            "VALUES (:bid, :sid)"
+        ),
+        {"bid": batch_id, "sid": so_id},
+    )
+
+    created_task_ids: list[int] = []
+    for seq, pick in enumerate(pick_entries, start=1):
+        line = line_by_id[pick["so_line_id"]]
+
+        # Atomic available check + on_hand decrement. The WHERE clause
+        # is the safety: if available drops below the requested qty
+        # between the validation read and the write, the UPDATE
+        # matches zero rows and RETURNING is empty. Treat that as
+        # insufficient_available and raise -- the caller's transaction
+        # rolls back any prior writes (batch row, prior picks).
+        updated = db.execute(
+            text(
+                "UPDATE inventory "
+                "   SET quantity_on_hand = quantity_on_hand - :qty, "
+                "       updated_at = NOW() "
+                " WHERE item_id = :iid AND bin_id = :bid "
+                "   AND quantity_on_hand - quantity_allocated >= :qty "
+                "RETURNING inventory_id"
+            ),
+            {
+                "qty": pick["quantity"],
+                "iid": line.item_id,
+                "bid": pick["bin_id"],
+            },
+        ).fetchone()
+        if updated is None:
+            raise AdminPickError(
+                f"bin {pick['bin_id']} has insufficient available stock "
+                f"for line {pick['so_line_id']} (requested {pick['quantity']})",
+                kind="insufficient_available",
+                so_line_id=pick["so_line_id"],
+                bin_id=pick["bin_id"],
+                requested=pick["quantity"],
+            )
+
+        # Bump line counters. GREATEST keeps quantity_allocated >= the
+        # new picked floor without overriding a higher standing
+        # reservation (matching the handheld path's invariant).
+        db.execute(
+            text(
+                "UPDATE sales_order_lines "
+                "   SET quantity_picked = quantity_picked + :qty, "
+                "       quantity_allocated = GREATEST( "
+                "           quantity_allocated, quantity_picked + :qty "
+                "       ) "
+                " WHERE so_line_id = :sol_id"
+            ),
+            {"qty": pick["quantity"], "sol_id": pick["so_line_id"]},
+        )
+
+        # Synthetic pick_task. status=PICKED, scan_confirmed=true,
+        # tote_number NULL (admin picks have no tote). pick_sequence
+        # 1..N within the batch keeps the (batch_id, pick_sequence)
+        # index dense.
+        task_id = db.execute(
+            text(
+                "INSERT INTO pick_tasks "
+                "  (batch_id, so_id, so_line_id, item_id, bin_id, "
+                "   quantity_to_pick, quantity_picked, pick_sequence, "
+                "   status, picked_by, picked_at, scan_confirmed) "
+                "VALUES (:bid, :sid, :sol, :iid, :bin, "
+                "        :qty, :qty, :seq, "
+                "        :st, :user, NOW(), TRUE) "
+                "RETURNING pick_task_id"
+            ),
+            {
+                "bid": batch_id,
+                "sid": so_id,
+                "sol": pick["so_line_id"],
+                "iid": line.item_id,
+                "bin": pick["bin_id"],
+                "qty": pick["quantity"],
+                "seq": seq,
+                "st": TASK_PICKED,
+                "user": username,
+            },
+        ).scalar()
+        created_task_ids.append(task_id)
+
+        # Audit row per pick. details.source='admin_virtual' is the
+        # discriminator that lets dashboards and post-incident readers
+        # separate operator shortcuts from handheld floor work.
+        item_sku = db.execute(
+            text("SELECT sku FROM items WHERE item_id = :iid"),
+            {"iid": line.item_id},
+        ).scalar()
+        write_audit_log(
+            db,
+            action_type=ACTION_PICK,
+            entity_type="SO",
+            entity_id=so_id,
+            user_id=username,
+            warehouse_id=so.warehouse_id,
+            details={
+                "source": "admin_virtual",
+                "sku": item_sku,
+                "quantity_to_pick": pick["quantity"],
+                "quantity_picked": pick["quantity"],
+                "pick_task_id": task_id,
+                "item_id": line.item_id,
+                "bin_id": pick["bin_id"],
+                "batch_id": batch_id,
+                "so_line_id": pick["so_line_id"],
+            },
+        )
+
+    return {
+        "batch_id": batch_id,
+        "batch_number": batch_number,
+        "pick_task_ids": created_task_ids,
+        "picks_applied": len(created_task_ids),
+    }
+
+
+def maybe_promote_so_to_picked(db, *, so_id: int, username: str) -> bool:
+    """If every line on the SO is fully picked, flip status to PICKED.
+
+    Mirrors complete_batch's status flip + pick.confirmed emit, but
+    only fires when the SO is the one being completed. Returns True
+    when the flip happened, False when at least one line is still
+    under-picked.
+
+    Caller owns the transaction boundary; this function performs no
+    commit. Skipped emission outside a Flask request context matches
+    complete_batch's pattern -- unit tests can call this directly and
+    get the status flip without the event side effect.
+    """
+    short = db.execute(
+        text(
+            "SELECT 1 FROM sales_order_lines "
+            " WHERE so_id = :sid AND quantity_picked < quantity_ordered "
+            " LIMIT 1"
+        ),
+        {"sid": so_id},
+    ).fetchone()
+    if short is not None:
+        return False
+
+    so = db.execute(
+        text(
+            "SELECT so_id, so_number, external_id, status, warehouse_id "
+            "  FROM sales_orders WHERE so_id = :sid FOR UPDATE"
+        ),
+        {"sid": so_id},
+    ).fetchone()
+    if so is None:
+        return False
+    if so.status != SO_OPEN:
+        # Some other request already promoted it; nothing to do.
+        return False
+
+    db.execute(
+        text(
+            "UPDATE sales_orders SET status = :st, picked_at = NOW() "
+            " WHERE so_id = :sid"
+        ),
+        {"sid": so_id, "st": SO_PICKED},
+    )
+
+    if not has_request_context():
+        return True
+
+    line_rows = db.execute(
+        text(
+            """
+            SELECT i.external_id AS item_external_id, sol.quantity_picked
+              FROM sales_order_lines sol
+              JOIN items i ON i.item_id = sol.item_id
+             WHERE sol.so_id = :sid
+             ORDER BY sol.line_number
+            """
+        ),
+        {"sid": so_id},
+    ).fetchall()
+    completed_at = (
+        datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    emit_event(
+        db,
+        event_type="pick.confirmed",
+        event_version=1,
+        aggregate_type="sales_order",
+        aggregate_id=so.so_id,
+        aggregate_external_id=so.external_id,
+        warehouse_id=so.warehouse_id,
+        source_txn_id=g.source_txn_id,
+        payload={
+            "sales_order_external_id": str(so.external_id),
+            "lines": [
+                {
+                    "item_external_id": str(line.item_external_id),
+                    "quantity_picked": line.quantity_picked,
+                    "lot_number": None,
+                    "serial_number": None,
+                }
+                for line in line_rows
+            ],
+            "completed_by_user_external_id": get_user_external_id(db, username),
+            "completed_at": completed_at,
+        },
+    )
+    return True

--- a/api/tests/test_admin_so_pick.py
+++ b/api/tests/test_admin_so_pick.py
@@ -1,0 +1,199 @@
+"""HTTP + service-layer tests for the admin virtual-pick path.
+
+POST /api/admin/sales-orders/<so_id>/admin-pick takes a batched body
+of {so_line_id, bin_id, quantity} entries and applies them as if the
+handheld had picked them. End state must be indistinguishable from a
+real pick: line counters bump, inventory.quantity_on_hand decrements,
+audit ACTION_PICK rows land per pick, pick.confirmed emits when the
+SO flips to PICKED.
+
+This file (C1) pins the happy path: single-line pick, full coverage,
+SO promotes to PICKED, response shape is what the UI expects.
+Edge cases live in C2 (test_admin_so_pick_edge_cases.py).
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from db_test_context import get_raw_connection
+
+
+# ----------------------------------------------------------------------
+# Seed helpers (raw cursors -- the per-test transaction owns the writes)
+# ----------------------------------------------------------------------
+
+
+def _insert_so(status="OPEN", warehouse_id=1):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_orders "
+        "(so_number, customer_name, status, warehouse_id, external_id) "
+        "VALUES (%s, %s, %s, %s, %s) RETURNING so_id, external_id",
+        (
+            f"SO-ADMINPICK-{uuid.uuid4().hex[:8]}",
+            "Cust",
+            status,
+            warehouse_id,
+            str(uuid.uuid4()),
+        ),
+    )
+    so_id, external_id = cur.fetchone()
+    cur.close()
+    return so_id, external_id
+
+
+def _insert_item():
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO items (sku, item_name, upc, external_id) "
+        "VALUES (%s, %s, %s, %s) RETURNING item_id",
+        (
+            f"SKU-{uuid.uuid4().hex[:8]}",
+            "Widget",
+            "0123456789012",
+            str(uuid.uuid4()),
+        ),
+    )
+    item_id = cur.fetchone()[0]
+    cur.close()
+    return item_id
+
+
+def _insert_line(so_id, item_id, *, qty_ordered=2, qty_picked=0, qty_allocated=0):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO sales_order_lines "
+        "(so_id, item_id, quantity_ordered, quantity_picked, "
+        " quantity_allocated, line_number, status) "
+        "VALUES (%s, %s, %s, %s, %s, 1, 'OPEN') RETURNING so_line_id",
+        (so_id, item_id, qty_ordered, qty_picked, qty_allocated),
+    )
+    sol_id = cur.fetchone()[0]
+    cur.close()
+    return sol_id
+
+
+def _set_inv(item_id, bin_id, qty_on_hand, qty_allocated=0, warehouse_id=1):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO inventory "
+        "(item_id, bin_id, warehouse_id, quantity_on_hand, quantity_allocated) "
+        "VALUES (%s, %s, %s, %s, %s) "
+        "ON CONFLICT (item_id, bin_id, lot_number) DO UPDATE "
+        "SET quantity_on_hand = EXCLUDED.quantity_on_hand, "
+        "    quantity_allocated = EXCLUDED.quantity_allocated",
+        (item_id, bin_id, warehouse_id, qty_on_hand, qty_allocated),
+    )
+    cur.close()
+
+
+def _read_so(so_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT status, picked_at FROM sales_orders WHERE so_id = %s",
+        (so_id,),
+    )
+    row = cur.fetchone()
+    cur.close()
+    return {"status": row[0], "picked_at": row[1]}
+
+
+def _read_line(sol_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT quantity_ordered, quantity_picked, quantity_allocated "
+        "FROM sales_order_lines WHERE so_line_id = %s",
+        (sol_id,),
+    )
+    row = cur.fetchone()
+    cur.close()
+    return {
+        "quantity_ordered": row[0],
+        "quantity_picked": row[1],
+        "quantity_allocated": row[2],
+    }
+
+
+def _read_inv(item_id, bin_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT quantity_on_hand, quantity_allocated FROM inventory "
+        "WHERE item_id = %s AND bin_id = %s",
+        (item_id, bin_id),
+    )
+    row = cur.fetchone()
+    cur.close()
+    return {
+        "quantity_on_hand": row[0],
+        "quantity_allocated": row[1],
+    }
+
+
+def _admin_headers(client):
+    resp = client.post(
+        "/api/auth/login", json={"username": "admin", "password": "admin"},
+    )
+    return {"Authorization": f"Bearer {resp.get_json()['token']}"}
+
+
+# ----------------------------------------------------------------------
+# C1: happy path
+# ----------------------------------------------------------------------
+
+
+class TestAdminPickHappyPath:
+    def test_single_line_full_pick_promotes_so(self, client):
+        # Seed: one OPEN SO with one line for 2 units, bin holds 5
+        # available. Operator admin-picks both units from the bin.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=2)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": 3, "quantity": 2},
+            ]},
+            headers=_admin_headers(client),
+        )
+
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["message"] == "Admin pick applied"
+        assert body["promoted_to_picked"] is True
+        assert body["picks_applied"] == 1
+        assert len(body["pick_task_ids"]) == 1
+        assert body["batch_number"].startswith(f"ADMIN-PICK-{so_id}-")
+
+        # Line counters bumped, inventory decremented at the bin.
+        line = _read_line(sol_id)
+        assert line["quantity_picked"] == 2
+        assert line["quantity_allocated"] >= 2  # picked-floor invariant
+
+        inv = _read_inv(item_id, 3)
+        assert inv["quantity_on_hand"] == 3
+        # quantity_allocated must NOT have been touched: admin-pick never
+        # pre-allocated against this bin (the available check is the
+        # safety, not pre-allocation).
+        assert inv["quantity_allocated"] == 0
+
+        # SO promoted: status flips, picked_at set.
+        so = _read_so(so_id)
+        assert so["status"] == "PICKED"
+        assert so["picked_at"] is not None

--- a/api/tests/test_admin_so_pick.py
+++ b/api/tests/test_admin_so_pick.py
@@ -197,3 +197,389 @@ class TestAdminPickHappyPath:
         so = _read_so(so_id)
         assert so["status"] == "PICKED"
         assert so["picked_at"] is not None
+
+
+# ----------------------------------------------------------------------
+# C2: edge cases -- partial picks, validation errors, all-or-nothing,
+# split-bin, event emission, undo round-trip, auth
+# ----------------------------------------------------------------------
+
+
+def _count_audit(so_id, action="PICK"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT COUNT(*) FROM audit_log "
+        " WHERE entity_type = 'SO' AND entity_id = %s AND action_type = %s",
+        (so_id, action),
+    )
+    n = cur.fetchone()[0]
+    cur.close()
+    return n
+
+
+def _count_events(so_id, event_type="pick.confirmed"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT COUNT(*) FROM integration_events "
+        " WHERE aggregate_type = 'sales_order' "
+        "   AND aggregate_id = %s AND event_type = %s",
+        (so_id, event_type),
+    )
+    n = cur.fetchone()[0]
+    cur.close()
+    return n
+
+
+def _count_pick_tasks(so_id, status="PICKED"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT COUNT(*) FROM pick_tasks WHERE so_id = %s AND status = %s",
+        (so_id, status),
+    )
+    n = cur.fetchone()[0]
+    cur.close()
+    return n
+
+
+class TestAdminPickValidation:
+    def test_so_not_open_returns_422(self, client):
+        # SO already PICKED -- the admin-pick path is for OPEN orders
+        # only; mutating a PICKED order goes through the line edit
+        # surface, not this endpoint.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5)
+        so_id, _ = _insert_so(status="PICKED")
+        sol_id = _insert_line(so_id, item_id, qty_ordered=2)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": 3, "quantity": 1},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 422, resp.get_json()
+        body = resp.get_json()
+        assert body["kind"] == "so_not_open"
+        assert body["current_status"] == "PICKED"
+
+    def test_over_pick_returns_422(self, client):
+        # Line ordered=2, already picked=1, remaining=1. Requesting 2
+        # should bounce.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=2, qty_picked=1)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": 3, "quantity": 2},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 422, resp.get_json()
+        body = resp.get_json()
+        assert body["kind"] == "over_pick"
+        assert body["requested"] == 2
+        assert body["remaining"] == 1
+
+    def test_insufficient_available_returns_409(self, client):
+        # Bin has 3 on-hand but 2 already allocated to a different SO.
+        # Available = 1; requesting 2 must fail with 409 (not 422 --
+        # this is a transient inventory state, not operator error).
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=3, qty_allocated=2)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=2)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": 3, "quantity": 2},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 409, resp.get_json()
+        body = resp.get_json()
+        assert body["kind"] == "insufficient_available"
+
+        # Atomic rollback: inventory untouched.
+        inv = _read_inv(item_id, 3)
+        assert inv["quantity_on_hand"] == 3
+        assert inv["quantity_allocated"] == 2
+
+    def test_bin_wrong_warehouse_returns_422(self, client):
+        # SO is in warehouse 1; bin lives in warehouse 2. Seed has the
+        # warehouse row but no zones/bins under it, so fabricate the
+        # zone + bin inside this test's transaction.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO zones "
+            "  (zone_name, zone_code, zone_type, warehouse_id) "
+            "VALUES (%s, %s, 'Pickable', 2) RETURNING zone_id",
+            (
+                f"Z-WH2-{uuid.uuid4().hex[:6]}",
+                f"ZWH2-{uuid.uuid4().hex[:6]}",
+            ),
+        )
+        zone_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO bins "
+            "  (zone_id, warehouse_id, bin_code, bin_barcode, external_id) "
+            "VALUES (%s, 2, %s, %s, %s) RETURNING bin_id",
+            (
+                zone_id,
+                f"WH2-{uuid.uuid4().hex[:6]}",
+                f"WH2BC-{uuid.uuid4().hex[:6]}",
+                str(uuid.uuid4()),
+            ),
+        )
+        wh2_bin_id = cur.fetchone()[0]
+        cur.close()
+
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5)
+        so_id, _ = _insert_so()  # warehouse 1
+        sol_id = _insert_line(so_id, item_id, qty_ordered=1)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": wh2_bin_id, "quantity": 1},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 422, resp.get_json()
+        assert resp.get_json()["kind"] == "bin_wrong_warehouse"
+
+    def test_line_not_on_so_returns_422(self, client):
+        # so_line_id belongs to a DIFFERENT SO. The endpoint must
+        # reject -- otherwise the wrong order's line counters move.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5)
+        so_a, _ = _insert_so()
+        so_b, _ = _insert_so()
+        sol_b = _insert_line(so_b, item_id, qty_ordered=2)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_a}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_b, "bin_id": 3, "quantity": 1},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 422, resp.get_json()
+        assert resp.get_json()["kind"] == "line_not_on_so"
+
+
+class TestAdminPickPartialAndFull:
+    def test_partial_pick_keeps_so_open_no_event(self, client):
+        # Line ordered=5, admin picks 2. SO stays OPEN -- no event.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=10)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=5)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": 3, "quantity": 2},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["promoted_to_picked"] is False
+
+        assert _read_so(so_id)["status"] == "OPEN"
+        assert _count_events(so_id) == 0
+        assert _read_line(sol_id)["quantity_picked"] == 2
+
+    def test_full_pick_emits_pick_confirmed_event(self, client):
+        # Single round of full picks promotes the SO and writes
+        # exactly one pick.confirmed row to integration_events.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=10)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=3)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": 3, "quantity": 3},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["promoted_to_picked"] is True
+
+        assert _read_so(so_id)["status"] == "PICKED"
+        assert _count_events(so_id, "pick.confirmed") == 1
+
+
+class TestAdminPickSplitBin:
+    def test_split_bin_picks_sum_per_line(self, client):
+        # Line ordered=5; operator splits across bin 3 (3 units) and
+        # bin 4 (2 units). Two pick_tasks land, line picked total = 5,
+        # SO promotes.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=4)
+        _set_inv(item_id, bin_id=4, qty_on_hand=4)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=5)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": 3, "quantity": 3},
+                {"so_line_id": sol_id, "bin_id": 4, "quantity": 2},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["picks_applied"] == 2
+        assert body["promoted_to_picked"] is True
+
+        assert _read_line(sol_id)["quantity_picked"] == 5
+        assert _read_inv(item_id, 3)["quantity_on_hand"] == 1
+        assert _read_inv(item_id, 4)["quantity_on_hand"] == 2
+        assert _count_pick_tasks(so_id) == 2
+        assert _count_audit(so_id, "PICK") == 2
+
+
+class TestAdminPickAtomic:
+    def test_all_or_nothing_failure_rolls_back_prior_writes(self, client):
+        # Two-line submit: line A's bin has enough, line B's bin does
+        # not. The whole batch must roll back; line A's quantity_picked
+        # must stay 0 and the bin inventory untouched.
+        item_a = _insert_item()
+        item_b = _insert_item()
+        _set_inv(item_a, bin_id=3, qty_on_hand=5)
+        _set_inv(item_b, bin_id=4, qty_on_hand=1)  # not enough for 2
+        so_id, _ = _insert_so()
+        sol_a = _insert_line(so_id, item_a, qty_ordered=2)
+        sol_b = _insert_line(so_id, item_b, qty_ordered=2)
+        # second insert added a row at line_number=1 again; fix it.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_order_lines SET line_number = 2 WHERE so_line_id = %s",
+            (sol_b,),
+        )
+        cur.close()
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_a, "bin_id": 3, "quantity": 2},
+                {"so_line_id": sol_b, "bin_id": 4, "quantity": 2},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 409, resp.get_json()
+        assert resp.get_json()["kind"] == "insufficient_available"
+
+        # Atomic rollback: NEITHER line moved, NEITHER bin decremented.
+        assert _read_line(sol_a)["quantity_picked"] == 0
+        assert _read_line(sol_b)["quantity_picked"] == 0
+        assert _read_inv(item_a, 3)["quantity_on_hand"] == 5
+        assert _read_inv(item_b, 4)["quantity_on_hand"] == 1
+        assert _read_so(so_id)["status"] == "OPEN"
+        assert _count_pick_tasks(so_id) == 0
+        assert _count_audit(so_id, "PICK") == 0
+
+
+class TestAdminPickReleaseRoundTrip:
+    def test_synthetic_pick_task_releases_via_revert_endpoint(self, client):
+        # An admin-pick that fully promotes the SO to PICKED. The
+        # operator then opens the existing Release modal and releases
+        # the synthetic pick_task. Inventory should restore, line
+        # picked count drops to zero, SO demotes back to OPEN. This
+        # is the round-trip the user wants: same Release button.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=2)
+
+        pick_resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": 3, "quantity": 2},
+            ]},
+            headers=_admin_headers(client),
+        )
+        assert pick_resp.status_code == 200, pick_resp.get_json()
+        pick_task_id = pick_resp.get_json()["pick_task_ids"][0]
+        assert _read_so(so_id)["status"] == "PICKED"
+        assert _read_inv(item_id, 3)["quantity_on_hand"] == 3
+
+        revert_resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/revert-status",
+            json={
+                "new_status": "OPEN",
+                "release_pick_task_ids": [pick_task_id],
+            },
+            headers=_admin_headers(client),
+        )
+        assert revert_resp.status_code == 200, revert_resp.get_json()
+
+        # Round-trip invariants.
+        assert _read_so(so_id)["status"] == "OPEN"
+        assert _read_line(sol_id)["quantity_picked"] == 0
+        assert _read_inv(item_id, 3)["quantity_on_hand"] == 5
+
+
+class TestAdminPickAuth:
+    def test_non_admin_without_override_returns_403(self, client):
+        # Provision a USER with sales-orders page permission but NO
+        # so-full-edit override. The page perm gets them past the
+        # decorator; the extra ADMIN-or-override check inside the
+        # handler should still 403.
+        admin_headers = _admin_headers(client)
+        create_resp = client.post(
+            "/api/admin/users",
+            json={
+                "username": f"adminpickuser-{uuid.uuid4().hex[:6]}",
+                "password": "password123",
+                "full_name": "Pick User",
+                "role": "USER",
+                "warehouse_ids": [1],
+            },
+            headers=admin_headers,
+        )
+        assert create_resp.status_code in (200, 201), create_resp.get_json()
+        new_user = create_resp.get_json()
+        username = new_user["username"]
+        user_id = new_user["user_id"]
+        perm_resp = client.put(
+            f"/api/admin/users/{user_id}/permissions",
+            json={"page_keys": ["sales-orders"]},
+            headers=admin_headers,
+        )
+        assert perm_resp.status_code == 200, perm_resp.get_json()
+        login = client.post(
+            "/api/auth/login",
+            json={"username": username, "password": "password123"},
+        )
+        user_headers = {
+            "Authorization": f"Bearer {login.get_json()['token']}",
+        }
+
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=1)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/admin-pick",
+            json={"lines": [
+                {"so_line_id": sol_id, "bin_id": 3, "quantity": 1},
+            ]},
+            headers=user_headers,
+        )
+        assert resp.status_code == 403, resp.get_json()

--- a/api/tests/test_admin_so_pick.py
+++ b/api/tests/test_admin_so_pick.py
@@ -534,6 +534,154 @@ class TestAdminPickReleaseRoundTrip:
         assert _read_inv(item_id, 3)["quantity_on_hand"] == 5
 
 
+# ----------------------------------------------------------------------
+# C3: GET /sales-orders/<so_id>/lines/<so_line_id>/available-bins
+# ----------------------------------------------------------------------
+
+
+class TestAdminPickAvailableBins:
+    def test_returns_bins_with_available_stock(self, client):
+        # Item stocked in bin 3 (5 on-hand, 1 allocated -> 4 available)
+        # and bin 4 (10 on-hand, 0 allocated -> 10 available). Both
+        # should surface.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5, qty_allocated=1)
+        _set_inv(item_id, bin_id=4, qty_on_hand=10)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=2)
+
+        resp = client.get(
+            f"/api/admin/sales-orders/{so_id}/lines/{sol_id}/available-bins",
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["item_id"] == item_id
+        assert body["warehouse_id"] == 1
+        bin_ids = [b["bin_id"] for b in body["bins"]]
+        assert 3 in bin_ids
+        assert 4 in bin_ids
+        bin_3 = next(b for b in body["bins"] if b["bin_id"] == 3)
+        assert bin_3["quantity_available"] == 4
+        assert bin_3["quantity_on_hand"] == 5
+        assert bin_3["quantity_allocated"] == 1
+
+    def test_excludes_zero_available_bins(self, client):
+        # Bin 3: fully allocated (on_hand 2, allocated 2 -> 0
+        # available). Bin 4: has stock. Only bin 4 surfaces.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=2, qty_allocated=2)
+        _set_inv(item_id, bin_id=4, qty_on_hand=5)
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=2)
+
+        resp = client.get(
+            f"/api/admin/sales-orders/{so_id}/lines/{sol_id}/available-bins",
+            headers=_admin_headers(client),
+        )
+        body = resp.get_json()
+        bin_ids = [b["bin_id"] for b in body["bins"]]
+        assert 3 not in bin_ids
+        assert 4 in bin_ids
+
+    def test_scoped_to_so_warehouse(self, client):
+        # Item has stock in a warehouse-2 bin AND in a warehouse-1
+        # bin. The SO lives in warehouse 1; only the warehouse-1 bin
+        # is allowed to surface.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO zones "
+            "  (zone_name, zone_code, zone_type, warehouse_id) "
+            "VALUES (%s, %s, 'Pickable', 2) RETURNING zone_id",
+            (
+                f"Z-WH2-{uuid.uuid4().hex[:6]}",
+                f"ZWH2-{uuid.uuid4().hex[:6]}",
+            ),
+        )
+        zone_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO bins "
+            "  (zone_id, warehouse_id, bin_code, bin_barcode, external_id) "
+            "VALUES (%s, 2, %s, %s, %s) RETURNING bin_id",
+            (
+                zone_id,
+                f"WH2-{uuid.uuid4().hex[:6]}",
+                f"WH2BC-{uuid.uuid4().hex[:6]}",
+                str(uuid.uuid4()),
+            ),
+        )
+        wh2_bin_id = cur.fetchone()[0]
+        cur.close()
+
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5)              # wh1
+        _set_inv(item_id, bin_id=wh2_bin_id, qty_on_hand=10,
+                 warehouse_id=2)
+        so_id, _ = _insert_so()  # warehouse 1
+        sol_id = _insert_line(so_id, item_id, qty_ordered=2)
+
+        resp = client.get(
+            f"/api/admin/sales-orders/{so_id}/lines/{sol_id}/available-bins",
+            headers=_admin_headers(client),
+        )
+        body = resp.get_json()
+        bin_ids = [b["bin_id"] for b in body["bins"]]
+        assert 3 in bin_ids
+        assert wh2_bin_id not in bin_ids
+
+    def test_sorts_preferred_bins_first(self, client):
+        # Bin 4 has preferred priority 1; bin 3 has no preferred row.
+        # Bin 4 must appear ahead of bin 3 in the response, regardless
+        # of which has more stock.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=99)
+        _set_inv(item_id, bin_id=4, qty_on_hand=1)
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO preferred_bins (item_id, bin_id, priority) "
+            "VALUES (%s, 4, 1)",
+            (item_id,),
+        )
+        cur.close()
+        so_id, _ = _insert_so()
+        sol_id = _insert_line(so_id, item_id, qty_ordered=1)
+
+        resp = client.get(
+            f"/api/admin/sales-orders/{so_id}/lines/{sol_id}/available-bins",
+            headers=_admin_headers(client),
+        )
+        body = resp.get_json()
+        bin_ids = [b["bin_id"] for b in body["bins"]]
+        # bin 4 (preferred priority 1) ahead of bin 3 (no preference)
+        assert bin_ids.index(4) < bin_ids.index(3)
+
+    def test_unknown_line_returns_404(self, client):
+        so_id, _ = _insert_so()
+        resp = client.get(
+            f"/api/admin/sales-orders/{so_id}/lines/9999999/available-bins",
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 404
+
+    def test_line_on_different_so_returns_404(self, client):
+        # The line exists but on a different SO; the endpoint must
+        # treat that as not-found rather than leaking the other SO's
+        # line shape.
+        item_id = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=5)
+        so_a, _ = _insert_so()
+        so_b, _ = _insert_so()
+        sol_b = _insert_line(so_b, item_id, qty_ordered=1)
+
+        resp = client.get(
+            f"/api/admin/sales-orders/{so_a}/lines/{sol_b}/available-bins",
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 404
+
+
 class TestAdminPickAuth:
     def test_non_admin_without_override_returns_403(self, client):
         # Provision a USER with sales-orders page permission but NO


### PR DESCRIPTION
## Summary

Adds an admin "virtual pick" path so an operator can mark an OPEN sales order picked from the admin UI when the digital pick never landed -- a legacy bridge, a stuck batch, or fulfilled-on-arrival inbound. The normal ship guard requires `quantity_picked > 0` per line, so without this the manual OPEN -> SHIPPED flip is blocked. The end state is indistinguishable from a handheld pick.

- `feat(admin): POST /sales-orders/<id>/admin-pick (virtual pick)` -- `record_admin_pick` applies a batched, all-or-nothing pick from a `{lines: [{so_line_id, bin_id, quantity}]}` body (multiple entries on one line model a split-bin pick; the route sums per line for the over-pick guard). It bumps the line counters, decrements `inventory.quantity_on_hand` at the chosen bin, writes an `ACTION_PICK` audit row per pick with `details.source='admin_virtual'` so dashboards can split operator shortcuts from floor work, and emits `pick.confirmed` when the SO flips to PICKED (mirroring `complete_batch`'s emit shape). Failures roll the whole batch back and return 422 / 409 with a `kind` discriminator (`so_not_open`, `over_pick`, `insufficient_available`, `bin_wrong_warehouse`, `line_not_on_so`). Gated to ADMIN or the so-full-edit override on top of the `sales-orders` page permission. The synthetic `pick_tasks` slot in like real ones, so the existing Release Picked Quantities / revert-status flow undoes an admin pick with no extra code.
- `test(admin-pick): edge cases, atomicity, undo round-trip, auth` -- validation kinds, partial-vs-full promotion semantics (partial keeps the SO OPEN with no event; full promotes and writes exactly one `pick.confirmed`), split-bin summing, all-or-nothing rollback on a mid-batch failure, the revert-status undo round-trip, and the ADMIN-or-override gate.
- `feat(admin): GET /sales-orders/<id>/lines/<line>/available-bins` -- powers the per-line bin dropdown: bins in the SO's warehouse holding the line's item with positive available stock (`on_hand - allocated`), sorted by preferred-bin priority (NULLS LAST) then bin code. Purely UX -- the POST re-validates warehouse + availability at submit. 404s on an unknown line or a line on a different SO so it does not leak line existence.
- `feat(admin-ui): Admin Pick modal + footer button in the SO edit view` -- an OPEN + ADMIN-or-override-gated footer button opens a sub-modal listing every unpicked line with a per-line bin dropdown and quantity input; a "+ bin" button adds a second `{bin, qty}` row so a split-bin pick lands in one submit. On success it closes and reloads.

## Mobile

No mobile/ diffs.

## Pre-merge gate

- [x] Full api suite green locally (2475 passed, 9 skipped; the 2 psql-host suites run only in CI); admin vitest 74/74; admin build clean
- [ ] CI green
