### PR TITLE
feat(picking): printable picking tickets + configurable packing-slip branding

### DIFF
--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -15,6 +15,7 @@ import PutAway from './pages/PutAway.jsx';
 import Picking from './pages/Picking.jsx';
 import PickingTickets from './pages/PickingTickets.jsx';
 import PickingTicketPrint from './pages/PickingTicketPrint.jsx';
+import PickingTicketPrintAll from './pages/PickingTicketPrintAll.jsx';
 import Packing from './pages/Packing.jsx';
 import Shipping from './pages/Shipping.jsx';
 import PickingBatches from './pages/PickingBatches.jsx';
@@ -67,6 +68,7 @@ export default function App() {
         <Route path="/sales-orders" element={<ErrorBoundary fallbackMessage="Could not load sales orders."><SalesOrders /></ErrorBoundary>} />
         <Route path="/picking" element={<ErrorBoundary fallbackMessage="Could not load picking."><Picking /></ErrorBoundary>} />
         <Route path="/picking-tickets" element={<ErrorBoundary fallbackMessage="Could not load picking tickets."><PickingTickets /></ErrorBoundary>} />
+        <Route path="/picking-tickets/print-all" element={<ErrorBoundary fallbackMessage="Could not render picking tickets."><PickingTicketPrintAll /></ErrorBoundary>} />
         <Route path="/picking-tickets/:soId/print" element={<ErrorBoundary fallbackMessage="Could not render picking ticket."><PickingTicketPrint /></ErrorBoundary>} />
         <Route path="/packing" element={<ErrorBoundary fallbackMessage="Could not load packing."><Packing /></ErrorBoundary>} />
         <Route path="/shipping" element={<ErrorBoundary fallbackMessage="Could not load shipping."><Shipping /></ErrorBoundary>} />

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -13,6 +13,8 @@ import PurchaseOrders from './pages/PurchaseOrders.jsx';
 import SalesOrders from './pages/SalesOrders.jsx';
 import PutAway from './pages/PutAway.jsx';
 import Picking from './pages/Picking.jsx';
+import PickingTickets from './pages/PickingTickets.jsx';
+import PickingTicketPrint from './pages/PickingTicketPrint.jsx';
 import Packing from './pages/Packing.jsx';
 import Shipping from './pages/Shipping.jsx';
 import PickingBatches from './pages/PickingBatches.jsx';
@@ -64,6 +66,8 @@ export default function App() {
         <Route path="/putaway" element={<ErrorBoundary fallbackMessage="Could not load put-away."><PutAway /></ErrorBoundary>} />
         <Route path="/sales-orders" element={<ErrorBoundary fallbackMessage="Could not load sales orders."><SalesOrders /></ErrorBoundary>} />
         <Route path="/picking" element={<ErrorBoundary fallbackMessage="Could not load picking."><Picking /></ErrorBoundary>} />
+        <Route path="/picking-tickets" element={<ErrorBoundary fallbackMessage="Could not load picking tickets."><PickingTickets /></ErrorBoundary>} />
+        <Route path="/picking-tickets/:soId/print" element={<ErrorBoundary fallbackMessage="Could not render picking ticket."><PickingTicketPrint /></ErrorBoundary>} />
         <Route path="/packing" element={<ErrorBoundary fallbackMessage="Could not load packing."><Packing /></ErrorBoundary>} />
         <Route path="/shipping" element={<ErrorBoundary fallbackMessage="Could not load shipping."><Shipping /></ErrorBoundary>} />
         <Route path="/picking-batches" element={<ErrorBoundary fallbackMessage="Could not load picking batches."><PickingBatches /></ErrorBoundary>} />

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -70,6 +70,20 @@ export default function App() {
           </ProtectedRoute>
         }
       />
+      {/* Individual ticket also renders standalone so the operator can
+          open it from any list / search surface in a new tab without
+          the admin sidebar competing for screen width or breaking the
+          per-page print CSS. */}
+      <Route
+        path="/picking-tickets/:soId/print"
+        element={
+          <ProtectedRoute>
+            <ErrorBoundary fallbackMessage="Could not render picking ticket.">
+              <PickingTicketPrint />
+            </ErrorBoundary>
+          </ProtectedRoute>
+        }
+      />
       <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
         <Route path="/change-password" element={<ErrorBoundary fallbackMessage="Could not load change-password form."><ChangePassword /></ErrorBoundary>} />
         <Route path="/" element={<ErrorBoundary fallbackMessage="Could not load dashboard."><Dashboard /></ErrorBoundary>} />
@@ -82,7 +96,6 @@ export default function App() {
         <Route path="/sales-orders" element={<ErrorBoundary fallbackMessage="Could not load sales orders."><SalesOrders /></ErrorBoundary>} />
         <Route path="/picking" element={<ErrorBoundary fallbackMessage="Could not load picking."><Picking /></ErrorBoundary>} />
         <Route path="/picking-tickets" element={<ErrorBoundary fallbackMessage="Could not load picking tickets."><PickingTickets /></ErrorBoundary>} />
-        <Route path="/picking-tickets/:soId/print" element={<ErrorBoundary fallbackMessage="Could not render picking ticket."><PickingTicketPrint /></ErrorBoundary>} />
         <Route path="/packing" element={<ErrorBoundary fallbackMessage="Could not load packing."><Packing /></ErrorBoundary>} />
         <Route path="/shipping" element={<ErrorBoundary fallbackMessage="Could not load shipping."><Shipping /></ErrorBoundary>} />
         <Route path="/picking-batches" element={<ErrorBoundary fallbackMessage="Could not load picking batches."><PickingBatches /></ErrorBoundary>} />

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -56,6 +56,20 @@ export default function App() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      {/* Standalone print views: rendered without the admin Layout
+          chrome so they fill the full window and the per-ticket page
+          break CSS doesn't have to fight a sidebar/header parent.
+          Still gated by ProtectedRoute so auth is required. */}
+      <Route
+        path="/picking-tickets/print-all"
+        element={
+          <ProtectedRoute>
+            <ErrorBoundary fallbackMessage="Could not render picking tickets.">
+              <PickingTicketPrintAll />
+            </ErrorBoundary>
+          </ProtectedRoute>
+        }
+      />
       <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
         <Route path="/change-password" element={<ErrorBoundary fallbackMessage="Could not load change-password form."><ChangePassword /></ErrorBoundary>} />
         <Route path="/" element={<ErrorBoundary fallbackMessage="Could not load dashboard."><Dashboard /></ErrorBoundary>} />
@@ -68,7 +82,6 @@ export default function App() {
         <Route path="/sales-orders" element={<ErrorBoundary fallbackMessage="Could not load sales orders."><SalesOrders /></ErrorBoundary>} />
         <Route path="/picking" element={<ErrorBoundary fallbackMessage="Could not load picking."><Picking /></ErrorBoundary>} />
         <Route path="/picking-tickets" element={<ErrorBoundary fallbackMessage="Could not load picking tickets."><PickingTickets /></ErrorBoundary>} />
-        <Route path="/picking-tickets/print-all" element={<ErrorBoundary fallbackMessage="Could not render picking tickets."><PickingTicketPrintAll /></ErrorBoundary>} />
         <Route path="/picking-tickets/:soId/print" element={<ErrorBoundary fallbackMessage="Could not render picking ticket."><PickingTicketPrint /></ErrorBoundary>} />
         <Route path="/packing" element={<ErrorBoundary fallbackMessage="Could not load packing."><Packing /></ErrorBoundary>} />
         <Route path="/shipping" element={<ErrorBoundary fallbackMessage="Could not load shipping."><Shipping /></ErrorBoundary>} />

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -32,6 +32,7 @@ const NAV = [
     label: 'Outbound',
     items: [
       { to: '/sales-orders', label: 'Sales Orders', pageKey: 'sales-orders' },
+      { to: '/picking-tickets', label: 'Picking Tickets', pageKey: 'picking-tickets' },
       { to: '/picking', label: 'Picking', pageKey: 'picking' },
       { to: '/packing', label: 'Packing', pageKey: 'packing' },
       { to: '/shipping', label: 'Shipping', pageKey: 'shipping' },

--- a/admin/src/pages/PickingTicketPrint.jsx
+++ b/admin/src/pages/PickingTicketPrint.jsx
@@ -230,6 +230,16 @@ export default function PickingTicketPrint() {
       setLines(data.lines || []);
       setBranding(data.branding || {});
       setLoading(false);
+      // mig 064: confirm-render trigger. Once we have both the SO
+      // header and its lines, fire-and-forget a mark-printed POST so
+      // this SO drops out of the Picking Tickets queue. Errors are
+      // ignored - the queue defaults to hiding only confirmed prints,
+      // so a network blip just means the SO stays visible.
+      if (data.sales_order?.so_id) {
+        api.post('/admin/sales-orders/mark-printed', {
+          so_ids: [data.sales_order.so_id],
+        }).catch(() => {});
+      }
     }
     load();
     return () => { cancelled = true; };

--- a/admin/src/pages/PickingTicketPrint.jsx
+++ b/admin/src/pages/PickingTicketPrint.jsx
@@ -68,6 +68,128 @@ function BarcodeSvg({ value, className, modulePx, height }) {
   );
 }
 
+export function TicketDocument({ so, lines, branding = {} }) {
+  const orderNumber = so.so_number || '';
+  const addressLines = shippingAddressLines(so);
+  return (
+    <div className="pt-page">
+      <table className="pt-header">
+        <tbody>
+          <tr>
+            <td rowSpan={3} className="pt-logo-cell">
+              <div className="pt-logo-row">
+                {branding.logo_url && (
+                  <img src={branding.logo_url} className="pt-logo" alt={branding.company_name || 'Company logo'} />
+                )}
+                {(branding.company_name || branding.company_address) && (
+                  <div className="pt-nameandaddress">
+                    {branding.company_name && (<>{branding.company_name}<br /></>)}
+                    {(branding.company_address || '').split(/\r?\n/).filter(Boolean).map((ln, i) => (
+                      <span key={i}>{ln}<br /></span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </td>
+            <td className="pt-right"><span className="pt-title">Packing Slip</span></td>
+          </tr>
+          <tr>
+            <td className="pt-right"><span className="pt-number">Order #{orderNumber}</span></td>
+          </tr>
+          <tr>
+            <td className="pt-right">Must ship by: {formatUSDate(so.ship_by_date)}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <br />
+
+      <table>
+        <tbody>
+          <tr>
+            <td className="pt-address-header"><b>Shipping Address</b></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td className="pt-address">
+              <b>Ship To:</b><br />
+              {addressLines.map((l, i) => (
+                <span key={i}>{l}{i < addressLines.length - 1 ? <br /> : null}</span>
+              ))}
+            </td>
+            <td className="pt-right">
+              <BarcodeSvg
+                value={orderNumber}
+                className="pt-barcode-small"
+                modulePx={1}
+                height={32}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <table className="pt-body">
+        <tbody>
+          <tr><th>Shipping Method</th><th>Order Date</th></tr>
+          <tr>
+            <td>{so.ship_method || ''}</td>
+            <td>{formatUSDate(so.order_date || so.created_at)}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <table className="pt-itemtable">
+        <thead>
+          <tr>
+            <th className="pt-center" colSpan={3}>Qty</th>
+            <th className="pt-center" colSpan={3}>Shipped</th>
+            <th colSpan={16}>Item</th>
+            <th colSpan={3}>Box</th>
+            <th className="pt-right" colSpan={5}>Bin</th>
+            <th className="pt-right" colSpan={4}>UPC</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lines.map((l) => (
+            <tr key={l.so_line_id}>
+              <td className="pt-center" colSpan={3} style={{ lineHeight: '150%' }}>{l.quantity_ordered}</td>
+              <td className="pt-center" colSpan={3} style={{ lineHeight: '150%' }}>{l.quantity_shipped}</td>
+              <td colSpan={16}>
+                <span className="pt-itemname">{l.sku} {l.item_name}</span>
+              </td>
+              <td colSpan={3}></td>
+              <td className="pt-right" colSpan={5}>{l.preferred_bin_code || ''}</td>
+              <td className="pt-right" colSpan={4}>{l.upc || ''}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="pt-tail">
+        {branding.returns_text && (
+          <div className="pt-returns">
+            {branding.returns_text}
+          </div>
+        )}
+
+        <div className="pt-footer">
+          <div>
+            <BarcodeSvg
+              value={orderNumber}
+              className="pt-barcode-large"
+              modulePx={1.2}
+              height={40}
+            />
+          </div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function PickingTicketPrint() {
   const { soId } = useParams();
   const [so, setSo] = useState(null);
@@ -133,131 +255,13 @@ export default function PickingTicketPrint() {
     );
   }
 
-  const orderNumber = so.so_number || '';
-  const addressLines = shippingAddressLines(so);
-
   return (
     <div className="pt-root">
       <div className="pt-toolbar pt-no-print">
         <Link to="/picking-tickets" className="pt-back">&larr; Back</Link>
         <button onClick={() => window.print()}>Print</button>
       </div>
-
-      <div className="pt-page">
-        <table className="pt-header">
-          <tbody>
-            <tr>
-              <td rowSpan={3} className="pt-logo-cell">
-                <div className="pt-logo-row">
-                  {branding.logo_url && (
-                    <img src={branding.logo_url} className="pt-logo" alt={branding.company_name || 'Company logo'} />
-                  )}
-                  {(branding.company_name || branding.company_address) && (
-                    <div className="pt-nameandaddress">
-                      {branding.company_name && (<>{branding.company_name}<br /></>)}
-                      {(branding.company_address || '').split(/\r?\n/).filter(Boolean).map((ln, i) => (
-                        <span key={i}>{ln}<br /></span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </td>
-              <td className="pt-right"><span className="pt-title">Packing Slip</span></td>
-            </tr>
-            <tr>
-              <td className="pt-right"><span className="pt-number">Order #{orderNumber}</span></td>
-            </tr>
-            <tr>
-              <td className="pt-right">Must ship by: {formatUSDate(so.ship_by_date)}</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <br />
-
-        <table>
-          <tbody>
-            <tr>
-              <td className="pt-address-header"><b>Shipping Address</b></td>
-              <td></td>
-            </tr>
-            <tr>
-              <td className="pt-address">
-                <b>Ship To:</b><br />
-                {addressLines.map((l, i) => (
-                  <span key={i}>{l}{i < addressLines.length - 1 ? <br /> : null}</span>
-                ))}
-              </td>
-              <td className="pt-right">
-                <BarcodeSvg
-                  value={orderNumber}
-                  className="pt-barcode-small"
-                  modulePx={1}
-                  height={32}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <table className="pt-body">
-          <tbody>
-            <tr><th>Shipping Method</th><th>Order Date</th></tr>
-            <tr>
-              <td>{so.ship_method || ''}</td>
-              <td>{formatUSDate(so.order_date || so.created_at)}</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <table className="pt-itemtable">
-          <thead>
-            <tr>
-              <th className="pt-center" colSpan={3}>Qty</th>
-              <th className="pt-center" colSpan={3}>Shipped</th>
-              <th colSpan={16}>Item</th>
-              <th colSpan={3}>Box</th>
-              <th className="pt-right" colSpan={5}>Bin</th>
-              <th className="pt-right" colSpan={4}>UPC</th>
-            </tr>
-          </thead>
-          <tbody>
-            {lines.map((l) => (
-              <tr key={l.so_line_id}>
-                <td className="pt-center" colSpan={3} style={{ lineHeight: '150%' }}>{l.quantity_ordered}</td>
-                <td className="pt-center" colSpan={3} style={{ lineHeight: '150%' }}>{l.quantity_shipped}</td>
-                <td colSpan={16}>
-                  <span className="pt-itemname">{l.sku} {l.item_name}</span>
-                </td>
-                <td colSpan={3}></td>
-                <td className="pt-right" colSpan={5}>{l.preferred_bin_code || ''}</td>
-                <td className="pt-right" colSpan={4}>{l.upc || ''}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-
-        <div className="pt-tail">
-          {branding.returns_text && (
-            <div className="pt-returns">
-              {branding.returns_text}
-            </div>
-          )}
-
-          <div className="pt-footer">
-            <div>
-              <BarcodeSvg
-                value={orderNumber}
-                className="pt-barcode-large"
-                modulePx={1.2}
-                height={40}
-              />
-            </div>
-            <div></div>
-            <div></div>
-          </div>
-        </div>
-      </div>
+      <TicketDocument so={so} lines={lines} branding={branding} />
     </div>
   );
 }

--- a/admin/src/pages/PickingTicketPrint.jsx
+++ b/admin/src/pages/PickingTicketPrint.jsx
@@ -1,0 +1,263 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api } from '../api.js';
+import { encodeCode128B } from '../utils/code128.js';
+import './pickingTicket.css';
+
+function formatUSDate(value) {
+  if (!value) return '';
+  // Accept both 'YYYY-MM-DD' and ISO timestamps. Building a Date from
+  // 'YYYY-MM-DD' alone hits the UTC-midnight gotcha (shifts a day in
+  // negative TZ), so split and rebuild as local.
+  const datePart = String(value).slice(0, 10);
+  const [y, m, d] = datePart.split('-').map(Number);
+  if (!y || !m || !d) return '';
+  return `${String(m).padStart(2, '0')}/${String(d).padStart(2, '0')}/${y}`;
+}
+
+function shippingAddressLines(so) {
+  const lines = [];
+  const name = so.shipping_address_name || so.customer_name || '';
+  if (name) lines.push(name);
+  if (so.shipping_address_line1) lines.push(so.shipping_address_line1);
+  if (so.shipping_address_line2) lines.push(so.shipping_address_line2);
+  const cityStateZip = [
+    so.shipping_address_city,
+    so.shipping_address_state,
+    so.shipping_address_postal_code,
+  ].filter(Boolean).join(' ');
+  if (cityStateZip) lines.push(cityStateZip);
+  if (lines.length === 0 && so.ship_address) {
+    // Legacy single-string ship address fallback. Split on newlines so
+    // multi-line legacy data still stacks visually.
+    return String(so.ship_address).split(/\r?\n/).filter(Boolean);
+  }
+  return lines;
+}
+
+function BarcodeSvg({ value, className, modulePx, height }) {
+  // Render Code 128 modules as <rect> elements. We never inject the
+  // user-supplied value into SVG text content, only into the encoder
+  // (which only emits numeric module widths) -- so this stays safe
+  // against arbitrary input.
+  const { bars, width } = useMemo(() => {
+    const { segments, totalModules } = encodeCode128B(value || '');
+    const out = [];
+    let cursor = 0;
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i];
+      const segWidth = seg.width * modulePx;
+      if (seg.black) out.push({ key: i, x: cursor, w: segWidth });
+      cursor += segWidth;
+    }
+    return { bars: out, width: totalModules * modulePx };
+  }, [value, modulePx]);
+  if (width === 0) return null;
+  return (
+    <svg
+      className={className}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label={`Barcode ${value}`}
+    >
+      {bars.map((b) => (
+        <rect key={b.key} x={b.x} y={0} width={b.w} height={height} fill="#000" />
+      ))}
+    </svg>
+  );
+}
+
+export default function PickingTicketPrint() {
+  const { soId } = useParams();
+  const [so, setSo] = useState(null);
+  const [lines, setLines] = useState([]);
+  const [branding, setBranding] = useState({});
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError('');
+      const res = await api.get(`/admin/sales-orders/${soId}/picking-ticket`);
+      if (cancelled) return;
+      if (!res) {
+        setError('Network error.');
+        setLoading(false);
+        return;
+      }
+      if (res.status === 404) {
+        setError(`Sales order #${soId} not found.`);
+        setLoading(false);
+        return;
+      }
+      if (!res.ok) {
+        setError(`Could not load sales order #${soId}.`);
+        setLoading(false);
+        return;
+      }
+      const data = await res.json();
+      setSo(data.sales_order || null);
+      setLines(data.lines || []);
+      setBranding(data.branding || {});
+      setLoading(false);
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [soId]);
+
+  if (loading) {
+    return (
+      <div className="pt-root">
+        <div className="pt-toolbar pt-no-print">
+          <Link to="/picking-tickets" className="pt-back">&larr; Back</Link>
+        </div>
+        <div className="pt-page">Loading ticket…</div>
+      </div>
+    );
+  }
+
+  if (error || !so) {
+    return (
+      <div className="pt-root">
+        <div className="pt-toolbar pt-no-print">
+          <Link to="/picking-tickets" className="pt-back">&larr; Back</Link>
+        </div>
+        <div className="pt-page">
+          <h2>Could not render ticket</h2>
+          <p>{error || 'Sales order data was empty.'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const orderNumber = so.so_number || '';
+  const addressLines = shippingAddressLines(so);
+
+  return (
+    <div className="pt-root">
+      <div className="pt-toolbar pt-no-print">
+        <Link to="/picking-tickets" className="pt-back">&larr; Back</Link>
+        <button onClick={() => window.print()}>Print</button>
+      </div>
+
+      <div className="pt-page">
+        <table className="pt-header">
+          <tbody>
+            <tr>
+              <td rowSpan={3} className="pt-logo-cell">
+                <div className="pt-logo-row">
+                  {branding.logo_url && (
+                    <img src={branding.logo_url} className="pt-logo" alt={branding.company_name || 'Company logo'} />
+                  )}
+                  {(branding.company_name || branding.company_address) && (
+                    <div className="pt-nameandaddress">
+                      {branding.company_name && (<>{branding.company_name}<br /></>)}
+                      {(branding.company_address || '').split(/\r?\n/).filter(Boolean).map((ln, i) => (
+                        <span key={i}>{ln}<br /></span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </td>
+              <td className="pt-right"><span className="pt-title">Packing Slip</span></td>
+            </tr>
+            <tr>
+              <td className="pt-right"><span className="pt-number">Order #{orderNumber}</span></td>
+            </tr>
+            <tr>
+              <td className="pt-right">Must ship by: {formatUSDate(so.ship_by_date)}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <br />
+
+        <table>
+          <tbody>
+            <tr>
+              <td className="pt-address-header"><b>Shipping Address</b></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td className="pt-address">
+                <b>Ship To:</b><br />
+                {addressLines.map((l, i) => (
+                  <span key={i}>{l}{i < addressLines.length - 1 ? <br /> : null}</span>
+                ))}
+              </td>
+              <td className="pt-right">
+                <BarcodeSvg
+                  value={orderNumber}
+                  className="pt-barcode-small"
+                  modulePx={1}
+                  height={32}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table className="pt-body">
+          <tbody>
+            <tr><th>Shipping Method</th><th>Order Date</th></tr>
+            <tr>
+              <td>{so.ship_method || ''}</td>
+              <td>{formatUSDate(so.order_date || so.created_at)}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table className="pt-itemtable">
+          <thead>
+            <tr>
+              <th className="pt-center" colSpan={3}>Qty</th>
+              <th className="pt-center" colSpan={3}>Shipped</th>
+              <th colSpan={16}>Item</th>
+              <th colSpan={3}>Box</th>
+              <th className="pt-right" colSpan={5}>Bin</th>
+              <th className="pt-right" colSpan={4}>UPC</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lines.map((l) => (
+              <tr key={l.so_line_id}>
+                <td className="pt-center" colSpan={3} style={{ lineHeight: '150%' }}>{l.quantity_ordered}</td>
+                <td className="pt-center" colSpan={3} style={{ lineHeight: '150%' }}>{l.quantity_shipped}</td>
+                <td colSpan={16}>
+                  <span className="pt-itemname">{l.sku} {l.item_name}</span>
+                </td>
+                <td colSpan={3}></td>
+                <td className="pt-right" colSpan={5}>{l.preferred_bin_code || ''}</td>
+                <td className="pt-right" colSpan={4}>{l.upc || ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <div className="pt-tail">
+          {branding.returns_text && (
+            <div className="pt-returns">
+              {branding.returns_text}
+            </div>
+          )}
+
+          <div className="pt-footer">
+            <div>
+              <BarcodeSvg
+                value={orderNumber}
+                className="pt-barcode-large"
+                modulePx={1.2}
+                height={40}
+              />
+            </div>
+            <div></div>
+            <div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/admin/src/pages/PickingTicketPrint.jsx
+++ b/admin/src/pages/PickingTicketPrint.jsx
@@ -2,18 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { api } from '../api.js';
 import { encodeCode128B } from '../utils/code128.js';
+import { formatDateOnly } from '../utils/date.js';
 import './pickingTicket.css';
-
-function formatUSDate(value) {
-  if (!value) return '';
-  // Accept both 'YYYY-MM-DD' and ISO timestamps. Building a Date from
-  // 'YYYY-MM-DD' alone hits the UTC-midnight gotcha (shifts a day in
-  // negative TZ), so split and rebuild as local.
-  const datePart = String(value).slice(0, 10);
-  const [y, m, d] = datePart.split('-').map(Number);
-  if (!y || !m || !d) return '';
-  return `${String(m).padStart(2, '0')}/${String(d).padStart(2, '0')}/${y}`;
-}
 
 function shippingAddressLines(so) {
   const lines = [];
@@ -97,7 +87,7 @@ export function TicketDocument({ so, lines, branding = {} }) {
             <td className="pt-right"><span className="pt-number">Order #{orderNumber}</span></td>
           </tr>
           <tr>
-            <td className="pt-right">Must ship by: {formatUSDate(so.ship_by_date)}</td>
+            <td className="pt-right">Must ship by: {formatDateOnly(so.ship_by_date)}</td>
           </tr>
         </tbody>
       </table>
@@ -134,7 +124,7 @@ export function TicketDocument({ so, lines, branding = {} }) {
           <tr><th>Shipping Method</th><th>Order Date</th></tr>
           <tr>
             <td>{so.ship_method || ''}</td>
-            <td>{formatUSDate(so.order_date || so.created_at)}</td>
+            <td>{formatDateOnly(so.order_date || so.created_at)}</td>
           </tr>
         </tbody>
       </table>

--- a/admin/src/pages/PickingTicketPrint.jsx
+++ b/admin/src/pages/PickingTicketPrint.jsx
@@ -197,6 +197,11 @@ export default function PickingTicketPrint() {
   const [branding, setBranding] = useState({});
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
+  // Bump to force a re-fetch of the current ticket. Lets a picker
+  // pull fresh data without leaving the page (e.g. after an upstream
+  // connector writes new shipping_address_* on an SO they already
+  // have open).
+  const [refreshCounter, setRefreshCounter] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -228,7 +233,7 @@ export default function PickingTicketPrint() {
     }
     load();
     return () => { cancelled = true; };
-  }, [soId]);
+  }, [soId, refreshCounter]);
 
   if (loading) {
     return (
@@ -259,6 +264,13 @@ export default function PickingTicketPrint() {
     <div className="pt-root">
       <div className="pt-toolbar pt-no-print">
         <Link to="/picking-tickets" className="pt-back">&larr; Back</Link>
+        <button
+          onClick={() => setRefreshCounter((c) => c + 1)}
+          disabled={loading}
+          title="Re-fetch this ticket's data from the server"
+        >
+          {loading ? 'Refreshing…' : 'Refresh'}
+        </button>
         <button onClick={() => window.print()}>Print</button>
       </div>
       <TicketDocument so={so} lines={lines} branding={branding} />

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -44,6 +44,18 @@ export default function PickingTicketPrintAll() {
         setLoading(false);
         return;
       }
+      // Sort by ship_by_date ascending so the printer stack comes out
+      // oldest-first, matching the default sort on the list page.
+      // Nulls sink to the bottom so SOs without a ship-by date do not
+      // hijack the top of the stack.
+      orders.sort((a, b) => {
+        const ad = a.ship_by_date;
+        const bd = b.ship_by_date;
+        if (!ad && !bd) return 0;
+        if (!ad) return 1;
+        if (!bd) return -1;
+        return new Date(ad) - new Date(bd);
+      });
       const detailResponses = await Promise.all(
         orders.map((o) => api.get(`/admin/sales-orders/${o.so_id}/picking-ticket`)),
       );

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -14,6 +14,12 @@ export default function PickingTicketPrintAll() {
   const [params] = useSearchParams();
   const status = params.get('status') || 'OPEN';
   const warehouseId = params.get('warehouse_id') || '';
+  // Optional comma-separated SO order from the list page. When
+  // present, we reorder fetched SOs to match this sequence so the
+  // print stack reflects the operator's chosen column sort. Absent
+  // (e.g. someone deep-links this URL) we fall back to the legacy
+  // primary_bin_pick_sequence sort.
+  const requestedOrderParam = params.get('so_ids') || '';
   const [tickets, setTickets] = useState([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
@@ -51,26 +57,42 @@ export default function PickingTicketPrintAll() {
         setLoading(false);
         return;
       }
-      // Sort by primary_bin_pick_sequence ascending so the printer
-      // stack matches the picker's physical walk through the
-      // warehouse and the shipper unpacks in the same order. SOs
-      // without a primary bin (no preferred_bins for their items)
-      // sink to the bottom of the stack with a secondary
-      // ship_by_date tiebreak so they remain ordered among
-      // themselves.
-      orders.sort((a, b) => {
-        const aps = a.primary_bin_pick_sequence;
-        const bps = b.primary_bin_pick_sequence;
-        if (aps != null && bps != null) return aps - bps;
-        if (aps != null) return -1;
-        if (bps != null) return 1;
-        const ad = a.ship_by_date;
-        const bd = b.ship_by_date;
-        if (!ad && !bd) return 0;
-        if (!ad) return 1;
-        if (!bd) return -1;
-        return new Date(ad) - new Date(bd);
-      });
+      const requestedIds = requestedOrderParam
+        ? requestedOrderParam.split(',').map((s) => parseInt(s, 10)).filter(Number.isFinite)
+        : [];
+      if (requestedIds.length > 0) {
+        // Honor the list page's sort. Build a rank map so SOs the
+        // operator did not see (status changed between tabs, late
+        // arrivals after they hit Print All) sink to the bottom but
+        // still print rather than getting silently dropped.
+        const rank = new Map(requestedIds.map((id, i) => [id, i]));
+        orders.sort((a, b) => {
+          const ra = rank.has(a.so_id) ? rank.get(a.so_id) : Number.MAX_SAFE_INTEGER;
+          const rb = rank.has(b.so_id) ? rank.get(b.so_id) : Number.MAX_SAFE_INTEGER;
+          return ra - rb;
+        });
+      } else {
+        // Legacy fallback for deep-linked print URLs without an
+        // explicit order. Sort by primary_bin_pick_sequence ascending
+        // so the printer stack matches the picker's physical walk
+        // through the warehouse. SOs without a primary bin (no
+        // preferred_bins for their items) sink to the bottom with a
+        // ship_by_date tiebreak so they remain ordered among
+        // themselves.
+        orders.sort((a, b) => {
+          const aps = a.primary_bin_pick_sequence;
+          const bps = b.primary_bin_pick_sequence;
+          if (aps != null && bps != null) return aps - bps;
+          if (aps != null) return -1;
+          if (bps != null) return 1;
+          const ad = a.ship_by_date;
+          const bd = b.ship_by_date;
+          if (!ad && !bd) return 0;
+          if (!ad) return 1;
+          if (!bd) return -1;
+          return new Date(ad) - new Date(bd);
+        });
+      }
       const detailResponses = await Promise.all(
         orders.map((o) => api.get(`/admin/sales-orders/${o.so_id}/picking-ticket`)),
       );
@@ -100,7 +122,7 @@ export default function PickingTicketPrintAll() {
     }
     load();
     return () => { cancelled = true; };
-  }, [status, warehouseId]);
+  }, [status, warehouseId, requestedOrderParam]);
 
   // Update the tab title once we know the count, so the user can
   // tell the queue tabs apart.

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -26,7 +26,14 @@ export default function PickingTicketPrintAll() {
       const statuses = status === 'ALL' ? PICKABLE_STATUSES : [status];
       const listResponses = await Promise.all(
         statuses.map((s) => {
-          const qs = new URLSearchParams({ status: s, per_page: '50' });
+          const qs = new URLSearchParams({
+            status: s,
+            per_page: '50',
+            // Pull primary_bin_pick_sequence so we can sort the print
+            // stack in warehouse-walk order. The picker fills the cart
+            // in this order; the shipper unpacks in the same order.
+            include_primary_bin: 'true',
+          });
           if (warehouseId) qs.set('warehouse_id', warehouseId);
           return api.get(`/admin/sales-orders?${qs.toString()}`);
         }),
@@ -44,11 +51,19 @@ export default function PickingTicketPrintAll() {
         setLoading(false);
         return;
       }
-      // Sort by ship_by_date ascending so the printer stack comes out
-      // oldest-first, matching the default sort on the list page.
-      // Nulls sink to the bottom so SOs without a ship-by date do not
-      // hijack the top of the stack.
+      // Sort by primary_bin_pick_sequence ascending so the printer
+      // stack matches the picker's physical walk through the
+      // warehouse and the shipper unpacks in the same order. SOs
+      // without a primary bin (no preferred_bins for their items)
+      // sink to the bottom of the stack with a secondary
+      // ship_by_date tiebreak so they remain ordered among
+      // themselves.
       orders.sort((a, b) => {
+        const aps = a.primary_bin_pick_sequence;
+        const bps = b.primary_bin_pick_sequence;
+        if (aps != null && bps != null) return aps - bps;
+        if (aps != null) return -1;
+        if (bps != null) return 1;
         const ad = a.ship_by_date;
         const bd = b.ship_by_date;
         if (!ad && !bd) return 0;

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -28,7 +28,7 @@ export default function PickingTicketPrintAll() {
         statuses.map((s) => {
           const qs = new URLSearchParams({
             status: s,
-            per_page: '50',
+            per_page: '100',
             // Pull primary_bin_pick_sequence so we can sort the print
             // stack in warehouse-walk order. The picker fills the cart
             // in this order; the shipper unpacks in the same order.

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -1,11 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { api } from '../api.js';
 import { TicketDocument } from './PickingTicketPrint.jsx';
 import './pickingTicket.css';
 
 const PICKABLE_STATUSES = ['OPEN', 'PICKED'];
 
+// Standalone print-queue view. Opened in a new tab from the picking
+// tickets page; renders every ticket in the current status filter
+// stacked one per page so the user can hit Ctrl/Cmd+P natively. No
+// toolbar, no auto-print, no admin Layout chrome.
 export default function PickingTicketPrintAll() {
   const [params] = useSearchParams();
   const status = params.get('status') || 'OPEN';
@@ -13,7 +17,6 @@ export default function PickingTicketPrintAll() {
   const [tickets, setTickets] = useState([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
-  const printedRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -54,9 +57,7 @@ export default function PickingTicketPrintAll() {
         }
       }
       if (cancelled) return;
-      if (out.length === 0) {
-        setError('No tickets could be loaded.');
-      }
+      if (out.length === 0) setError('No tickets could be loaded.');
       setTickets(out);
       setLoading(false);
     }
@@ -64,49 +65,47 @@ export default function PickingTicketPrintAll() {
     return () => { cancelled = true; };
   }, [status, warehouseId]);
 
-  // Auto-trigger the print dialog once tickets are rendered. Guarded
-  // by a ref so React's StrictMode double-invoke doesn't fire it twice.
+  // Update the tab title once we know the count, so the user can
+  // tell the queue tabs apart.
   useEffect(() => {
-    if (loading || error || tickets.length === 0) return;
-    if (printedRef.current) return;
-    printedRef.current = true;
-    // Defer to next tick so the DOM has flushed all ticket pages
-    // before the browser snapshots them for print preview.
-    const t = setTimeout(() => window.print(), 100);
-    return () => clearTimeout(t);
-  }, [loading, error, tickets.length]);
+    if (loading) {
+      document.title = 'Loading picking tickets…';
+    } else if (error) {
+      document.title = 'Picking tickets — error';
+    } else {
+      document.title = `Picking tickets (${tickets.length}) — ${status}`;
+    }
+  }, [loading, error, tickets.length, status]);
 
-  return (
-    <div className="pt-root">
-      <div className="pt-toolbar pt-no-print">
-        <Link to="/picking-tickets" className="pt-back">&larr; Back</Link>
-        <span style={{ fontSize: '10pt', color: '#333' }}>
-          {loading
-            ? 'Loading tickets…'
-            : `${tickets.length} ticket${tickets.length === 1 ? '' : 's'} (${status})`}
-        </span>
-        <button onClick={() => window.print()} disabled={loading || tickets.length === 0}>
-          Print
-        </button>
-      </div>
+  if (loading) {
+    return <div className="pt-root"><div className="pt-page">Loading tickets…</div></div>;
+  }
 
-      {loading && <div className="pt-page">Loading tickets…</div>}
-
-      {!loading && error && (
+  if (error) {
+    return (
+      <div className="pt-root">
         <div className="pt-page">
           <h2>Could not render tickets</h2>
           <p>{error}</p>
         </div>
-      )}
+      </div>
+    );
+  }
 
-      {!loading && !error && tickets.length === 0 && (
+  if (tickets.length === 0) {
+    return (
+      <div className="pt-root">
         <div className="pt-page">
           <h2>No tickets to print</h2>
           <p>No sales orders matched status {status}.</p>
         </div>
-      )}
+      </div>
+    );
+  }
 
-      {!loading && tickets.map(({ so, lines, branding }) => (
+  return (
+    <div className="pt-root">
+      {tickets.map(({ so, lines, branding }) => (
         <TicketDocument key={so.so_id} so={so} lines={lines} branding={branding} />
       ))}
     </div>

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { api } from '../api.js';
 import { TicketDocument } from './PickingTicketPrint.jsx';
+import { PRINT_BATCH_LIMIT } from './pickingConstants.js';
 import './pickingTicket.css';
 
 const PICKABLE_STATUSES = ['OPEN', 'PICKED'];
@@ -75,7 +76,7 @@ export default function PickingTicketPrintAll() {
           statuses.map((s) => {
             const qs = new URLSearchParams({
               status: s,
-              per_page: '100',
+              per_page: String(PRINT_BATCH_LIMIT),
               // primary_bin_pick_sequence drives the warehouse-walk sort.
               include_primary_bin: 'true',
             });
@@ -107,6 +108,11 @@ export default function PickingTicketPrintAll() {
       }
 
       if (cancelled) return;
+
+      // One tab renders at most PRINT_BATCH_LIMIT tickets. The list page
+      // already slices its hand-off to this; we re-clamp so a stale or
+      // hand-edited URL can't stack an unbounded run into one tab.
+      soIds = soIds.slice(0, PRINT_BATCH_LIMIT);
       if (soIds.length === 0) {
         setTickets([]);
         setLoading(false);

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -34,11 +34,12 @@ export default function PickingTicketPrintAll() {
   const [params] = useSearchParams();
   const status = params.get('status') || 'OPEN';
   const warehouseId = params.get('warehouse_id') || '';
-  // Optional comma-separated SO order from the list page. When
-  // present, we reorder fetched SOs to match this sequence so the
-  // print stack reflects the operator's chosen column sort. Absent
-  // (e.g. someone deep-links this URL) we fall back to the legacy
-  // primary_bin_pick_sequence sort.
+  // Comma-separated SO ids from the list page: the authoritative set
+  // AND order to print, already Hide-Printed-filtered and sorted exactly
+  // as the operator sees them. When present we print precisely these and
+  // skip re-deriving the queue, so the print stack can never drift from
+  // the screen. Absent (a hand-typed or bookmarked deep link) we fall
+  // back to fetching the status queue in warehouse-walk order.
   const requestedOrderParam = params.get('so_ids') || '';
   const [tickets, setTickets] = useState([]);
   const [error, setError] = useState('');
@@ -52,56 +53,43 @@ export default function PickingTicketPrintAll() {
       setLoading(true);
       setError('');
       setMarkPrintedFailed(false);
-      const statuses = status === 'ALL' ? PICKABLE_STATUSES : [status];
-      const listResponses = await Promise.all(
-        statuses.map((s) => {
-          const qs = new URLSearchParams({
-            status: s,
-            per_page: '100',
-            // Pull primary_bin_pick_sequence so we can sort the print
-            // stack in warehouse-walk order. The picker fills the cart
-            // in this order; the shipper unpacks in the same order.
-            include_primary_bin: 'true',
-          });
-          if (warehouseId) qs.set('warehouse_id', warehouseId);
-          return api.get(`/admin/sales-orders?${qs.toString()}`);
-        }),
-      );
-      const orders = [];
-      for (const res of listResponses) {
-        if (res?.ok) {
-          const data = await res.json();
-          orders.push(...(data.sales_orders || []));
-        }
-      }
-      if (cancelled) return;
-      if (orders.length === 0) {
-        setTickets([]);
-        setLoading(false);
-        return;
-      }
-      const requestedIds = requestedOrderParam
+
+      // Resolve the ordered set of SO ids to print. When the list page
+      // handed over so_ids, that IS the queue - already Hide-Printed
+      // filtered and sorted as the operator sees it - so we use it
+      // verbatim and never re-fetch the list. This is what keeps the
+      // print stack identical to the screen (no already-printed tickets
+      // leaking in, no sort drift).
+      let soIds = requestedOrderParam
         ? requestedOrderParam.split(',').map((s) => parseInt(s, 10)).filter(Number.isFinite)
         : [];
-      if (requestedIds.length > 0) {
-        // Honor the list page's sort. Build a rank map so SOs the
-        // operator did not see (status changed between tabs, late
-        // arrivals after they hit Print All) sink to the bottom but
-        // still print rather than getting silently dropped.
-        const rank = new Map(requestedIds.map((id, i) => [id, i]));
-        orders.sort((a, b) => {
-          const ra = rank.has(a.so_id) ? rank.get(a.so_id) : Number.MAX_SAFE_INTEGER;
-          const rb = rank.has(b.so_id) ? rank.get(b.so_id) : Number.MAX_SAFE_INTEGER;
-          return ra - rb;
-        });
-      } else {
-        // Legacy fallback for deep-linked print URLs without an
-        // explicit order. Sort by primary_bin_pick_sequence ascending
-        // so the printer stack matches the picker's physical walk
-        // through the warehouse. SOs without a primary bin (no
-        // preferred_bins for their items) sink to the bottom with a
-        // ship_by_date tiebreak so they remain ordered among
-        // themselves.
+
+      if (soIds.length === 0) {
+        // Deep-link fallback only (hand-typed or bookmarked URL with no
+        // so_ids). Rediscover the status queue ourselves and sort by
+        // warehouse-walk order (primary_bin_pick_sequence) with a
+        // ship_by_date tiebreak. No Hide-Printed filter here by design:
+        // a bare deep link is an explicit "print this whole status".
+        const statuses = status === 'ALL' ? PICKABLE_STATUSES : [status];
+        const listResponses = await Promise.all(
+          statuses.map((s) => {
+            const qs = new URLSearchParams({
+              status: s,
+              per_page: '100',
+              // primary_bin_pick_sequence drives the warehouse-walk sort.
+              include_primary_bin: 'true',
+            });
+            if (warehouseId) qs.set('warehouse_id', warehouseId);
+            return api.get(`/admin/sales-orders?${qs.toString()}`);
+          }),
+        );
+        const orders = [];
+        for (const res of listResponses) {
+          if (res?.ok) {
+            const data = await res.json();
+            orders.push(...(data.sales_orders || []));
+          }
+        }
         orders.sort((a, b) => {
           const aps = a.primary_bin_pick_sequence;
           const bps = b.primary_bin_pick_sequence;
@@ -115,13 +103,23 @@ export default function PickingTicketPrintAll() {
           if (!bd) return -1;
           return new Date(ad) - new Date(bd);
         });
+        soIds = orders.map((o) => o.so_id);
       }
+
+      if (cancelled) return;
+      if (soIds.length === 0) {
+        setTickets([]);
+        setLoading(false);
+        return;
+      }
+
+      // Fetch ticket detail per SO in the resolved order. Promise.all
+      // preserves index order, so the rendered stack matches soIds.
       const detailResponses = await Promise.all(
-        orders.map((o) => api.get(`/admin/sales-orders/${o.so_id}/picking-ticket`)),
+        soIds.map((id) => api.get(`/admin/sales-orders/${id}/picking-ticket`)),
       );
       const out = [];
-      for (let i = 0; i < detailResponses.length; i++) {
-        const res = detailResponses[i];
+      for (const res of detailResponses) {
         if (!res?.ok) continue;
         const data = await res.json();
         if (data.sales_order) {
@@ -129,7 +127,11 @@ export default function PickingTicketPrintAll() {
         }
       }
       if (cancelled) return;
-      if (out.length === 0) setError('No tickets could be loaded.');
+      if (out.length === 0) {
+        setError('No tickets could be loaded.');
+        setLoading(false);
+        return;
+      }
       setTickets(out);
       setLoading(false);
       // mig 064: only mark SOs whose ticket data actually made it into
@@ -139,10 +141,8 @@ export default function PickingTicketPrintAll() {
       // losing them. Persistent mark-printed failures surface via the
       // toast below so the operator knows to verify the list rather
       // than assume the DB matches the screen.
-      if (out.length > 0) {
-        const ok = await markPrintedWithRetry(out.map((t) => t.so.so_id));
-        if (!cancelled && !ok) setMarkPrintedFailed(true);
-      }
+      const ok = await markPrintedWithRetry(out.map((t) => t.so.so_id));
+      if (!cancelled && !ok) setMarkPrintedFailed(true);
     }
     load();
     return () => { cancelled = true; };

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { api } from '../api.js';
+import { TicketDocument } from './PickingTicketPrint.jsx';
+import './pickingTicket.css';
+
+const PICKABLE_STATUSES = ['OPEN', 'PICKED'];
+
+export default function PickingTicketPrintAll() {
+  const [params] = useSearchParams();
+  const status = params.get('status') || 'OPEN';
+  const warehouseId = params.get('warehouse_id') || '';
+  const [tickets, setTickets] = useState([]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const printedRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError('');
+      const statuses = status === 'ALL' ? PICKABLE_STATUSES : [status];
+      const listResponses = await Promise.all(
+        statuses.map((s) => {
+          const qs = new URLSearchParams({ status: s, per_page: '50' });
+          if (warehouseId) qs.set('warehouse_id', warehouseId);
+          return api.get(`/admin/sales-orders?${qs.toString()}`);
+        }),
+      );
+      const orders = [];
+      for (const res of listResponses) {
+        if (res?.ok) {
+          const data = await res.json();
+          orders.push(...(data.sales_orders || []));
+        }
+      }
+      if (cancelled) return;
+      if (orders.length === 0) {
+        setTickets([]);
+        setLoading(false);
+        return;
+      }
+      const detailResponses = await Promise.all(
+        orders.map((o) => api.get(`/admin/sales-orders/${o.so_id}/picking-ticket`)),
+      );
+      const out = [];
+      for (let i = 0; i < detailResponses.length; i++) {
+        const res = detailResponses[i];
+        if (!res?.ok) continue;
+        const data = await res.json();
+        if (data.sales_order) {
+          out.push({ so: data.sales_order, lines: data.lines || [], branding: data.branding || {} });
+        }
+      }
+      if (cancelled) return;
+      if (out.length === 0) {
+        setError('No tickets could be loaded.');
+      }
+      setTickets(out);
+      setLoading(false);
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [status, warehouseId]);
+
+  // Auto-trigger the print dialog once tickets are rendered. Guarded
+  // by a ref so React's StrictMode double-invoke doesn't fire it twice.
+  useEffect(() => {
+    if (loading || error || tickets.length === 0) return;
+    if (printedRef.current) return;
+    printedRef.current = true;
+    // Defer to next tick so the DOM has flushed all ticket pages
+    // before the browser snapshots them for print preview.
+    const t = setTimeout(() => window.print(), 100);
+    return () => clearTimeout(t);
+  }, [loading, error, tickets.length]);
+
+  return (
+    <div className="pt-root">
+      <div className="pt-toolbar pt-no-print">
+        <Link to="/picking-tickets" className="pt-back">&larr; Back</Link>
+        <span style={{ fontSize: '10pt', color: '#333' }}>
+          {loading
+            ? 'Loading tickets…'
+            : `${tickets.length} ticket${tickets.length === 1 ? '' : 's'} (${status})`}
+        </span>
+        <button onClick={() => window.print()} disabled={loading || tickets.length === 0}>
+          Print
+        </button>
+      </div>
+
+      {loading && <div className="pt-page">Loading tickets…</div>}
+
+      {!loading && error && (
+        <div className="pt-page">
+          <h2>Could not render tickets</h2>
+          <p>{error}</p>
+        </div>
+      )}
+
+      {!loading && !error && tickets.length === 0 && (
+        <div className="pt-page">
+          <h2>No tickets to print</h2>
+          <p>No sales orders matched status {status}.</p>
+        </div>
+      )}
+
+      {!loading && tickets.map(({ so, lines, branding }) => (
+        <TicketDocument key={so.so_id} so={so} lines={lines} branding={branding} />
+      ))}
+    </div>
+  );
+}

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -168,9 +168,9 @@ export default function PickingTicketPrintAll() {
     if (loading) {
       document.title = 'Loading picking tickets…';
     } else if (error) {
-      document.title = 'Picking tickets — error';
+      document.title = 'Picking tickets - error';
     } else {
-      document.title = `Picking tickets (${tickets.length}) — ${status}`;
+      document.title = `Picking tickets (${tickets.length}) - ${status}`;
     }
   }, [loading, error, tickets.length, status]);
 

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -72,6 +72,16 @@ export default function PickingTicketPrintAll() {
       if (out.length === 0) setError('No tickets could be loaded.');
       setTickets(out);
       setLoading(false);
+      // mig 064: only mark SOs whose ticket data actually made it into
+      // the render array. Orders that failed earlier (404, network
+      // error, malformed payload) stay unprinted so they reappear in
+      // the queue and the operator can retry rather than silently
+      // losing them.
+      if (out.length > 0) {
+        api.post('/admin/sales-orders/mark-printed', {
+          so_ids: out.map((t) => t.so.so_id),
+        }).catch(() => {});
+      }
     }
     load();
     return () => { cancelled = true; };

--- a/admin/src/pages/PickingTicketPrintAll.jsx
+++ b/admin/src/pages/PickingTicketPrintAll.jsx
@@ -6,6 +6,26 @@ import './pickingTicket.css';
 
 const PICKABLE_STATUSES = ['OPEN', 'PICKED'];
 
+// POST /admin/sales-orders/mark-printed with one retry. Replaces the
+// previous fire-and-forget POST whose `.catch(() => {})` swallowed
+// every failure, so a transient network blip left printed_at NULL in
+// the DB while the operator walked away with the paper. Returns true
+// only when the server confirmed the write.
+async function markPrintedWithRetry(soIds) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await api.post('/admin/sales-orders/mark-printed', { so_ids: soIds });
+      if (res?.ok) return true;
+    } catch (_) {
+      // fall through to retry
+    }
+    if (attempt === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+  }
+  return false;
+}
+
 // Standalone print-queue view. Opened in a new tab from the picking
 // tickets page; renders every ticket in the current status filter
 // stacked one per page so the user can hit Ctrl/Cmd+P natively. No
@@ -23,12 +43,15 @@ export default function PickingTicketPrintAll() {
   const [tickets, setTickets] = useState([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
+  const [markPrintedFailed, setMarkPrintedFailed] = useState(false);
+  const [retryingMark, setRetryingMark] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     async function load() {
       setLoading(true);
       setError('');
+      setMarkPrintedFailed(false);
       const statuses = status === 'ALL' ? PICKABLE_STATUSES : [status];
       const listResponses = await Promise.all(
         statuses.map((s) => {
@@ -113,16 +136,25 @@ export default function PickingTicketPrintAll() {
       // the render array. Orders that failed earlier (404, network
       // error, malformed payload) stay unprinted so they reappear in
       // the queue and the operator can retry rather than silently
-      // losing them.
+      // losing them. Persistent mark-printed failures surface via the
+      // toast below so the operator knows to verify the list rather
+      // than assume the DB matches the screen.
       if (out.length > 0) {
-        api.post('/admin/sales-orders/mark-printed', {
-          so_ids: out.map((t) => t.so.so_id),
-        }).catch(() => {});
+        const ok = await markPrintedWithRetry(out.map((t) => t.so.so_id));
+        if (!cancelled && !ok) setMarkPrintedFailed(true);
       }
     }
     load();
     return () => { cancelled = true; };
   }, [status, warehouseId, requestedOrderParam]);
+
+  async function retryMarkPrinted() {
+    if (tickets.length === 0) return;
+    setRetryingMark(true);
+    const ok = await markPrintedWithRetry(tickets.map((t) => t.so.so_id));
+    setRetryingMark(false);
+    if (ok) setMarkPrintedFailed(false);
+  }
 
   // Update the tab title once we know the count, so the user can
   // tell the queue tabs apart.
@@ -164,6 +196,20 @@ export default function PickingTicketPrintAll() {
 
   return (
     <div className="pt-root">
+      {markPrintedFailed && (
+        <div className="pt-toast pt-no-print" role="alert">
+          <span>
+            Some tickets may not have been marked as printed. Refresh
+            the list to verify, or retry.
+          </span>
+          <button type="button" onClick={retryMarkPrinted} disabled={retryingMark}>
+            {retryingMark ? 'Retrying…' : 'Retry'}
+          </button>
+          <button type="button" onClick={() => setMarkPrintedFailed(false)}>
+            Dismiss
+          </button>
+        </div>
+      )}
       {tickets.map(({ so, lines, branding }) => (
         <TicketDocument key={so.so_id} so={so} lines={lines} branding={branding} />
       ))}

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -78,7 +78,10 @@ export default function PickingTickets() {
   function printAll() {
     const qs = new URLSearchParams({ status });
     if (warehouseId) qs.set('warehouse_id', String(warehouseId));
-    navigate(`/picking-tickets/print-all?${qs.toString()}`);
+    // Open in a new tab so the print queue renders standalone (no
+    // admin Layout chrome) and the user can leave it open while
+    // continuing to work in the original tab.
+    window.open(`/picking-tickets/print-all?${qs.toString()}`, '_blank', 'noopener');
   }
 
   const columns = [

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -56,6 +56,11 @@ export default function PickingTickets() {
             status: s,
             warehouse_id: String(warehouseId),
             per_page: '50',
+            // Picking-tickets queue wants the lowest-pick_sequence
+            // bin per SO so the picker can walk the warehouse in
+            // physical order. The flag opts into the per-row
+            // primary-bin subquery.
+            include_primary_bin: 'true',
           });
           if (hidePrinted) qs.set('hide_printed', 'true');
           return api.get(`/admin/sales-orders?${qs}`);
@@ -127,6 +132,17 @@ export default function PickingTickets() {
       render: (r) => (r.ship_by_date ? new Date(r.ship_by_date).toLocaleDateString() : '-'),
     },
     { key: 'ship_method', label: 'Ship Method', sortable: true, render: (r) => r.ship_method || '-' },
+    {
+      // Lowest-pick_sequence preferred bin across the SO's line items.
+      // Sorting by this column orders the queue in warehouse-walking
+      // order so the picker can fill the cart left-to-right and the
+      // shipper unpacks in the same order.
+      key: 'primary_bin_code',
+      label: 'Bin',
+      mono: true,
+      sortable: true,
+      render: (r) => r.primary_bin_code || '-',
+    },
     { key: 'status', label: 'Status', sortable: true, render: (r) => <StatusTag status={r.status} /> },
     {
       key: 'actions',
@@ -159,13 +175,20 @@ export default function PickingTickets() {
     if (!sortKey) return orders;
     const dir = sortDir === 'asc' ? 1 : -1;
     return [...orders].sort((a, b) => {
-      let av = a[sortKey];
-      let bv = b[sortKey];
+      // Sorting by the Bin column uses pick_sequence (numeric) so the
+      // queue order matches physical walking order in the warehouse,
+      // not bin-code alphabetical (which would mix aisles randomly).
+      const key = sortKey === 'primary_bin_code' ? 'primary_bin_pick_sequence' : sortKey;
+      let av = a[key];
+      let bv = b[key];
       if (av == null && bv == null) return 0;
       if (av == null) return 1;  // nulls always at the bottom
       if (bv == null) return -1;
-      if (sortKey === 'ship_by_date') {
+      if (key === 'ship_by_date') {
         return (new Date(av) - new Date(bv)) * dir;
+      }
+      if (key === 'primary_bin_pick_sequence') {
+        return (av - bv) * dir;
       }
       return String(av).localeCompare(String(bv), undefined, { numeric: true }) * dir;
     });

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -115,6 +115,15 @@ export default function PickingTickets() {
   function printAll() {
     const qs = new URLSearchParams({ status });
     if (warehouseId) qs.set('warehouse_id', String(warehouseId));
+    // Hand the print tab the exact SO order the operator is looking
+    // at so the print stack matches the on-screen sort. PrintAll
+    // reorders its fetched orders against this sequence rather than
+    // deriving a sort independently. Single source of truth for the
+    // ordering lives here.
+    const orderedIds = sortedOrders.map((o) => o.so_id);
+    if (orderedIds.length > 0) {
+      qs.set('so_ids', orderedIds.join(','));
+    }
     // Open in a new tab so the print queue renders standalone (no
     // admin Layout chrome) and the user can leave it open while
     // continuing to work in the original tab.

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -55,7 +55,7 @@ export default function PickingTickets() {
           const qs = new URLSearchParams({
             status: s,
             warehouse_id: String(warehouseId),
-            per_page: '50',
+            per_page: '100',
             // Picking-tickets queue wants the lowest-pick_sequence
             // bin per SO so the picker can walk the warehouse in
             // physical order. The flag opts into the per-row

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -1,0 +1,132 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '../api.js';
+import { useWarehouse } from '../warehouse.jsx';
+import DataTable from '../components/DataTable.jsx';
+import PageHeader from '../components/PageHeader.jsx';
+import StatusTag from '../components/StatusTag.jsx';
+
+// Statuses that still have something useful to put on a printed
+// picking ticket. SHIPPED/CANCELLED orders are skipped from the queue
+// so we don't accidentally hand a picker a slip for a done order.
+const PICKABLE_STATUSES = ['OPEN', 'ALLOCATED', 'PICKING', 'PICKED'];
+
+export default function PickingTickets() {
+  const navigate = useNavigate();
+  const { warehouseId } = useWarehouse();
+  const [orders, setOrders] = useState([]);
+  const [search, setSearch] = useState('');
+  const [lookupError, setLookupError] = useState('');
+
+  useEffect(() => {
+    if (!warehouseId) return;
+    let cancelled = false;
+    (async () => {
+      const responses = await Promise.all(
+        PICKABLE_STATUSES.map((status) =>
+          api.get(`/admin/sales-orders?status=${status}&warehouse_id=${warehouseId}&per_page=50`),
+        ),
+      );
+      const all = [];
+      for (const res of responses) {
+        if (res?.ok) {
+          const data = await res.json();
+          all.push(...(data.sales_orders || []));
+        }
+      }
+      if (!cancelled) setOrders(all);
+    })();
+    return () => { cancelled = true; };
+  }, [warehouseId]);
+
+  async function openTicket() {
+    const term = search.trim();
+    if (!term) return;
+    setLookupError('');
+    // Reuse the existing list endpoint so we go through the same
+    // auth/role gate as everything else; the detail endpoint takes an
+    // so_id (int), not so_number, so we resolve the number first.
+    const res = await api.get(
+      `/admin/sales-orders?q=${encodeURIComponent(term)}&per_page=10`,
+    );
+    if (!res?.ok) {
+      setLookupError('Could not search sales orders.');
+      return;
+    }
+    const data = await res.json();
+    const matches = data.sales_orders || [];
+    const exact = matches.find((o) => o.so_number === term) || matches[0];
+    if (!exact) {
+      setLookupError(`No sales order found matching "${term}".`);
+      return;
+    }
+    navigate(`/picking-tickets/${exact.so_id}/print`);
+  }
+
+  function onSearchKey(e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      openTicket();
+    }
+  }
+
+  const columns = [
+    { key: 'so_number', label: 'SO Number', mono: true },
+    { key: 'customer_name', label: 'Customer' },
+    {
+      key: 'ship_by_date',
+      label: 'Ship By',
+      mono: true,
+      render: (r) => (r.ship_by_date ? new Date(r.ship_by_date).toLocaleDateString() : '-'),
+    },
+    { key: 'ship_method', label: 'Ship Method', render: (r) => r.ship_method || '-' },
+    { key: 'status', label: 'Status', render: (r) => <StatusTag status={r.status} /> },
+    {
+      key: 'actions',
+      label: '',
+      render: (r) => (
+        <button
+          className="btn btn-sm btn-primary"
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/picking-tickets/${r.so_id}/print`);
+          }}
+        >Print Ticket</button>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <PageHeader title="Picking Tickets" />
+
+      <div className="section">
+        <div className="section-title">Find a ticket</div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', maxWidth: 520 }}>
+          <input
+            className="form-input"
+            style={{ flex: 1 }}
+            placeholder="Sales order number, e.g. 648415"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={onSearchKey}
+          />
+          <button className="btn btn-primary" onClick={openTicket}>Open</button>
+        </div>
+        {lookupError && (
+          <div className="form-error" style={{ marginTop: 8 }}>{lookupError}</div>
+        )}
+      </div>
+
+      <div className="section">
+        <div className="section-title">Orders ready to pick</div>
+        <DataTable
+          columns={columns}
+          data={orders}
+          emptyMessage="No orders ready for picking"
+          onRowClick={(r) => navigate(`/picking-tickets/${r.so_id}/print`)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { api } from '../api.js';
+import { formatDateOnly } from '../utils/date.js';
 import { useWarehouse } from '../warehouse.jsx';
 import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
@@ -143,7 +144,7 @@ export default function PickingTickets() {
       label: 'Ship By',
       mono: true,
       sortable: true,
-      render: (r) => (r.ship_by_date ? new Date(r.ship_by_date).toLocaleDateString() : '-'),
+      render: (r) => (r.ship_by_date ? formatDateOnly(r.ship_by_date) : '-'),
     },
     { key: 'ship_method', label: 'Ship Method', sortable: true, render: (r) => r.ship_method || '-' },
     {

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -21,10 +21,18 @@ export default function PickingTickets() {
   const [orders, setOrders] = useState([]);
   const [search, setSearch] = useState('');
   const [lookupError, setLookupError] = useState('');
+  // Bump this to force a refetch of the list under the current filters.
+  // Lets a manual Refresh button pull fresh sales-order data without
+  // requiring the user to navigate away and back (e.g. after an
+  // upstream connector updates customer details on already-pushed
+  // SOs).
+  const [refreshCounter, setRefreshCounter] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
     if (!warehouseId) return;
     let cancelled = false;
+    setRefreshing(true);
     (async () => {
       const statuses = status === 'ALL' ? PICKABLE_STATUSES : [status];
       const responses = await Promise.all(
@@ -39,10 +47,13 @@ export default function PickingTickets() {
           all.push(...(data.sales_orders || []));
         }
       }
-      if (!cancelled) setOrders(all);
+      if (!cancelled) {
+        setOrders(all);
+        setRefreshing(false);
+      }
     })();
     return () => { cancelled = true; };
-  }, [warehouseId, status]);
+  }, [warehouseId, status, refreshCounter]);
 
   async function openTicket() {
     const term = search.trim();
@@ -155,6 +166,14 @@ export default function PickingTickets() {
                 <option key={s} value={s}>{s}</option>
               ))}
             </select>
+            <button
+              className="btn btn-secondary"
+              onClick={() => setRefreshCounter((c) => c + 1)}
+              disabled={refreshing}
+              title="Re-fetch the list from the server (e.g. to pick up just-pushed customer name + shipping address)"
+            >
+              {refreshing ? 'Refreshing…' : 'Refresh'}
+            </button>
             <button
               className="btn btn-primary"
               onClick={printAll}

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { api } from '../api.js';
 import { useWarehouse } from '../warehouse.jsx';
 import DataTable from '../components/DataTable.jsx';
@@ -34,6 +34,11 @@ export default function PickingTickets() {
   // SOs).
   const [refreshCounter, setRefreshCounter] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
+  // Default sort: ship-by date ascending so the oldest must-ship-by
+  // orders rise to the top of the queue. Picker can re-sort by
+  // clicking any column header.
+  const [sortKey, setSortKey] = useState('ship_by_date');
+  const [sortDir, setSortDir] = useState('asc');
 
   useEffect(() => {
     if (!warehouseId) return;
@@ -102,16 +107,17 @@ export default function PickingTickets() {
   }
 
   const columns = [
-    { key: 'so_number', label: 'SO Number', mono: true },
-    { key: 'customer_name', label: 'Customer' },
+    { key: 'so_number', label: 'SO Number', mono: true, sortable: true },
+    { key: 'customer_name', label: 'Customer', sortable: true },
     {
       key: 'ship_by_date',
       label: 'Ship By',
       mono: true,
+      sortable: true,
       render: (r) => (r.ship_by_date ? new Date(r.ship_by_date).toLocaleDateString() : '-'),
     },
-    { key: 'ship_method', label: 'Ship Method', render: (r) => r.ship_method || '-' },
-    { key: 'status', label: 'Status', render: (r) => <StatusTag status={r.status} /> },
+    { key: 'ship_method', label: 'Ship Method', sortable: true, render: (r) => r.ship_method || '-' },
+    { key: 'status', label: 'Status', sortable: true, render: (r) => <StatusTag status={r.status} /> },
     {
       key: 'actions',
       label: '',
@@ -126,6 +132,34 @@ export default function PickingTickets() {
       ),
     },
   ];
+
+  function handleSort(key) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  }
+
+  // Sort happens client-side because the list is already paged to 50
+  // per status (typically the entire queue) and the picker wants the
+  // visible rows reordered immediately without a round trip.
+  const sortedOrders = useMemo(() => {
+    if (!sortKey) return orders;
+    const dir = sortDir === 'asc' ? 1 : -1;
+    return [...orders].sort((a, b) => {
+      let av = a[sortKey];
+      let bv = b[sortKey];
+      if (av == null && bv == null) return 0;
+      if (av == null) return 1;  // nulls always at the bottom
+      if (bv == null) return -1;
+      if (sortKey === 'ship_by_date') {
+        return (new Date(av) - new Date(bv)) * dir;
+      }
+      return String(av).localeCompare(String(bv), undefined, { numeric: true }) * dir;
+    });
+  }, [orders, sortKey, sortDir]);
 
   return (
     <div>
@@ -191,9 +225,12 @@ export default function PickingTickets() {
         </div>
         <DataTable
           columns={columns}
-          data={orders}
+          data={sortedOrders}
           emptyMessage="No orders ready for picking"
           onRowClick={(r) => openTicketInNewTab(r.so_id)}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={handleSort}
         />
       </div>
     </div>

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { api } from '../api.js';
 import { useWarehouse } from '../warehouse.jsx';
 import DataTable from '../components/DataTable.jsx';
@@ -14,8 +13,15 @@ import StatusTag from '../components/StatusTag.jsx';
 const PICKABLE_STATUSES = ['OPEN', 'PICKED'];
 const STATUS_OPTIONS = [...PICKABLE_STATUSES, 'ALL'];
 
+// Open an individual picking ticket in a standalone tab (no admin
+// Layout chrome) so the ticket fills the window and the per-ticket
+// print CSS does not fight a sidebar/topbar parent. Mirrors the
+// Print All flow.
+function openTicketInNewTab(soId) {
+  window.open(`/picking-tickets/${soId}/print`, '_blank', 'noopener');
+}
+
 export default function PickingTickets() {
-  const navigate = useNavigate();
   const { warehouseId } = useWarehouse();
   const [status, setStatus] = useState('OPEN');
   const [orders, setOrders] = useState([]);
@@ -76,7 +82,7 @@ export default function PickingTickets() {
       setLookupError(`No sales order found matching "${term}".`);
       return;
     }
-    navigate(`/picking-tickets/${exact.so_id}/print`);
+    openTicketInNewTab(exact.so_id);
   }
 
   function onSearchKey(e) {
@@ -114,7 +120,7 @@ export default function PickingTickets() {
           className="btn btn-sm btn-primary"
           onClick={(e) => {
             e.stopPropagation();
-            navigate(`/picking-tickets/${r.so_id}/print`);
+            openTicketInNewTab(r.so_id);
           }}
         >Print Ticket</button>
       ),
@@ -187,7 +193,7 @@ export default function PickingTickets() {
           columns={columns}
           data={orders}
           emptyMessage="No orders ready for picking"
-          onRowClick={(r) => navigate(`/picking-tickets/${r.so_id}/print`)}
+          onRowClick={(r) => openTicketInNewTab(r.so_id)}
         />
       </div>
     </div>

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -7,13 +7,17 @@ import PageHeader from '../components/PageHeader.jsx';
 import StatusTag from '../components/StatusTag.jsx';
 
 // Statuses that still have something useful to put on a printed
-// picking ticket. SHIPPED/CANCELLED orders are skipped from the queue
-// so we don't accidentally hand a picker a slip for a done order.
-const PICKABLE_STATUSES = ['OPEN', 'ALLOCATED', 'PICKING', 'PICKED'];
+// picking ticket. SHIPPED/CANCELLED orders are skipped from the
+// switcher so we don't accidentally hand a picker a slip for a done
+// order. OPEN is the default because that's what the warehouse pulls
+// from first thing in the morning.
+const PICKABLE_STATUSES = ['OPEN', 'PICKED'];
+const STATUS_OPTIONS = [...PICKABLE_STATUSES, 'ALL'];
 
 export default function PickingTickets() {
   const navigate = useNavigate();
   const { warehouseId } = useWarehouse();
+  const [status, setStatus] = useState('OPEN');
   const [orders, setOrders] = useState([]);
   const [search, setSearch] = useState('');
   const [lookupError, setLookupError] = useState('');
@@ -22,9 +26,10 @@ export default function PickingTickets() {
     if (!warehouseId) return;
     let cancelled = false;
     (async () => {
+      const statuses = status === 'ALL' ? PICKABLE_STATUSES : [status];
       const responses = await Promise.all(
-        PICKABLE_STATUSES.map((status) =>
-          api.get(`/admin/sales-orders?status=${status}&warehouse_id=${warehouseId}&per_page=50`),
+        statuses.map((s) =>
+          api.get(`/admin/sales-orders?status=${s}&warehouse_id=${warehouseId}&per_page=50`),
         ),
       );
       const all = [];
@@ -37,7 +42,7 @@ export default function PickingTickets() {
       if (!cancelled) setOrders(all);
     })();
     return () => { cancelled = true; };
-  }, [warehouseId]);
+  }, [warehouseId, status]);
 
   async function openTicket() {
     const term = search.trim();
@@ -68,6 +73,12 @@ export default function PickingTickets() {
       e.preventDefault();
       openTicket();
     }
+  }
+
+  function printAll() {
+    const qs = new URLSearchParams({ status });
+    if (warehouseId) qs.set('warehouse_id', String(warehouseId));
+    navigate(`/picking-tickets/print-all?${qs.toString()}`);
   }
 
   const columns = [
@@ -119,7 +130,37 @@ export default function PickingTickets() {
       </div>
 
       <div className="section">
-        <div className="section-title">Orders ready to pick</div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: 12,
+            marginBottom: 8,
+          }}
+        >
+          <div className="section-title" style={{ marginBottom: 0 }}>Orders ready to pick</div>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <label style={{ fontSize: 13, color: '#555' }}>Status</label>
+            <select
+              className="form-input"
+              style={{ width: 'auto' }}
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
+              {STATUS_OPTIONS.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+            <button
+              className="btn btn-primary"
+              onClick={printAll}
+              disabled={orders.length === 0}
+            >
+              Print All ({orders.length})
+            </button>
+          </div>
+        </div>
         <DataTable
           columns={columns}
           data={orders}

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -39,6 +39,10 @@ export default function PickingTickets() {
   // clicking any column header.
   const [sortKey, setSortKey] = useState('ship_by_date');
   const [sortDir, setSortDir] = useState('asc');
+  // mig 064: default to hiding orders whose picking ticket was
+  // already confirm-rendered. Operator opts back in to verify a
+  // reprint or audit historical queue state.
+  const [hidePrinted, setHidePrinted] = useState(true);
 
   useEffect(() => {
     if (!warehouseId) return;
@@ -47,9 +51,15 @@ export default function PickingTickets() {
     (async () => {
       const statuses = status === 'ALL' ? PICKABLE_STATUSES : [status];
       const responses = await Promise.all(
-        statuses.map((s) =>
-          api.get(`/admin/sales-orders?status=${s}&warehouse_id=${warehouseId}&per_page=50`),
-        ),
+        statuses.map((s) => {
+          const qs = new URLSearchParams({
+            status: s,
+            warehouse_id: String(warehouseId),
+            per_page: '50',
+          });
+          if (hidePrinted) qs.set('hide_printed', 'true');
+          return api.get(`/admin/sales-orders?${qs}`);
+        }),
       );
       const all = [];
       for (const res of responses) {
@@ -64,7 +74,7 @@ export default function PickingTickets() {
       }
     })();
     return () => { cancelled = true; };
-  }, [warehouseId, status, refreshCounter]);
+  }, [warehouseId, status, refreshCounter, hidePrinted]);
 
   async function openTicket() {
     const term = search.trim();
@@ -206,6 +216,17 @@ export default function PickingTickets() {
                 <option key={s} value={s}>{s}</option>
               ))}
             </select>
+            <label style={{
+              display: 'flex', alignItems: 'center', gap: 6,
+              fontSize: 13, color: '#555', cursor: 'pointer',
+            }} title="Hide orders whose picking ticket has already been rendered (mig 064 printed_at)">
+              <input
+                type="checkbox"
+                checked={hidePrinted}
+                onChange={(e) => setHidePrinted(e.target.checked)}
+              />
+              Hide Printed
+            </label>
             <button
               className="btn btn-secondary"
               onClick={() => setRefreshCounter((c) => c + 1)}

--- a/admin/src/pages/PickingTickets.jsx
+++ b/admin/src/pages/PickingTickets.jsx
@@ -4,6 +4,7 @@ import { useWarehouse } from '../warehouse.jsx';
 import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 import StatusTag from '../components/StatusTag.jsx';
+import { PRINT_BATCH_LIMIT } from './pickingConstants.js';
 
 // Statuses that still have something useful to put on a printed
 // picking ticket. SHIPPED/CANCELLED orders are skipped from the
@@ -55,7 +56,9 @@ export default function PickingTickets() {
           const qs = new URLSearchParams({
             status: s,
             warehouse_id: String(warehouseId),
-            per_page: '100',
+            // Fetch up to a full print batch so the operator can see -
+            // and hand off to Print All - the whole printable queue.
+            per_page: String(PRINT_BATCH_LIMIT),
             // Picking-tickets queue wants the lowest-pick_sequence
             // bin per SO so the picker can walk the warehouse in
             // physical order. The flag opts into the per-row
@@ -115,12 +118,14 @@ export default function PickingTickets() {
   function printAll() {
     const qs = new URLSearchParams({ status });
     if (warehouseId) qs.set('warehouse_id', String(warehouseId));
-    // Hand the print tab the exact SO order the operator is looking
-    // at so the print stack matches the on-screen sort. PrintAll
-    // reorders its fetched orders against this sequence rather than
-    // deriving a sort independently. Single source of truth for the
-    // ordering lives here.
-    const orderedIds = sortedOrders.map((o) => o.so_id);
+    // Hand the print tab the exact SOs the operator is looking at, in
+    // the exact on-screen order. so_ids is the single source of truth
+    // for both the set (Hide Printed already applied) and the order
+    // (current column sort); the print tab renders precisely these and
+    // never re-derives the queue. Capped at one batch per tab - if the
+    // queue is larger, the operator prints the top batch, those SOs
+    // drop off via Hide Printed, then Print All again for the next.
+    const orderedIds = sortedOrders.slice(0, PRINT_BATCH_LIMIT).map((o) => o.so_id);
     if (orderedIds.length > 0) {
       qs.set('so_ids', orderedIds.join(','));
     }
@@ -271,8 +276,15 @@ export default function PickingTickets() {
               className="btn btn-primary"
               onClick={printAll}
               disabled={orders.length === 0}
+              title={
+                orders.length > PRINT_BATCH_LIMIT
+                  ? `Queue has ${orders.length}; one tab prints the top ${PRINT_BATCH_LIMIT} in the current sort. Clear them and Print All again for the rest.`
+                  : undefined
+              }
             >
-              Print All ({orders.length})
+              {orders.length > PRINT_BATCH_LIMIT
+                ? `Print First ${PRINT_BATCH_LIMIT} (of ${orders.length})`
+                : `Print All (${orders.length})`}
             </button>
           </div>
         </div>

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { api } from '../api.js';
+import { formatDateOnly } from '../utils/date.js';
 import { useAuth } from '../auth.jsx';
 import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
@@ -708,7 +709,7 @@ export default function SalesOrders() {
   const columns = [
     { key: 'so_number', label: 'SO Number', mono: true },
     { key: 'customer_name', label: 'Customer' },
-    { key: 'ship_by_date', label: 'Ship By', mono: true, render: (r) => r.ship_by_date ? new Date(r.ship_by_date).toLocaleDateString() : '-' },
+    { key: 'ship_by_date', label: 'Ship By', mono: true, render: (r) => r.ship_by_date ? formatDateOnly(r.ship_by_date) : '-' },
     { key: 'status', label: 'Status', render: (r) => <StatusTag status={r.status} /> },
     { key: 'created_at', label: 'Created', render: (r) => r.created_at ? new Date(r.created_at).toLocaleDateString() : '-' },
     { key: 'actions', label: '', render: (r) => (
@@ -762,7 +763,7 @@ export default function SalesOrders() {
                   by the inbound payload mapping. */}
               <span className="detail-label">Source:</span>
               <span><NullableValue value={selectedSO.order_origin} /></span>
-              <span className="detail-label">Ship By</span><span className="mono">{selectedSO.ship_by_date ? new Date(selectedSO.ship_by_date).toLocaleDateString() : '-'}</span>
+              <span className="detail-label">Ship By</span><span className="mono">{selectedSO.ship_by_date ? formatDateOnly(selectedSO.ship_by_date) : '-'}</span>
               <span className="detail-label">Ship Method</span><span>{selectedSO.ship_method || '-'}</span>
               {/* v1.8.0 (#282) per-order cost fields. order_total +
                   customer_shipping_paid arrive as strings on the wire to

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -51,6 +51,10 @@ export default function Settings() {
       api.get('/admin/settings/allow_over_receiving'),
       api.get('/admin/settings/default_receiving_bin'),
       api.get('/admin/settings/require_count_approval_separation'),
+      api.get('/admin/settings/picking_ticket_company_name'),
+      api.get('/admin/settings/picking_ticket_company_address'),
+      api.get('/admin/settings/picking_ticket_logo_url'),
+      api.get('/admin/settings/picking_ticket_returns_text'),
     ]).then(async (responses) => {
       const initial = {};
       for (const res of responses) {
@@ -65,6 +69,13 @@ export default function Settings() {
       if (!('allow_over_receiving' in initial)) initial.allow_over_receiving = 'true';
       if (!('default_receiving_bin' in initial)) initial.default_receiving_bin = '';
       if (!('require_count_approval_separation' in initial)) initial.require_count_approval_separation = 'false';
+      // Picking-ticket / packing-slip branding. All default to empty so a
+      // fresh install prints a clean, unbranded slip until an operator
+      // fills these in.
+      if (!('picking_ticket_company_name' in initial)) initial.picking_ticket_company_name = '';
+      if (!('picking_ticket_company_address' in initial)) initial.picking_ticket_company_address = '';
+      if (!('picking_ticket_logo_url' in initial)) initial.picking_ticket_logo_url = '';
+      if (!('picking_ticket_returns_text' in initial)) initial.picking_ticket_returns_text = '';
       setSavedSettings({ ...initial });
       setDraftSettings({ ...initial });
     });
@@ -368,6 +379,54 @@ export default function Settings() {
           </label>
         </div>
         <p className="settings-note">When enabled, the admin who performed a cycle count cannot approve the resulting adjustments. A different admin must review and approve.</p>
+      </div>
+
+      {/* Picking Ticket branding */}
+      <div className="settings-section">
+        <h3>Picking Ticket</h3>
+        <p className="settings-note">
+          Branding for the printable packing slip (Outbound &gt; Picking Tickets).
+          All fields are optional; leave them blank for a clean, unbranded slip.
+        </p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '8px 0', maxWidth: 480 }}>
+          <label style={{ fontSize: 13 }}>Company name</label>
+          <input
+            className="form-input"
+            value={draftSettings.picking_ticket_company_name || ''}
+            onChange={(e) => updateDraft('picking_ticket_company_name', e.target.value)}
+            placeholder="e.g. Acme Distribution"
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '8px 0', maxWidth: 480 }}>
+          <label style={{ fontSize: 13 }}>Company address</label>
+          <textarea
+            className="form-input"
+            rows={4}
+            value={draftSettings.picking_ticket_company_address || ''}
+            onChange={(e) => updateDraft('picking_ticket_company_address', e.target.value)}
+            placeholder={'One line per row, e.g.\n123 Warehouse Way\nSuite 100\nCity ST 00000'}
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '8px 0', maxWidth: 480 }}>
+          <label style={{ fontSize: 13 }}>Logo URL</label>
+          <input
+            className="form-input"
+            value={draftSettings.picking_ticket_logo_url || ''}
+            onChange={(e) => updateDraft('picking_ticket_logo_url', e.target.value)}
+            placeholder="/picking-tickets/logo.png or https://..."
+          />
+          <p className="settings-note">Path or URL to a logo image shown in the slip header. Blank hides it.</p>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '8px 0', maxWidth: 480 }}>
+          <label style={{ fontSize: 13 }}>Returns text</label>
+          <textarea
+            className="form-input"
+            rows={3}
+            value={draftSettings.picking_ticket_returns_text || ''}
+            onChange={(e) => updateDraft('picking_ticket_returns_text', e.target.value)}
+            placeholder="e.g. Returns accepted within 30 days. See example.com/returns."
+          />
+        </div>
       </div>
 
       {/* Save button */}

--- a/admin/src/pages/pickingConstants.js
+++ b/admin/src/pages/pickingConstants.js
@@ -1,0 +1,12 @@
+// Shared picking-ticket constants. Kept in a side-effect-free module so
+// the list page can import the print-batch limit without pulling the
+// print view's CSS into its bundle.
+
+// Max tickets one Print All tab renders. Enforced on both sides: the
+// list page slices its so_ids hand-off to this, and the print page
+// re-clamps so a stale or hand-edited URL can't stack an unbounded run
+// (and that many detail fetches) into one tab. When a queue exceeds
+// this, the operator prints the top batch, those SOs get marked printed
+// and drop off the Hide-Printed list, and the next Print All picks up
+// where it left off.
+export const PRINT_BATCH_LIMIT = 200;

--- a/admin/src/pages/pickingTicket.css
+++ b/admin/src/pages/pickingTicket.css
@@ -135,6 +135,36 @@
    with the toolbar. */
 .pt-page + .pt-page { margin-top: 24px; }
 
+/* Surfaced when the mark-printed POST fails after a retry. Combined
+   with .pt-no-print so the toast never appears on paper. */
+.pt-toast {
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  color: #664d03;
+  padding: 10px 14px;
+  font-size: 10pt;
+  z-index: 100;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  max-width: 8.5in;
+}
+.pt-toast button {
+  font-family: inherit;
+  font-size: 9pt;
+  padding: 4px 10px;
+  border: 1px solid #997404;
+  background: white;
+  cursor: pointer;
+}
+.pt-toast button:hover:not(:disabled) { background: #fffaf0; }
+.pt-toast button:disabled { opacity: 0.6; cursor: default; }
+
 @media print {
   @page { size: letter; margin: 0.5in; }
   .pt-root { background: white; padding: 0; }

--- a/admin/src/pages/pickingTicket.css
+++ b/admin/src/pages/pickingTicket.css
@@ -129,6 +129,12 @@
 .pt-barcode-large { width: 220px; height: 40px; }
 .pt-barcode-small { width: 180px; height: 32px; }
 
+/* When multiple tickets are stacked (print-all view), force each
+   subsequent ticket onto its own page on screen too, with a visible
+   gap between them. The first .pt-page gets no rule so it sits flush
+   with the toolbar. */
+.pt-page + .pt-page { margin-top: 24px; }
+
 @media print {
   @page { size: letter; margin: 0.5in; }
   .pt-root { background: white; padding: 0; }
@@ -138,6 +144,12 @@
     padding: 0;
     width: auto;
     min-height: 0;
+  }
+  /* Hard page break between consecutive tickets in print-all mode. */
+  .pt-page + .pt-page {
+    margin-top: 0;
+    page-break-before: always;
+    break-before: page;
   }
   .pt-no-print { display: none !important; }
 }

--- a/admin/src/pages/pickingTicket.css
+++ b/admin/src/pages/pickingTicket.css
@@ -1,0 +1,143 @@
+/* Picking ticket / packing slip layout. A print-oriented packing slip
+   rendered from the SO data. Scoped to .pt-root so the admin SPA's
+   typography never bleeds in. */
+
+.pt-root {
+  font-family: Helvetica, Arial, sans-serif;
+  color: #111;
+  background: #f0f0f0;
+  padding: 40px 0;
+}
+
+.pt-toolbar {
+  width: 8.5in;
+  margin: 0 auto 12px auto;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+}
+.pt-toolbar .pt-back {
+  font-size: 10pt;
+  color: #333;
+  text-decoration: none;
+  margin-right: auto;
+}
+.pt-toolbar .pt-back:hover { text-decoration: underline; }
+.pt-toolbar button {
+  font-family: inherit;
+  font-size: 10pt;
+  padding: 6px 14px;
+  border: 1px solid #999;
+  background: white;
+  cursor: pointer;
+}
+.pt-toolbar button:hover { background: #f5f5f5; }
+
+.pt-page {
+  background: white;
+  width: 8.5in;
+  min-height: 11in;
+  margin: 0 auto;
+  padding: 0.5in;
+  box-sizing: border-box;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.pt-page table {
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 9pt;
+  margin-top: 10px;
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.pt-page th {
+  font-weight: bold;
+  font-size: 8pt;
+  padding: 5px 6px 3px 6px;
+  background-color: #e3e3e3;
+  color: #333;
+  text-align: left;
+}
+
+.pt-page td { padding: 4px 6px; vertical-align: top; }
+.pt-page b { font-weight: bold; color: #333; }
+
+.pt-header td { padding: 0; font-size: 10pt; vertical-align: top; }
+.pt-header .pt-logo-cell { width: 60%; }
+.pt-header .pt-logo-row {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+.pt-header .pt-logo {
+  height: 90px;
+  flex-shrink: 0;
+}
+.pt-header .pt-nameandaddress { line-height: 1.5; }
+.pt-title { font-size: 28pt; }
+.pt-number { font-size: 16pt; }
+
+.pt-address-header { font-size: 8pt; padding-top: 6px; padding-bottom: 2px; }
+.pt-address { padding-top: 0; line-height: 1.4; }
+
+.pt-body td { padding-top: 2px; }
+
+.pt-itemtable th { padding: 6px 6px 4px 6px; }
+.pt-itemtable td { padding: 2px 6px; }
+.pt-itemname {
+  font-weight: bold;
+  line-height: 130%;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.pt-itemtable tr {
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+.pt-right { text-align: right; }
+.pt-center { text-align: center; }
+
+.pt-returns {
+  margin-top: 8px;
+  font-size: 10pt;
+  line-height: 1.4;
+}
+
+.pt-review { margin: 12px 0 8px 0; text-align: center; }
+.pt-review img { max-width: 100%; height: auto; }
+
+.pt-tail {
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+.pt-footer {
+  margin-top: 14px;
+  padding-top: 8px;
+  border-top: 1px solid #d3d3d3;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 8pt;
+}
+.pt-memo { font-size: 12pt; font-weight: bold; }
+
+.pt-barcode-large { width: 220px; height: 40px; }
+.pt-barcode-small { width: 180px; height: 32px; }
+
+@media print {
+  @page { size: letter; margin: 0.5in; }
+  .pt-root { background: white; padding: 0; }
+  .pt-page {
+    box-shadow: none;
+    margin: 0;
+    padding: 0;
+    width: auto;
+    min-height: 0;
+  }
+  .pt-no-print { display: none !important; }
+}

--- a/admin/src/test/formatDateOnly.test.js
+++ b/admin/src/test/formatDateOnly.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { formatDateOnly } from '../utils/date.js';
+
+// sentry-wms#52: a date-only string must format to the same calendar day in
+// any timezone. The helper avoids `new Date()` entirely, so this holds even
+// under a negative-offset TZ (e.g. run with TZ='America/Denver').
+describe('formatDateOnly', () => {
+  it('formats a date-only string to the same calendar day (no UTC-midnight shift)', () => {
+    expect(formatDateOnly('2026-06-09')).toBe('06/09/2026');
+  });
+
+  it('uses the date part of a full ISO timestamp', () => {
+    expect(formatDateOnly('2026-06-09T23:30:00Z')).toBe('06/09/2026');
+  });
+
+  it('zero-pads single-digit month and day', () => {
+    expect(formatDateOnly('2026-01-05')).toBe('01/05/2026');
+  });
+
+  it('returns empty string for falsy or malformed input', () => {
+    expect(formatDateOnly('')).toBe('');
+    expect(formatDateOnly(null)).toBe('');
+    expect(formatDateOnly(undefined)).toBe('');
+    expect(formatDateOnly('not-a-date')).toBe('');
+  });
+});

--- a/admin/src/utils/code128.js
+++ b/admin/src/utils/code128.js
@@ -1,0 +1,67 @@
+// Minimal Code 128 (subset B) encoder used by the picking ticket print
+// view. Returns an array of { width, black } module segments suitable
+// for rendering as SVG <rect> elements. Kept inline to avoid a runtime
+// dependency on a barcode library.
+//
+// Reference: GS1 / ISO/IEC 15417 Code 128 symbology. Subset B covers
+// ASCII 32-127, which is sufficient for order numbers (digits + a few
+// punctuation chars). Patterns are encoded as digit strings where each
+// digit is the module width of an alternating bar/space starting with
+// a bar.
+
+const PATTERNS = [
+  '212222', '222122', '222221', '121223', '121322', '131222', '122213',
+  '122312', '132212', '221213', '221312', '231212', '112232', '122132',
+  '122231', '113222', '123122', '123221', '223211', '221132', '221231',
+  '213212', '223112', '312131', '311222', '321122', '321221', '312212',
+  '322112', '322211', '212123', '212321', '232121', '111323', '131123',
+  '131321', '112313', '132113', '132311', '211313', '231113', '231311',
+  '112133', '112331', '132131', '113123', '113321', '133121', '313121',
+  '211331', '231131', '213113', '213311', '213131', '311123', '311321',
+  '331121', '312113', '312311', '332111', '314111', '221411', '431111',
+  '111224', '111422', '121124', '121421', '141122', '141221', '112214',
+  '112412', '122114', '122411', '142112', '142211', '241211', '221114',
+  '413111', '241112', '134111', '111242', '121142', '121241', '114212',
+  '124112', '124211', '411212', '421112', '421211', '212141', '214121',
+  '412121', '111143', '111341', '131141', '114113', '114311', '411113',
+  '411311', '113141', '114131', '311141', '411131', '211412', '211214',
+  '211232',
+];
+const STOP_PATTERN = '2331112';
+const START_B = 104;
+
+export function encodeCode128B(text) {
+  if (!text) return { segments: [], totalModules: 0 };
+  const values = [START_B];
+  for (const ch of text) {
+    const code = ch.charCodeAt(0);
+    // Code 128 subset B covers ASCII 32-127. Fall back to '?' for
+    // anything outside that range so a stray unicode glyph in a memo
+    // never throws.
+    const value = code >= 32 && code <= 127 ? code - 32 : '?'.charCodeAt(0) - 32;
+    values.push(value);
+  }
+  let checksum = START_B;
+  for (let i = 1; i < values.length; i++) {
+    checksum += values[i] * i;
+  }
+  checksum %= 103;
+  values.push(checksum);
+
+  const segments = [];
+  let totalModules = 0;
+  for (const v of values) {
+    const pattern = PATTERNS[v];
+    for (let i = 0; i < pattern.length; i++) {
+      const width = Number(pattern[i]);
+      segments.push({ width, black: i % 2 === 0 });
+      totalModules += width;
+    }
+  }
+  for (let i = 0; i < STOP_PATTERN.length; i++) {
+    const width = Number(STOP_PATTERN[i]);
+    segments.push({ width, black: i % 2 === 0 });
+    totalModules += width;
+  }
+  return { segments, totalModules };
+}

--- a/admin/src/utils/date.js
+++ b/admin/src/utils/date.js
@@ -1,0 +1,23 @@
+// Shared date-only formatter. Avoids the UTC-midnight off-by-one shift.
+//
+// `ship_by_date` / `order_date` arrive as date-only strings ('YYYY-MM-DD').
+// `new Date('2026-06-09')` parses as UTC midnight per the ECMAScript spec, so
+// `.toLocaleDateString()` in a negative-offset timezone (US Mountain/Pacific)
+// renders the PREVIOUS calendar day (e.g. 6/8/2026). For a warehouse in MT/PT
+// that makes today's orders look already-late and breaks the picking queue's
+// ship-by sort.
+//
+// The fix is to never build a Date from the date-only string: split the
+// 'YYYY-MM-DD' part and rebuild the label directly. This is the same approach
+// the printed picking ticket already used (formerly PickingTicketPrint's local
+// `formatUSDate`), now shared. Result is timezone-independent by construction.
+//
+// Accepts 'YYYY-MM-DD' or a full ISO timestamp (uses the leading date part).
+// Returns 'MM/DD/YYYY', or '' for falsy / malformed input.
+export function formatDateOnly(value) {
+  if (!value) return '';
+  const datePart = String(value).slice(0, 10);
+  const [y, m, d] = datePart.split('-').map(Number);
+  if (!y || !m || !d) return '';
+  return `${String(m).padStart(2, '0')}/${String(d).padStart(2, '0')}/${y}`;
+}

--- a/api/constants.py
+++ b/api/constants.py
@@ -178,6 +178,10 @@ ALL_PAGE_KEYS = (
     "inventory", "cycle-counts", "count-approvals",
     "purchase-orders", "receiving", "putaway",
     "sales-orders",
+    # Picking Tickets (Outbound): the printable packing-slip queue and
+    # the per-SO / Print All print views. Holders see the /picking-tickets
+    # page and can mark tickets printed.
+    "picking-tickets",
     # Picking Batches (Outbound): lists the active pick batches that hold
     # the cross-pick lock and lets an admin release a stuck one. Holders
     # see the /picking-batches page plus the SO batch-release action.

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -36,6 +36,7 @@ from schemas.sales_orders import (
     AddSalesOrderLineRequest,
     AdminPickRequest,
     CreateSalesOrderRequest,
+    MarkSalesOrdersPrintedRequest,
     RevertSalesOrderStatusRequest,
     UpdateSalesOrderAddressRequest,
     UpdateSalesOrderLineRequest,
@@ -329,12 +330,19 @@ def list_sales_orders():
     status = request.args.get("status")
     warehouse_id = request.args.get("warehouse_id", type=int)
     search = (request.args.get("q") or "").strip()
+    # Opt-in filter from the Picking Tickets queue. When set, drops SOs
+    # whose ticket was already confirm-rendered to the operator (mig
+    # 057 printed_at). Pages that show the full SO ledger (Sales
+    # Orders, Fraud, POS Activity) leave the param unset.
+    hide_printed = request.args.get("hide_printed", "false").lower() == "true"
     if status:
         where_clauses.append("status = :status")
         params["status"] = status
     if warehouse_id:
         where_clauses.append("warehouse_id = :wid")
         params["wid"] = warehouse_id
+    if hide_printed:
+        where_clauses.append("printed_at IS NULL")
     if search:
         where_clauses.append("(so_number ILIKE :q OR customer_name ILIKE :q)")
         params["q"] = f"%{search}%"
@@ -352,7 +360,7 @@ def list_sales_orders():
                    ship_method, ship_address, order_date, ship_by_date, created_at, created_by,
                    carrier, tracking_number, shipped_at,
                    (shipped_at AT TIME ZONE :company_tz)::date AS shipped_date_local,
-                   memo
+                   memo, printed_at
             FROM sales_orders {where_sql} ORDER BY so_id DESC LIMIT :limit OFFSET :offset
         """),
         {**params, "company_tz": COMPANY_TIMEZONE},
@@ -370,7 +378,8 @@ def list_sales_orders():
              "carrier": r.carrier, "tracking_number": r.tracking_number,
              "shipped_at": r.shipped_at.isoformat() if r.shipped_at else None,
              "shipped_date_local": r.shipped_date_local.isoformat() if r.shipped_date_local else None,
-             "memo": r.memo}
+             "memo": r.memo,
+             "printed_at": r.printed_at.isoformat() if r.printed_at else None}
             for r in rows
         ],
         "total": total, "page": page, "per_page": per_page, "pages": pages,
@@ -604,6 +613,39 @@ def get_picking_ticket(so_id):
             for l in lines
         ],
         "branding": _picking_ticket_branding(g.db),
+    })
+
+
+@admin_bp.route("/sales-orders/mark-printed", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("picking-tickets")
+@validate_body(MarkSalesOrdersPrintedRequest)
+@with_db
+def mark_sales_orders_printed(validated):
+    """Stamp printed_at = NOW() for a batch of SOs whose picking
+    tickets the client has successfully rendered. The picking ticket
+    print pages POST here so the Picking Tickets queue can hide
+    already-printed orders without coupling render success to a
+    server-side GET side effect."""
+    so_ids = validated.so_ids
+    rows = g.db.execute(
+        text(
+            """
+            UPDATE sales_orders
+               SET printed_at = NOW()
+             WHERE so_id = ANY(:ids)
+               AND printed_at IS NULL
+            RETURNING so_id, printed_at
+            """
+        ),
+        {"ids": so_ids},
+    ).fetchall()
+    g.db.commit()
+    return jsonify({
+        "marked": [
+            {"so_id": r.so_id, "printed_at": r.printed_at.isoformat()}
+            for r in rows
+        ],
     })
 
 

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -335,53 +335,98 @@ def list_sales_orders():
     # 057 printed_at). Pages that show the full SO ledger (Sales
     # Orders, Fraud, POS Activity) leave the param unset.
     hide_printed = request.args.get("hide_printed", "false").lower() == "true"
+    # Opt-in primary-bin computation for the Picking Tickets queue.
+    # When set, each row carries the bin_code + pick_sequence of the
+    # preferred bin with the LOWEST pick_sequence among the SO's
+    # line items, scoped to the SO's warehouse. The list page sorts
+    # by pick_sequence so a picker walks the warehouse in physical
+    # order; the shipper unpacks the cart in the same order.
+    include_primary_bin = request.args.get("include_primary_bin", "false").lower() == "true"
     if status:
-        where_clauses.append("status = :status")
+        where_clauses.append("so.status = :status")
         params["status"] = status
     if warehouse_id:
-        where_clauses.append("warehouse_id = :wid")
+        where_clauses.append("so.warehouse_id = :wid")
         params["wid"] = warehouse_id
     if hide_printed:
-        where_clauses.append("printed_at IS NULL")
+        where_clauses.append("so.printed_at IS NULL")
     if search:
-        where_clauses.append("(so_number ILIKE :q OR customer_name ILIKE :q)")
+        where_clauses.append("(so.so_number ILIKE :q OR so.customer_name ILIKE :q)")
         params["q"] = f"%{search}%"
 
     where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
-    total = g.db.execute(text(f"SELECT COUNT(*) FROM sales_orders {where_sql}"), params).scalar()
+    total = g.db.execute(
+        text(f"SELECT COUNT(*) FROM sales_orders so {where_sql}"),
+        params,
+    ).scalar()
     pages = max(1, math.ceil(total / per_page))
 
     params["limit"] = per_page
     params["offset"] = (page - 1) * per_page
+    # Primary-bin subqueries only render when the caller asks for them;
+    # other pages avoid the per-row scalar subquery cost. Both columns
+    # come from the same logical row, so the planner can fold them
+    # into one index scan even though they read as two subqueries.
+    primary_bin_select = ""
+    if include_primary_bin:
+        primary_bin_select = """
+            , (SELECT b.bin_code
+                 FROM sales_order_lines sol
+                 JOIN preferred_bins pb ON pb.item_id = sol.item_id
+                 JOIN bins b ON b.bin_id = pb.bin_id
+                WHERE sol.so_id = so.so_id
+                  AND b.warehouse_id = so.warehouse_id
+                ORDER BY b.pick_sequence ASC NULLS LAST, pb.priority ASC
+                LIMIT 1) AS primary_bin_code
+            , (SELECT b.pick_sequence
+                 FROM sales_order_lines sol
+                 JOIN preferred_bins pb ON pb.item_id = sol.item_id
+                 JOIN bins b ON b.bin_id = pb.bin_id
+                WHERE sol.so_id = so.so_id
+                  AND b.warehouse_id = so.warehouse_id
+                ORDER BY b.pick_sequence ASC NULLS LAST, pb.priority ASC
+                LIMIT 1) AS primary_bin_pick_sequence
+        """
     rows = g.db.execute(
         text(f"""
-            SELECT so_id, so_number, so_barcode, customer_name, customer_phone, customer_address,
-                   status, priority, warehouse_id,
-                   ship_method, ship_address, order_date, ship_by_date, created_at, created_by,
-                   carrier, tracking_number, shipped_at,
-                   (shipped_at AT TIME ZONE :company_tz)::date AS shipped_date_local,
-                   memo, printed_at
-            FROM sales_orders {where_sql} ORDER BY so_id DESC LIMIT :limit OFFSET :offset
+            SELECT so.so_id, so.so_number, so.so_barcode, so.customer_name, so.customer_phone, so.customer_address,
+                   so.status, so.priority, so.warehouse_id,
+                   so.ship_method, so.ship_address, so.order_date, so.ship_by_date, so.created_at, so.created_by,
+                   so.carrier, so.tracking_number, so.shipped_at,
+                   (so.shipped_at AT TIME ZONE :company_tz)::date AS shipped_date_local,
+                   so.memo, so.printed_at
+                   {primary_bin_select}
+            FROM sales_orders so {where_sql}
+            ORDER BY so.so_id DESC LIMIT :limit OFFSET :offset
         """),
         {**params, "company_tz": COMPANY_TIMEZONE},
     ).fetchall()
 
+    def _row_to_dict(r):
+        out = {
+            "so_id": r.so_id, "so_number": r.so_number, "so_barcode": r.so_barcode,
+            "customer_name": r.customer_name, "customer_phone": r.customer_phone,
+            "customer_address": r.customer_address,
+            "status": r.status, "priority": r.priority,
+            "warehouse_id": r.warehouse_id, "ship_method": r.ship_method,
+            "ship_address": r.ship_address,
+            "order_date": r.order_date.isoformat() if r.order_date else None,
+            "ship_by_date": r.ship_by_date.isoformat() if r.ship_by_date else None,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+            "created_by": r.created_by,
+            "carrier": r.carrier, "tracking_number": r.tracking_number,
+            "shipped_at": r.shipped_at.isoformat() if r.shipped_at else None,
+            "shipped_date_local": r.shipped_date_local.isoformat() if r.shipped_date_local else None,
+            "memo": r.memo,
+            "printed_at": r.printed_at.isoformat() if r.printed_at else None,
+        }
+        if include_primary_bin:
+            out["primary_bin_code"] = r.primary_bin_code
+            out["primary_bin_pick_sequence"] = r.primary_bin_pick_sequence
+        return out
+
     return jsonify({
-        "sales_orders": [
-            {"so_id": r.so_id, "so_number": r.so_number, "so_barcode": r.so_barcode,
-             "customer_name": r.customer_name, "customer_phone": r.customer_phone, "customer_address": r.customer_address,
-             "status": r.status, "priority": r.priority,
-             "warehouse_id": r.warehouse_id, "ship_method": r.ship_method, "ship_address": r.ship_address,
-             "order_date": r.order_date.isoformat() if r.order_date else None,
-             "ship_by_date": r.ship_by_date.isoformat() if r.ship_by_date else None,
-             "created_at": r.created_at.isoformat() if r.created_at else None, "created_by": r.created_by,
-             "carrier": r.carrier, "tracking_number": r.tracking_number,
-             "shipped_at": r.shipped_at.isoformat() if r.shipped_at else None,
-             "shipped_date_local": r.shipped_date_local.isoformat() if r.shipped_date_local else None,
-             "memo": r.memo,
-             "printed_at": r.printed_at.isoformat() if r.printed_at else None}
-            for r in rows
-        ],
+        "sales_orders": [_row_to_dict(r) for r in rows],
         "total": total, "page": page, "per_page": per_page, "pages": pages,
     })
 

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -509,6 +509,104 @@ def get_sales_order(so_id):
     })
 
 
+def _picking_ticket_branding(db):
+    """Configurable packing-slip branding from app_settings. All four keys
+    default to empty so a fresh install renders a clean, unbranded slip; an
+    operator sets them under Settings > Picking Ticket."""
+    rows = db.execute(
+        text(
+            "SELECT key, value FROM app_settings WHERE key IN ("
+            "'picking_ticket_company_name', 'picking_ticket_company_address', "
+            "'picking_ticket_logo_url', 'picking_ticket_returns_text')"
+        )
+    ).fetchall()
+    vals = {r.key: r.value for r in rows}
+    return {
+        "company_name": vals.get("picking_ticket_company_name", ""),
+        "company_address": vals.get("picking_ticket_company_address", ""),
+        "logo_url": vals.get("picking_ticket_logo_url", ""),
+        "returns_text": vals.get("picking_ticket_returns_text", ""),
+    }
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/picking-ticket", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission("picking-tickets")
+@with_db
+def get_picking_ticket(so_id):
+    """Picking-ticket view of an SO: header + lines with the top-priority
+    preferred bin for each item, scoped to the SO's warehouse. Used by
+    the Outbound > Picking Tickets print page."""
+    so = g.db.execute(
+        text("""
+            SELECT so_id, so_number, customer_name, status,
+                   warehouse_id, ship_method,
+                   order_date, ship_by_date, created_at,
+                   shipping_address_name, shipping_address_line1, shipping_address_line2,
+                   shipping_address_city, shipping_address_state,
+                   shipping_address_postal_code, shipping_address_country
+              FROM sales_orders WHERE so_id = :sid
+        """),
+        {"sid": so_id},
+    ).fetchone()
+    if not so:
+        return jsonify({"error": "Sales order not found"}), 404
+
+    # Per line, fetch the top-priority preferred bin scoped to the SO's
+    # warehouse. A LEFT JOIN LATERAL keeps the row when there is no
+    # preferred bin so the picker still sees the SKU with a blank bin
+    # column rather than the line dropping out entirely.
+    lines = g.db.execute(
+        text("""
+            SELECT sol.so_line_id, sol.line_number, sol.item_id,
+                   i.sku, i.item_name, i.upc,
+                   sol.quantity_ordered, sol.quantity_shipped,
+                   pref.bin_code AS preferred_bin_code
+            FROM sales_order_lines sol
+            JOIN items i ON i.item_id = sol.item_id
+            LEFT JOIN LATERAL (
+                SELECT b.bin_code
+                  FROM preferred_bins pb
+                  JOIN bins b ON b.bin_id = pb.bin_id
+                 WHERE pb.item_id = sol.item_id
+                   AND b.warehouse_id = :wid
+                 ORDER BY pb.priority ASC
+                 LIMIT 1
+            ) pref ON TRUE
+            WHERE sol.so_id = :sid
+            ORDER BY sol.line_number
+        """),
+        {"sid": so_id, "wid": so.warehouse_id},
+    ).fetchall()
+
+    return jsonify({
+        "sales_order": {
+            "so_id": so.so_id, "so_number": so.so_number,
+            "customer_name": so.customer_name, "status": so.status,
+            "warehouse_id": so.warehouse_id, "ship_method": so.ship_method,
+            "order_date": so.order_date.isoformat() if so.order_date else None,
+            "ship_by_date": so.ship_by_date.isoformat() if so.ship_by_date else None,
+            "created_at": so.created_at.isoformat() if so.created_at else None,
+            "shipping_address_name": so.shipping_address_name,
+            "shipping_address_line1": so.shipping_address_line1,
+            "shipping_address_line2": so.shipping_address_line2,
+            "shipping_address_city": so.shipping_address_city,
+            "shipping_address_state": so.shipping_address_state,
+            "shipping_address_postal_code": so.shipping_address_postal_code,
+            "shipping_address_country": so.shipping_address_country,
+        },
+        "lines": [
+            {"so_line_id": l.so_line_id, "line_number": l.line_number,
+             "sku": l.sku, "item_name": l.item_name, "upc": l.upc,
+             "quantity_ordered": l.quantity_ordered,
+             "quantity_shipped": l.quantity_shipped,
+             "preferred_bin_code": l.preferred_bin_code}
+            for l in lines
+        ],
+        "branding": _picking_ticket_branding(g.db),
+    })
+
+
 @admin_bp.route("/sales-orders", methods=["POST"])
 @require_auth
 @require_admin_or_page_permission("sales-orders")

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -172,3 +172,14 @@ class UpdateSalesOrderAddressRequest(BaseModel):
                 "send an empty string to clear a field."
             )
         return self
+
+
+class MarkSalesOrdersPrintedRequest(BaseModel):
+    """mig 064: POST body to stamp printed_at on a batch of SOs. Sent by
+    the picking-ticket print page after the client-side render confirms
+    the ticket reached the operator. The server is intentionally NOT the
+    trigger: Print All fetches data for many SOs and any of them could
+    fail to render client-side; marking them printed unconditionally
+    would silently drop those tickets from the queue."""
+
+    so_ids: List[int] = Field(..., min_length=1, max_length=200)

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -460,6 +460,59 @@ class TestSalesOrdersHidePrintedAndMarkPrinted:
         assert 1 in unfiltered_ids
         assert 1 not in filtered_ids
 
+
+class TestSalesOrdersPrimaryBin:
+    """avid-overhaul-mk1 P4.1: include_primary_bin=true on the SO list
+    surfaces the bin_code + pick_sequence of the LOWEST-pick_sequence
+    preferred bin across an SO's line items, so the picking-tickets
+    page can sort the queue in physical walk order."""
+
+    def test_default_response_omits_primary_bin_fields(self, client, auth_headers):
+        # Other pages should not pay the per-row subquery cost.
+        resp = client.get("/api/admin/sales-orders", headers=auth_headers)
+        so = resp.get_json()["sales_orders"][0]
+        assert "primary_bin_code" not in so
+        assert "primary_bin_pick_sequence" not in so
+
+    def test_include_primary_bin_returns_lowest_pick_sequence_bin(self, client, auth_headers):
+        # Item 1 (TST-001) has default_bin_id=3 (A-01-01) per seed but
+        # is not in preferred_bins by default. Insert preferred_bins
+        # rows so the computation has something to lock onto:
+        #   item 1 -> bin 3 (A-01-01, pick_sequence=100)
+        #   item 1 -> bin 4 (A-01-02, pick_sequence=200)
+        # The primary bin should be the lower pick_sequence (bin 3).
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO preferred_bins (item_id, bin_id, priority) VALUES (1, 3, 1)"
+        )
+        cur.execute(
+            "INSERT INTO preferred_bins (item_id, bin_id, priority) VALUES (1, 4, 2)"
+        )
+        cur.close()
+
+        resp = client.get(
+            "/api/admin/sales-orders?include_primary_bin=true&q=SO-2026-001",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        so = next(s for s in resp.get_json()["sales_orders"] if s["so_number"] == "SO-2026-001")
+        assert so["primary_bin_code"] == "A-01-01"
+        assert so["primary_bin_pick_sequence"] == 100
+
+    def test_include_primary_bin_null_when_no_preferred_bin(self, client, auth_headers):
+        # No preferred_bins rows for the items on this SO -> primary
+        # bin fields surface as null rather than failing the request.
+        resp = client.get(
+            "/api/admin/sales-orders?include_primary_bin=true&q=SO-2026-002",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        rows = resp.get_json()["sales_orders"]
+        if rows:
+            assert rows[0]["primary_bin_code"] is None
+            assert rows[0]["primary_bin_pick_sequence"] is None
+
     def test_get_sales_order(self, client, auth_headers):
         resp = client.get("/api/admin/sales-orders/1", headers=auth_headers)
         assert resp.status_code == 200

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -385,6 +385,81 @@ class TestSalesOrders:
         assert "tracking_number" in so
         assert "shipped_at" in so
 
+    def test_list_sales_orders_includes_printed_at(self, client, auth_headers):
+        # mig 064 column. Default value is NULL until /mark-printed
+        # stamps it.
+        resp = client.get("/api/admin/sales-orders", headers=auth_headers)
+        so = resp.get_json()["sales_orders"][0]
+        assert "printed_at" in so
+        assert so["printed_at"] is None
+
+
+class TestSalesOrdersHidePrintedAndMarkPrinted:
+    """mig 064: printed_at column drives the
+    Picking Tickets queue's hide-printed filter. The endpoint that
+    stamps printed_at is /admin/sales-orders/mark-printed - server
+    only sets the timestamp when the client confirms the ticket
+    render reached the operator."""
+
+    def test_mark_printed_stamps_timestamp(self, client, auth_headers):
+        # SO 1 starts unprinted.
+        before = client.get("/api/admin/sales-orders/1", headers=auth_headers).get_json()
+        assert before["sales_order"].get("printed_at") in (None, "")
+        resp = client.post(
+            "/api/admin/sales-orders/mark-printed",
+            json={"so_ids": [1]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data["marked"]) == 1
+        assert data["marked"][0]["so_id"] == 1
+        assert data["marked"][0]["printed_at"] is not None
+
+        # Now the row carries the timestamp.
+        printed_at = _query_val("SELECT printed_at FROM sales_orders WHERE so_id = 1")
+        assert printed_at is not None
+
+    def test_mark_printed_is_idempotent(self, client, auth_headers):
+        # Stamping twice does not update an already-printed row, so the
+        # original render-confirm timestamp survives.
+        client.post(
+            "/api/admin/sales-orders/mark-printed",
+            json={"so_ids": [1]},
+            headers=auth_headers,
+        )
+        first = _query_val("SELECT printed_at FROM sales_orders WHERE so_id = 1")
+        resp = client.post(
+            "/api/admin/sales-orders/mark-printed",
+            json={"so_ids": [1]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert len(resp.get_json()["marked"]) == 0  # row was already non-null
+        second = _query_val("SELECT printed_at FROM sales_orders WHERE so_id = 1")
+        assert second == first
+
+    def test_hide_printed_filters_list(self, client, auth_headers):
+        # Mark SO 1 as printed, then assert the hide_printed list
+        # excludes it while the unfiltered list still shows it.
+        client.post(
+            "/api/admin/sales-orders/mark-printed",
+            json={"so_ids": [1]},
+            headers=auth_headers,
+        )
+        unfiltered = client.get(
+            "/api/admin/sales-orders?warehouse_id=1&per_page=200",
+            headers=auth_headers,
+        ).get_json()
+        filtered = client.get(
+            "/api/admin/sales-orders?warehouse_id=1&per_page=200&hide_printed=true",
+            headers=auth_headers,
+        ).get_json()
+        unfiltered_ids = {s["so_id"] for s in unfiltered["sales_orders"]}
+        filtered_ids = {s["so_id"] for s in filtered["sales_orders"]}
+        assert 1 in unfiltered_ids
+        assert 1 not in filtered_ids
+
     def test_get_sales_order(self, client, auth_headers):
         resp = client.get("/api/admin/sales-orders/1", headers=auth_headers)
         assert resp.status_code == 200

--- a/db/migrations/064_sales_orders_printed_at.sql
+++ b/db/migrations/064_sales_orders_printed_at.sql
@@ -1,0 +1,20 @@
+-- 064: track when a picking ticket has been rendered for a sales
+-- order so the Picking Tickets queue can hide already-printed orders
+-- without dropping them from the SO history entirely.
+--
+-- The column is NULL until a successful client-side render confirms
+-- the ticket made it to the operator. POST /admin/sales-orders/mark-printed
+-- writes the timestamp; the GET picking-ticket endpoint itself does
+-- NOT set it, because Print All can fetch ticket data for SOs that
+-- subsequently fail to render client-side, and we do not want those
+-- orders silently disappearing from the queue.
+
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS printed_at TIMESTAMPTZ;
+
+-- Partial index for the "unprinted in queue" predicate path. The
+-- picking-tickets list filters with status IN (...) AND printed_at
+-- IS NULL; the partial index keeps the index small (only rows that
+-- still need to print) and serves the common query directly.
+CREATE INDEX IF NOT EXISTS ix_sales_orders_unprinted
+    ON sales_orders (status, ship_by_date)
+    WHERE printed_at IS NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -270,8 +270,17 @@ CREATE TABLE sales_orders (
                             CHECK (order_type IN ('sale','refund')),
     parent_so_id            INT REFERENCES sales_orders(so_id),
     refunded_at             TIMESTAMPTZ,
-    refund_so_id            INT REFERENCES sales_orders(so_id)
+    refund_so_id            INT REFERENCES sales_orders(so_id),
+    -- mig 064: timestamp set when a picking ticket has been
+    -- confirmed-rendered for this SO. POST /sales-orders/mark-printed
+    -- writes it once the client-side ticket render succeeds. NULL
+    -- means "still in the picking queue".
+    printed_at              TIMESTAMPTZ
 );
+
+CREATE INDEX IF NOT EXISTS ix_sales_orders_unprinted
+    ON sales_orders (status, ship_by_date)
+    WHERE printed_at IS NULL;
 
 CREATE TABLE sales_order_lines (
     so_line_id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary

Adds an Outbound > Picking Tickets surface: a printable packing-slip queue plus per-SO and Print All print views, with a Code 128 barcode and warehouse-walk ordering. The slip's branding is Settings-driven with neutral defaults, so a fresh install prints a clean, unbranded slip.

- **Picking Tickets queue** (`/picking-tickets`): a searchable SO list defaulting to OPEN, a status switcher (OPEN / PICKED / ALL), a Hide-Printed toggle, a sortable Bin column showing the lowest-`pick_sequence` preferred bin (so a picker walks the warehouse in physical order), and Refresh. Gated by a new `picking-tickets` page permission.
- **Print views**: a per-SO packing slip rendered by a shared `TicketDocument` component (`GET /admin/sales-orders/<id>/picking-ticket`), and a standalone Print All tab that renders the on-screen queue in warehouse-walk order, each ticket page-broken for printing and capped at 200 tickets per tab.
- **printed_at tracking** (migration 064): `POST /admin/sales-orders/mark-printed` stamps `printed_at` once the client confirms a successful render, never as a side effect of the GET. That lets the queue hide already-printed orders without dropping them; the print pages mark-printed with one retry and surface persistent failures via a toast so an operator can verify rather than assume the DB matches the screen.
- **Configurable branding**: `get_picking_ticket` returns a `branding` object read from `app_settings` (`picking_ticket_company_name` / `_company_address` / `_logo_url` / `_returns_text`), all defaulting to empty. The slip renders the logo, company block, and returns text only when set, and Settings > Picking Ticket configures them.
- **Date handling**: a shared `formatDateOnly` (`utils/date.js`) renders date-only fields without the UTC-midnight off-by-one shift, used across the picking-ticket views and the SO list.

The picking-ticket endpoints are gated by the `picking-tickets` page permission, consistent with the rest of the admin permission model.

## Migrations

- **064** -- `sales_orders.printed_at TIMESTAMPTZ` plus a partial index `(status, ship_by_date) WHERE printed_at IS NULL` so the "unprinted, soonest-ship-by-first" queue predicate stays cheap.

## Mobile

No mobile/ diffs.

## Pre-merge gate

- [x] Full api suite green locally (2482 passed, 9 skipped; the 2 psql-host suites run only in CI); admin vitest 78/78; admin build clean
- [ ] CI green
