### PR TITLE
feat(admin): Vendors admin page with CRUD

### DIFF
--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -22,6 +22,7 @@ import PickingBatches from './pages/PickingBatches.jsx';
 import Bins from './pages/Bins.jsx';
 import Zones from './pages/Zones.jsx';
 import Items from './pages/Items.jsx';
+import Vendors from './pages/Vendors.jsx';
 import Warehouses from './pages/Warehouses.jsx';
 import Users from './pages/Users.jsx';
 import Tokens from './pages/Tokens.jsx';
@@ -102,6 +103,7 @@ export default function App() {
         <Route path="/bins" element={<ErrorBoundary fallbackMessage="Could not load bins."><Bins /></ErrorBoundary>} />
         <Route path="/zones" element={<ErrorBoundary fallbackMessage="Could not load zones."><Zones /></ErrorBoundary>} />
         <Route path="/items" element={<ErrorBoundary fallbackMessage="Could not load items."><Items /></ErrorBoundary>} />
+        <Route path="/vendors" element={<ErrorBoundary fallbackMessage="Could not load vendors."><Vendors /></ErrorBoundary>} />
         <Route path="/warehouses" element={<ErrorBoundary fallbackMessage="Could not load warehouses."><Warehouses /></ErrorBoundary>} />
         <Route path="/preferred-bins" element={<ErrorBoundary fallbackMessage="Could not load preferred bins."><PreferredBins /></ErrorBoundary>} />
         <Route path="/users" element={<ErrorBoundary fallbackMessage="Could not load users."><Users /></ErrorBoundary>} />

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -46,6 +46,7 @@ const NAV = [
       { to: '/bins', label: 'Bins', pageKey: 'bins' },
       { to: '/zones', label: 'Zones', pageKey: 'zones' },
       { to: '/items', label: 'Items', pageKey: 'items' },
+      { to: '/vendors', label: 'Vendors', pageKey: 'vendors' },
       { to: '/preferred-bins', label: 'Preferred Bins', pageKey: 'preferred-bins' },
       { to: '/adjustments', label: 'Adjustments', pageKey: 'adjustments' },
       { to: '/transfer-orders', label: 'Transfer Orders', pageKey: 'transfer-orders' },

--- a/admin/src/pages/Users.jsx
+++ b/admin/src/pages/Users.jsx
@@ -52,6 +52,7 @@ const PAGE_GROUPS = [
     label: 'Warehouse',
     pages: [
       { key: 'items', label: 'Items' },
+      { key: 'vendors', label: 'Vendors' },
       { key: 'adjustments', label: 'Inventory Adjustments' },
       { key: 'inter-warehouse-transfers', label: 'Inventory Transfers' },
       { key: 'transfer-orders', label: 'Transfer Orders' },

--- a/admin/src/pages/Vendors.jsx
+++ b/admin/src/pages/Vendors.jsx
@@ -1,0 +1,287 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api.js';
+import DataTable from '../components/DataTable.jsx';
+import PageHeader from '../components/PageHeader.jsx';
+import Modal from '../components/Modal.jsx';
+
+const FILTER_OPTIONS = [
+  { label: 'Active', value: 'active' },
+  { label: 'Archived', value: 'archived' },
+  { label: 'All', value: 'all' },
+];
+
+function formatApiError(data, fallback) {
+  if (!data) return fallback;
+  if (Array.isArray(data.details) && data.details.length > 0) {
+    return data.details
+      .map((d) => {
+        const field = Array.isArray(d.loc) && d.loc.length ? d.loc.join('.') : 'request';
+        return `${field}: ${d.msg}`;
+      })
+      .join('; ');
+  }
+  return data.error || fallback;
+}
+
+export default function Vendors() {
+  const [vendors, setVendors] = useState([]);
+  const [pagination, setPagination] = useState(null);
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState('active');
+  const [showModal, setShowModal] = useState(false);
+  const [editId, setEditId] = useState(null);
+  const [form, setForm] = useState({});
+  const [error, setError] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleteError, setDeleteError] = useState('');
+
+  useEffect(() => { loadVendors(); }, [page, search, filter]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function loadVendors() {
+    const params = new URLSearchParams({ page: String(page), per_page: '50' });
+    if (search) params.set('q', search);
+    if (filter === 'active') params.set('active', 'true');
+    else if (filter === 'archived') params.set('active', 'false');
+    const res = await api.get(`/admin/vendors?${params}`);
+    if (!res?.ok) return;
+    const data = await res.json();
+    setVendors(data.vendors || []);
+    setPagination({ page: data.page, pages: data.pages, total: data.total, per_page: data.per_page });
+  }
+
+  function openCreate() {
+    setEditId(null);
+    setForm({ vendor_name: '', contact_name: '', email: '', phone: '', tax_id: '', payment_terms: '', is_active: true });
+    setError('');
+    setShowModal(true);
+  }
+
+  function openEdit(vendor) {
+    setEditId(vendor.canonical_id);
+    setForm({
+      vendor_name: vendor.vendor_name || '',
+      contact_name: vendor.contact_name || '',
+      email: vendor.email || '',
+      phone: vendor.phone || '',
+      billing_address: vendor.billing_address || '',
+      remit_to_address: vendor.remit_to_address || '',
+      tax_id: vendor.tax_id || '',
+      payment_terms: vendor.payment_terms || '',
+      is_active: vendor.is_active !== false,
+    });
+    setError('');
+    setShowModal(true);
+  }
+
+  async function save() {
+    setError('');
+    const body = {
+      vendor_name: form.vendor_name,
+      contact_name: form.contact_name || null,
+      email: form.email || null,
+      phone: form.phone || null,
+      billing_address: form.billing_address || null,
+      remit_to_address: form.remit_to_address || null,
+      tax_id: form.tax_id || null,
+      payment_terms: form.payment_terms || null,
+      is_active: !!form.is_active,
+    };
+    const res = editId
+      ? await api.put(`/admin/vendors/${editId}`, body)
+      : await api.post('/admin/vendors', body);
+    if (res?.ok) {
+      setShowModal(false);
+      loadVendors();
+    } else {
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
+      setError(formatApiError(data, 'Failed to save'));
+    }
+  }
+
+  async function confirmDelete() {
+    setDeleteError('');
+    if (!deleteTarget) return;
+    const res = await api.delete(`/admin/vendors/${deleteTarget.canonical_id}`);
+    if (res?.ok) {
+      setDeleteTarget(null);
+      loadVendors();
+    } else {
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
+      setDeleteError(formatApiError(data, 'Failed to delete'));
+    }
+  }
+
+  const columns = [
+    { key: 'vendor_name', label: 'Vendor', sortable: true },
+    { key: 'contact_name', label: 'Contact', render: (r) => r.contact_name || '-' },
+    { key: 'email', label: 'Email', render: (r) => r.email || '-' },
+    { key: 'phone', label: 'Phone', mono: true, render: (r) => r.phone || '-' },
+    { key: 'is_active', label: 'Active', render: (r) => (r.is_active === false ? 'No' : 'Yes') },
+    {
+      key: 'actions', label: '', render: (r) => (
+        <div style={{ display: 'flex', gap: 4 }}>
+          <button className="btn btn-sm" onClick={(e) => { e.stopPropagation(); openEdit(r); }} aria-label="Edit" title="Edit">&#9998;</button>
+          <button
+            className="btn btn-sm btn-danger"
+            onClick={(e) => { e.stopPropagation(); setDeleteTarget(r); setDeleteError(''); }}
+            aria-label="Delete" title="Delete (only when no items reference this vendor)"
+          >&#128465;</button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <PageHeader title="Vendors">
+        <button className="btn btn-primary" onClick={openCreate}>New Vendor</button>
+      </PageHeader>
+
+      <div className="filter-bar">
+        <input
+          className="form-input"
+          placeholder="Search by name, contact, email"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+          style={{ maxWidth: 320 }}
+        />
+        <select
+          className="form-select"
+          value={filter}
+          onChange={(e) => { setFilter(e.target.value); setPage(1); }}
+        >
+          {FILTER_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+        </select>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={vendors}
+        pagination={pagination}
+        onPageChange={setPage}
+        onRowClick={openEdit}
+        emptyMessage="No vendors found"
+      />
+
+      {showModal && (
+        <Modal
+          title={editId ? 'Edit Vendor' : 'New Vendor'}
+          onClose={() => setShowModal(false)}
+          footer={
+            <>
+              <button className="btn" onClick={() => setShowModal(false)}>Cancel</button>
+              <button className="btn btn-primary" onClick={save}>Save</button>
+            </>
+          }
+          size="wide"
+        >
+          {error && <div className="form-error" style={{ marginBottom: 12 }}>{error}</div>}
+          <div className="form-row">
+            <div className="form-group">
+              <label>Vendor Name</label>
+              <input
+                className="form-input" autoFocus
+                value={form.vendor_name || ''}
+                onChange={(e) => setForm({ ...form, vendor_name: e.target.value })}
+              />
+            </div>
+            <div className="form-group">
+              <label>Contact Name</label>
+              <input
+                className="form-input"
+                value={form.contact_name || ''}
+                onChange={(e) => setForm({ ...form, contact_name: e.target.value })}
+              />
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label>Email</label>
+              <input
+                className="form-input" type="email"
+                value={form.email || ''}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+              />
+            </div>
+            <div className="form-group">
+              <label>Phone</label>
+              <input
+                className="form-input"
+                value={form.phone || ''}
+                onChange={(e) => setForm({ ...form, phone: e.target.value })}
+              />
+            </div>
+          </div>
+          <div className="form-group">
+            <label>Billing Address</label>
+            <textarea
+              className="form-input" rows={2}
+              value={form.billing_address || ''}
+              onChange={(e) => setForm({ ...form, billing_address: e.target.value })}
+            />
+          </div>
+          <div className="form-group">
+            <label>Remit-To Address</label>
+            <textarea
+              className="form-input" rows={2}
+              value={form.remit_to_address || ''}
+              onChange={(e) => setForm({ ...form, remit_to_address: e.target.value })}
+            />
+          </div>
+          <div className="form-row">
+            <div className="form-group">
+              <label>Tax ID</label>
+              <input
+                className="form-input"
+                value={form.tax_id || ''}
+                onChange={(e) => setForm({ ...form, tax_id: e.target.value })}
+              />
+            </div>
+            <div className="form-group">
+              <label>Payment Terms</label>
+              <input
+                className="form-input"
+                placeholder="e.g. Net 30"
+                value={form.payment_terms || ''}
+                onChange={(e) => setForm({ ...form, payment_terms: e.target.value })}
+              />
+            </div>
+          </div>
+          <div className="form-group">
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={form.is_active !== false}
+                onChange={(e) => setForm({ ...form, is_active: e.target.checked })}
+              />
+              <span>Active (uncheck to hide from item / PO vendor pickers)</span>
+            </label>
+          </div>
+        </Modal>
+      )}
+
+      {deleteTarget && (
+        <Modal
+          title={`Delete vendor ${deleteTarget.vendor_name}?`}
+          onClose={() => { setDeleteTarget(null); setDeleteError(''); }}
+          footer={
+            <>
+              <button className="btn" onClick={() => { setDeleteTarget(null); setDeleteError(''); }}>Cancel</button>
+              <button className="btn btn-danger" onClick={confirmDelete}>Delete</button>
+            </>
+          }
+        >
+          {deleteError && <div className="form-error" style={{ marginBottom: 12 }}>{deleteError}</div>}
+          <p style={{ fontSize: 13 }}>
+            Permanently delete this vendor. The action is blocked when any item still
+            references this vendor; soft-archive via the Active checkbox in the edit form
+            for that case.
+          </p>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/api/constants.py
+++ b/api/constants.py
@@ -187,7 +187,7 @@ ALL_PAGE_KEYS = (
     # see the /picking-batches page plus the SO batch-release action.
     "picking-batches",
     "picking", "packing", "shipping",
-    "items",
+    "items", "vendors",
     "adjustments", "inter-warehouse-transfers", "transfer-orders",
     "warehouses", "bins", "zones", "preferred-bins",
     "users", "api-tokens", "inbound", "consumer-groups",

--- a/api/routes/admin/__init__.py
+++ b/api/routes/admin/__init__.py
@@ -57,6 +57,7 @@ from routes.admin import (  # noqa: E402, F401
     admin_tokens,
     admin_transfer_orders,
     admin_users,
+    admin_vendors,
     admin_warehouse,
     admin_webhooks,
 )

--- a/api/routes/admin/admin_vendors.py
+++ b/api/routes/admin/admin_vendors.py
@@ -1,0 +1,196 @@
+"""Admin CRUD for the canonical vendors table.
+
+The upstream vendors table ships without an admin-facing endpoint;
+this adds one so operators can manage the roster without round-tripping
+through the inbound pipe. An items.vendor_id linkage is deferred to a
+future release; soft-archive via is_active=false remains the supported
+way to retire a vendor.
+"""
+
+import math
+
+from flask import g, jsonify, request
+from sqlalchemy import text
+
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
+from middleware.db import with_db
+from routes.admin import admin_bp
+from schemas.vendors import CreateVendorRequest, UpdateVendorRequest
+from utils.validation import validate_body
+
+
+def _vendor_row_to_dict(row):
+    return {
+        "canonical_id": str(row.canonical_id),
+        "external_id": str(row.external_id),
+        "vendor_name": row.vendor_name,
+        "contact_name": row.contact_name,
+        "email": row.email,
+        "phone": row.phone,
+        "billing_address": row.billing_address,
+        "remit_to_address": row.remit_to_address,
+        "tax_id": row.tax_id,
+        "payment_terms": row.payment_terms,
+        "is_active": row.is_active,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
+@admin_bp.route("/vendors", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission("vendors")
+@with_db
+def list_vendors():
+    page = request.args.get("page", 1, type=int)
+    per_page = min(request.args.get("per_page", 50, type=int), 1000)
+    search = (request.args.get("q") or "").strip()
+    # Same active-vs-archived axis the Items page uses. Default 'active'
+    # so retired vendors do not clutter the picker.
+    active = request.args.get("active")
+
+    where_clauses, params = [], {}
+    if search:
+        where_clauses.append(
+            "(vendor_name ILIKE :q OR contact_name ILIKE :q OR email ILIKE :q)"
+        )
+        params["q"] = f"%{search}%"
+    if active is not None:
+        where_clauses.append("is_active = :active")
+        params["active"] = active.lower() == "true"
+
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+    total = g.db.execute(
+        text(f"SELECT COUNT(*) FROM vendors {where_sql}"),
+        params,
+    ).scalar()
+    pages = max(1, math.ceil(total / per_page)) if total else 1
+
+    params["limit"] = per_page
+    params["offset"] = (page - 1) * per_page
+    rows = g.db.execute(
+        text(
+            f"""
+            SELECT canonical_id, external_id, vendor_name, contact_name,
+                   email, phone, billing_address, remit_to_address,
+                   tax_id, payment_terms, is_active, created_at, updated_at
+              FROM vendors {where_sql}
+             ORDER BY vendor_name NULLS LAST, canonical_id
+             LIMIT :limit OFFSET :offset
+            """
+        ),
+        params,
+    ).fetchall()
+
+    return jsonify({
+        "vendors": [_vendor_row_to_dict(r) for r in rows],
+        "total": total, "page": page, "per_page": per_page, "pages": pages,
+    })
+
+
+@admin_bp.route("/vendors/<uuid:canonical_id>", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission("vendors")
+@with_db
+def get_vendor(canonical_id):
+    row = g.db.execute(
+        text(
+            """
+            SELECT canonical_id, external_id, vendor_name, contact_name,
+                   email, phone, billing_address, remit_to_address,
+                   tax_id, payment_terms, is_active, created_at, updated_at
+              FROM vendors WHERE canonical_id = :cid
+            """
+        ),
+        {"cid": str(canonical_id)},
+    ).fetchone()
+    if not row:
+        return jsonify({"error": "Vendor not found"}), 404
+    return jsonify({"vendor": _vendor_row_to_dict(row)})
+
+
+@admin_bp.route("/vendors", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("vendors")
+@validate_body(CreateVendorRequest)
+@with_db
+def create_vendor(validated):
+    data = validated.model_dump()
+    row = g.db.execute(
+        text(
+            """
+            INSERT INTO vendors (
+                vendor_name, contact_name, email, phone,
+                billing_address, remit_to_address, tax_id,
+                payment_terms, is_active
+            ) VALUES (
+                :vendor_name, :contact_name, :email, :phone,
+                :billing_address, :remit_to_address, :tax_id,
+                :payment_terms, :is_active
+            )
+            RETURNING canonical_id, external_id, vendor_name, contact_name,
+                      email, phone, billing_address, remit_to_address,
+                      tax_id, payment_terms, is_active, created_at, updated_at
+            """
+        ),
+        data,
+    ).fetchone()
+    g.db.commit()
+    return jsonify({"vendor": _vendor_row_to_dict(row)}), 201
+
+
+@admin_bp.route("/vendors/<uuid:canonical_id>", methods=["PUT"])
+@require_auth
+@require_admin_or_page_permission("vendors")
+@validate_body(UpdateVendorRequest)
+@with_db
+def update_vendor(canonical_id, validated):
+    data = validated.model_dump(exclude_unset=True)
+    if not data:
+        return jsonify({"error": "No valid fields provided"}), 400
+
+    existing = g.db.execute(
+        text("SELECT canonical_id FROM vendors WHERE canonical_id = :cid"),
+        {"cid": str(canonical_id)},
+    ).fetchone()
+    if not existing:
+        return jsonify({"error": "Vendor not found"}), 404
+
+    set_fragments = [f"{col} = :{col}" for col in data]
+    set_fragments.append("updated_at = NOW()")
+    params = {**data, "cid": str(canonical_id)}
+    row = g.db.execute(
+        text(
+            f"""
+            UPDATE vendors SET {', '.join(set_fragments)}
+             WHERE canonical_id = :cid
+            RETURNING canonical_id, external_id, vendor_name, contact_name,
+                      email, phone, billing_address, remit_to_address,
+                      tax_id, payment_terms, is_active, created_at, updated_at
+            """
+        ),
+        params,
+    ).fetchone()
+    g.db.commit()
+    return jsonify({"vendor": _vendor_row_to_dict(row)})
+
+
+@admin_bp.route("/vendors/<uuid:canonical_id>", methods=["DELETE"])
+@require_auth
+@require_admin_or_page_permission("vendors")
+@with_db
+def delete_vendor(canonical_id):
+    existing = g.db.execute(
+        text("SELECT canonical_id FROM vendors WHERE canonical_id = :cid"),
+        {"cid": str(canonical_id)},
+    ).fetchone()
+    if not existing:
+        return jsonify({"error": "Vendor not found"}), 404
+
+    g.db.execute(
+        text("DELETE FROM vendors WHERE canonical_id = :cid"),
+        {"cid": str(canonical_id)},
+    )
+    g.db.commit()
+    return jsonify({"deleted": True})

--- a/api/schemas/vendors.py
+++ b/api/schemas/vendors.py
@@ -1,0 +1,35 @@
+"""Vendor request schemas.
+
+The canonical vendors table ships without an admin-facing CRUD path
+upstream; this adds one so operators can manage the vendor roster
+directly. Same locked fields as the table itself; is_active defaults
+to True on create so new vendors are immediately active.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CreateVendorRequest(BaseModel):
+    vendor_name: str = Field(..., min_length=1, max_length=200)
+    contact_name: Optional[str] = Field(None, max_length=200)
+    email: Optional[str] = Field(None, max_length=255)
+    phone: Optional[str] = Field(None, max_length=50)
+    billing_address: Optional[str] = Field(None, max_length=2000)
+    remit_to_address: Optional[str] = Field(None, max_length=2000)
+    tax_id: Optional[str] = Field(None, max_length=64)
+    payment_terms: Optional[str] = Field(None, max_length=64)
+    is_active: Optional[bool] = Field(True)
+
+
+class UpdateVendorRequest(BaseModel):
+    vendor_name: Optional[str] = Field(None, min_length=1, max_length=200)
+    contact_name: Optional[str] = Field(None, max_length=200)
+    email: Optional[str] = Field(None, max_length=255)
+    phone: Optional[str] = Field(None, max_length=50)
+    billing_address: Optional[str] = Field(None, max_length=2000)
+    remit_to_address: Optional[str] = Field(None, max_length=2000)
+    tax_id: Optional[str] = Field(None, max_length=64)
+    payment_terms: Optional[str] = Field(None, max_length=64)
+    is_active: Optional[bool] = Field(None)

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -1688,3 +1688,90 @@ class TestInventorySearchQ:
         resp = client.get("/api/admin/inventory?warehouse_id=1&q=%20%20%20", headers=auth_headers)
         assert resp.status_code == 200
         assert resp.get_json()["total"] == baseline
+
+
+class TestVendorsCRUD:
+    """Admin CRUD over the canonical vendors table: validates
+    create / list / get / update / delete."""
+
+    def test_create_and_get_vendor(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/vendors",
+            json={"vendor_name": "Acme Tackle Co", "email": "buyer@acme.example"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+        v = resp.get_json()["vendor"]
+        assert v["vendor_name"] == "Acme Tackle Co"
+        assert v["email"] == "buyer@acme.example"
+        assert v["is_active"] is True
+        assert v["canonical_id"]
+
+        detail = client.get(
+            f"/api/admin/vendors/{v['canonical_id']}",
+            headers=auth_headers,
+        )
+        assert detail.status_code == 200
+        assert detail.get_json()["vendor"]["canonical_id"] == v["canonical_id"]
+
+    def test_list_vendors_filters_by_active(self, client, auth_headers):
+        client.post(
+            "/api/admin/vendors",
+            json={"vendor_name": "Archived Vendor", "is_active": False},
+            headers=auth_headers,
+        )
+        client.post(
+            "/api/admin/vendors",
+            json={"vendor_name": "Active Vendor", "is_active": True},
+            headers=auth_headers,
+        )
+        active = client.get(
+            "/api/admin/vendors?active=true",
+            headers=auth_headers,
+        ).get_json()
+        archived = client.get(
+            "/api/admin/vendors?active=false",
+            headers=auth_headers,
+        ).get_json()
+        active_names = {v["vendor_name"] for v in active["vendors"]}
+        archived_names = {v["vendor_name"] for v in archived["vendors"]}
+        assert "Active Vendor" in active_names
+        assert "Active Vendor" not in archived_names
+        assert "Archived Vendor" in archived_names
+        assert "Archived Vendor" not in active_names
+
+    def test_update_vendor(self, client, auth_headers):
+        v = client.post(
+            "/api/admin/vendors",
+            json={"vendor_name": "Edit Target"},
+            headers=auth_headers,
+        ).get_json()["vendor"]
+        resp = client.put(
+            f"/api/admin/vendors/{v['canonical_id']}",
+            json={"contact_name": "Jane Buyer", "phone": "555-0100"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        updated = resp.get_json()["vendor"]
+        assert updated["contact_name"] == "Jane Buyer"
+        assert updated["phone"] == "555-0100"
+        assert updated["vendor_name"] == "Edit Target"  # untouched
+
+    def test_delete_unreferenced_vendor(self, client, auth_headers):
+        v = client.post(
+            "/api/admin/vendors",
+            json={"vendor_name": "Disposable Vendor"},
+            headers=auth_headers,
+        ).get_json()["vendor"]
+        resp = client.delete(
+            f"/api/admin/vendors/{v['canonical_id']}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["deleted"] is True
+        # Vendor is gone.
+        missing = client.get(
+            f"/api/admin/vendors/{v['canonical_id']}",
+            headers=auth_headers,
+        )
+        assert missing.status_code == 404


### PR DESCRIPTION
Adds a Vendors admin page backed by CRUD against the canonical vendors
table, which shipped without an admin-facing path upstream.

- Backend: list / get / create / update / delete on the vendors table,
  gated by the vendors page permission. is_active defaults to true on
  create; soft-archive via is_active=false is the supported retire path.
- Admin UI: Vendors page (list + create + edit + delete), a Vendors
  entry in the sidebar and the Users permission grid, and the vendors
  page key wired into the route + permission set.

No migration: the vendors table already exists upstream. The
items.vendor_id linkage is intentionally deferred to a future release.