### PR TITLE
feat(admin-po): PO management - editable lines, statuses, CSV, inline receiving

### DIFF
--- a/admin/src/pages/PurchaseOrders.jsx
+++ b/admin/src/pages/PurchaseOrders.jsx
@@ -21,6 +21,23 @@ function statusDropdownOptions(currentStatus) {
   });
 }
 
+// Surfaces field-level validation errors from the @validate_body
+// decorator alongside flat string errors from the route handlers,
+// so the operator sees what specifically failed instead of a bare
+// "validation_error" label.
+function formatApiError(data, fallback) {
+  if (!data) return fallback;
+  if (Array.isArray(data.details) && data.details.length > 0) {
+    return data.details
+      .map((d) => {
+        const field = Array.isArray(d.loc) && d.loc.length ? d.loc.join('.') : 'request';
+        return `${field}: ${d.msg}`;
+      })
+      .join('; ');
+  }
+  return data.error || fallback;
+}
+
 export default function PurchaseOrders() {
   const [searchParams] = useSearchParams();
   const [search, setSearch] = useState(searchParams.get('q') || '');
@@ -175,8 +192,9 @@ export default function PurchaseOrders() {
       closeEdit();
       loadOrders();
     } else {
-      const data = await res?.json();
-      setEditError(data?.error || 'Failed to save');
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
+      setEditError(formatApiError(data, 'Failed to save'));
     }
   }
 
@@ -193,10 +211,11 @@ export default function PurchaseOrders() {
           : l,
       ));
     } else {
-      const data = await res?.json();
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
       setLineErrors((e) => ({
         ...e,
-        [line.po_line_id]: data?.error || 'Failed to update',
+        [line.po_line_id]: formatApiError(data, 'Failed to update'),
       }));
     }
   }
@@ -209,10 +228,11 @@ export default function PurchaseOrders() {
     if (res?.ok) {
       setEditLines((ls) => ls.filter((l) => l.po_line_id !== line.po_line_id));
     } else {
-      const data = await res?.json();
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
       setLineErrors((e) => ({
         ...e,
-        [line.po_line_id]: data?.error || 'Failed to remove',
+        [line.po_line_id]: formatApiError(data, 'Failed to remove'),
       }));
     }
   }
@@ -275,8 +295,9 @@ export default function PurchaseOrders() {
         setResolvedItem(null);
         setSkuSuggestions([]);
       } else {
-        const data = await res?.json();
-        setNewLineError(data?.error || 'Failed to add line');
+        let data = null;
+        try { data = await res?.json(); } catch (_) { /* non-JSON body */ }
+        setNewLineError(formatApiError(data, 'Failed to add line'));
       }
     } finally {
       setAddingLine(false);
@@ -437,7 +458,23 @@ export default function PurchaseOrders() {
           }
           size="wide"
         >
-          {editError && <div className="form-error" style={{ marginBottom: 12 }}>{editError}</div>}
+          {editError && (
+            <div
+              className="form-error"
+              style={{
+                position: 'sticky',
+                top: 0,
+                zIndex: 5,
+                background: 'var(--danger-bg)',
+                padding: '10px 14px',
+                margin: '-20px -20px 16px',
+                borderBottom: '1px solid var(--danger)',
+                fontSize: 13,
+              }}
+            >
+              {editError}
+            </div>
+          )}
 
           <section className="section">
             <div className="section-title">Header</div>

--- a/admin/src/pages/PurchaseOrders.jsx
+++ b/admin/src/pages/PurchaseOrders.jsx
@@ -45,8 +45,46 @@ export default function PurchaseOrders() {
   const [newLineQty, setNewLineQty] = useState('');
   const [newLineError, setNewLineError] = useState('');
   const [addingLine, setAddingLine] = useState(false);
+  // Typeahead state: debounced fetch as the operator types in the
+  // SKU field populates a datalist + drives a live "Found: ..."
+  // preview so the operator can see the resolution before clicking
+  // Add. Beats the original "type a SKU and pray it matches" UX.
+  const [skuSuggestions, setSkuSuggestions] = useState([]);
+  const [resolvedItem, setResolvedItem] = useState(null);
 
   useEffect(() => { loadOrders(); }, [page, statusFilter, search, showArchived]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Debounced SKU lookup. Fires while the operator is typing in the
+  // Add Line SKU input so suggestions surface without a server query
+  // per keystroke. Skips when the modal is not open or the field
+  // is empty.
+  useEffect(() => {
+    if (!editing) return;
+    const sku = newLineSku.trim();
+    if (sku.length < 2) {
+      setSkuSuggestions([]);
+      setResolvedItem(null);
+      return;
+    }
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/items?q=${encodeURIComponent(sku)}&per_page=10&active=true`,
+      );
+      if (!res?.ok) {
+        setSkuSuggestions([]);
+        setResolvedItem(null);
+        return;
+      }
+      const data = await res.json();
+      const items = data.items || [];
+      setSkuSuggestions(items);
+      const exact = items.find(
+        (i) => String(i.sku || '').trim().toLowerCase() === sku.toLowerCase(),
+      ) || null;
+      setResolvedItem(exact);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [newLineSku, editing]);
 
   async function loadOrders() {
     const qp = new URLSearchParams({ page: String(page), per_page: '50' });
@@ -209,7 +247,15 @@ export default function PurchaseOrders() {
     }
     setAddingLine(true);
     try {
-      const item = await resolveSku(sku);
+      // Prefer the resolvedItem from the live typeahead so we do not
+      // pay a second round-trip when the operator already saw the
+      // "Found" preview. Fall back to an on-demand server lookup so
+      // the button still works if the operator types and clicks Add
+      // faster than the 200ms debounce.
+      let item = resolvedItem;
+      if (!item || String(item.sku).toLowerCase() !== sku.toLowerCase()) {
+        item = await resolveSku(sku);
+      }
       if (!item) {
         setNewLineError(`Unknown SKU: ${sku}`);
         return;
@@ -226,6 +272,8 @@ export default function PurchaseOrders() {
         ]);
         setNewLineSku('');
         setNewLineQty('');
+        setResolvedItem(null);
+        setSkuSuggestions([]);
       } else {
         const data = await res?.json();
         setNewLineError(data?.error || 'Failed to add line');
@@ -519,42 +567,65 @@ export default function PurchaseOrders() {
                 marginTop: 12, padding: 12,
                 background: 'var(--surface)',
                 borderRadius: 'var(--radius)',
-                display: 'flex', alignItems: 'flex-start', gap: 8,
               }}>
-                <div style={{ flex: '0 0 200px' }}>
-                  <label style={{ fontSize: 11, color: 'var(--text-secondary)', fontWeight: 500 }}>SKU</label>
-                  <input
-                    className="form-input"
-                    placeholder="Enter SKU"
-                    value={newLineSku}
-                    onChange={(e) => setNewLineSku(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === 'Enter') addLine(); }}
-                  />
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+                  <div style={{ flex: '0 0 240px' }}>
+                    <label style={{ fontSize: 11, color: 'var(--text-secondary)', fontWeight: 500 }}>SKU</label>
+                    <input
+                      className="form-input mono"
+                      placeholder="Type SKU to search"
+                      list="po-edit-sku-suggestions"
+                      value={newLineSku}
+                      onChange={(e) => setNewLineSku(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') addLine(); }}
+                    />
+                    <datalist id="po-edit-sku-suggestions">
+                      {skuSuggestions.map((it) => (
+                        <option key={it.item_id} value={it.sku}>{it.item_name}</option>
+                      ))}
+                    </datalist>
+                  </div>
+                  <div style={{ flex: '0 0 120px' }}>
+                    <label style={{ fontSize: 11, color: 'var(--text-secondary)', fontWeight: 500 }}>Quantity</label>
+                    <input
+                      className="form-input"
+                      type="number"
+                      min={1}
+                      placeholder="0"
+                      value={newLineQty}
+                      onChange={(e) => setNewLineQty(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') addLine(); }}
+                    />
+                  </div>
+                  <div style={{ flexGrow: 1 }} />
+                  <button
+                    className="btn btn-primary"
+                    onClick={addLine}
+                    disabled={addingLine}
+                    style={{ marginTop: 16 }}
+                  >
+                    {addingLine ? 'Adding...' : 'Add Line'}
+                  </button>
                 </div>
-                <div style={{ flex: '0 0 120px' }}>
-                  <label style={{ fontSize: 11, color: 'var(--text-secondary)', fontWeight: 500 }}>Quantity</label>
-                  <input
-                    className="form-input"
-                    type="number"
-                    min={1}
-                    placeholder="0"
-                    value={newLineQty}
-                    onChange={(e) => setNewLineQty(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === 'Enter') addLine(); }}
-                  />
-                </div>
-                <div style={{ flexGrow: 1 }} />
-                <button
-                  className="btn btn-primary"
-                  onClick={addLine}
-                  disabled={addingLine}
-                  style={{ marginTop: 16 }}
-                >
-                  {addingLine ? 'Adding...' : 'Add Line'}
-                </button>
+                {/* Live resolution preview / error sit immediately under
+                    the inputs so feedback is impossible to miss. */}
+                {newLineError && (
+                  <div className="form-error" style={{ marginTop: 8, fontSize: 12 }}>
+                    {newLineError}
+                  </div>
+                )}
+                {!newLineError && resolvedItem && (
+                  <div style={{ marginTop: 8, fontSize: 12, color: 'var(--success)' }}>
+                    Found: <strong>{resolvedItem.sku}</strong> - {resolvedItem.item_name}
+                  </div>
+                )}
+                {!newLineError && !resolvedItem && newLineSku.trim().length >= 2 && skuSuggestions.length === 0 && (
+                  <div style={{ marginTop: 8, fontSize: 12, color: 'var(--text-secondary)' }}>
+                    No matches for "{newLineSku.trim()}". Click Add Line to retry the lookup.
+                  </div>
+                )}
               </div>
             )}
-            {newLineError && <div className="form-error" style={{ marginTop: 8 }}>{newLineError}</div>}
           </section>
         </Modal>
       )}

--- a/admin/src/pages/PurchaseOrders.jsx
+++ b/admin/src/pages/PurchaseOrders.jsx
@@ -6,7 +6,20 @@ import PageHeader from '../components/PageHeader.jsx';
 import Modal from '../components/Modal.jsx';
 import StatusTag from '../components/StatusTag.jsx';
 
-const STATUS_OPTIONS = ['All', 'OPEN', 'PARTIAL', 'RECEIVED', 'CLOSED'];
+const STATUS_OPTIONS = ['All', 'OPEN', 'PARTIAL', 'RECEIVED', 'CLOSED', 'ARCHIVED'];
+const ALL_PO_STATUSES = ['OPEN', 'PARTIAL', 'RECEIVED', 'CLOSED', 'ARCHIVED'];
+// ARCHIVED is reachable only from CLOSED in the backend state
+// machine. Surface that rule in the dropdown so an operator never
+// sees a 400 from the server for picking an invalid transition.
+const EDIT_LOCKED_STATUSES = new Set(['CLOSED', 'ARCHIVED']);
+
+function statusDropdownOptions(currentStatus) {
+  return ALL_PO_STATUSES.filter((s) => {
+    if (s === currentStatus) return true;
+    if (s === 'ARCHIVED') return currentStatus === 'CLOSED';
+    return true;
+  });
+}
 
 export default function PurchaseOrders() {
   const [searchParams] = useSearchParams();
@@ -15,19 +28,31 @@ export default function PurchaseOrders() {
   const [pagination, setPagination] = useState(null);
   const [page, setPage] = useState(1);
   const [statusFilter, setStatusFilter] = useState('All');
+  // ARCHIVED POs are hidden by default to keep the active list clean.
+  // The Show Archived toggle flips include_archived on the backend
+  // call so an operator can audit completed orders when needed.
+  const [showArchived, setShowArchived] = useState(false);
   const [selectedPO, setSelectedPO] = useState(null);
   const [poLines, setPOLines] = useState([]);
+  // Edit modal state: full PO + its lines so the modal can drive the
+  // line CRUD endpoints without a second fetch.
   const [editing, setEditing] = useState(null);
   const [editForm, setEditForm] = useState({});
   const [editError, setEditError] = useState('');
-  const [confirmClose, setConfirmClose] = useState(false);
+  const [editLines, setEditLines] = useState([]);
+  const [lineErrors, setLineErrors] = useState({});
+  const [newLineSku, setNewLineSku] = useState('');
+  const [newLineQty, setNewLineQty] = useState('');
+  const [newLineError, setNewLineError] = useState('');
+  const [addingLine, setAddingLine] = useState(false);
 
-  useEffect(() => { loadOrders(); }, [page, statusFilter, search]);  // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { loadOrders(); }, [page, statusFilter, search, showArchived]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   async function loadOrders() {
     const qp = new URLSearchParams({ page: String(page), per_page: '50' });
     if (statusFilter !== 'All') qp.set('status', statusFilter);
     if (search) qp.set('q', search);
+    if (showArchived) qp.set('include_archived', 'true');
     const res = await api.get(`/admin/purchase-orders?${qp}`);
     if (res?.ok) {
       const data = await res.json();
@@ -54,28 +79,62 @@ export default function PurchaseOrders() {
     setPage(newPage);
   }
 
-  function openEdit(po) {
-    setEditing(po);
+  async function openEdit(po) {
+    // Load the full PO with its lines so the Edit modal can show
+    // editable line items. Open detail-style endpoint reuses what
+    // the read-only view modal also uses.
+    const res = await api.get(`/admin/purchase-orders/${po.po_id || po.id}`);
+    if (!res?.ok) return;
+    const data = await res.json();
+    const full = data.purchase_order;
+    setEditing(full);
     setEditForm({
-      po_number: po.po_number || '',
-      vendor_name: po.vendor_name || '',
-      expected_date: po.expected_date ? po.expected_date.slice(0, 10) : '',
-      notes: po.notes || '',
+      po_number: full.po_number || '',
+      vendor_name: full.vendor_name || '',
+      expected_date: full.expected_date ? full.expected_date.slice(0, 10) : '',
+      notes: full.notes || '',
+      status: full.status,
     });
+    setEditLines(data.lines || []);
+    setLineErrors({});
+    setNewLineSku('');
+    setNewLineQty('');
+    setNewLineError('');
+    setEditError('');
+  }
+
+  function closeEdit() {
+    setEditing(null);
+    setEditLines([]);
+    setLineErrors({});
+    setNewLineSku('');
+    setNewLineQty('');
+    setNewLineError('');
     setEditError('');
   }
 
   async function saveEdit() {
     setEditError('');
-    const body = {
-      po_number: editForm.po_number,
-      vendor_name: editForm.vendor_name || null,
-      expected_date: editForm.expected_date || null,
-      notes: editForm.notes || null,
-    };
+    const body = {};
+    // Only send header fields when the PO is still in an editable
+    // status; for CLOSED / ARCHIVED only the status itself is allowed.
+    const headerEditable = !EDIT_LOCKED_STATUSES.has(editing.status);
+    if (headerEditable) {
+      body.po_number = editForm.po_number;
+      body.vendor_name = editForm.vendor_name || null;
+      body.expected_date = editForm.expected_date || null;
+      body.notes = editForm.notes || null;
+    }
+    if (editForm.status && editForm.status !== editing.status) {
+      body.status = editForm.status;
+    }
+    if (Object.keys(body).length === 0) {
+      closeEdit();
+      return;
+    }
     const res = await api.put(`/admin/purchase-orders/${editing.po_id}`, body);
     if (res?.ok) {
-      setEditing(null);
+      closeEdit();
       loadOrders();
     } else {
       const data = await res?.json();
@@ -83,29 +142,96 @@ export default function PurchaseOrders() {
     }
   }
 
-  async function closePO() {
-    setEditError('');
-    const res = await api.post(`/admin/purchase-orders/${editing.po_id}/close`, {});
+  async function updateLineQty(line, newQty) {
+    setLineErrors((e) => ({ ...e, [line.po_line_id]: '' }));
+    const res = await api.patch(
+      `/admin/purchase-orders/${editing.po_id}/lines/${line.po_line_id}`,
+      { quantity_ordered: newQty },
+    );
     if (res?.ok) {
-      setConfirmClose(false);
-      setEditing(null);
-      loadOrders();
+      setEditLines((ls) => ls.map((l) =>
+        l.po_line_id === line.po_line_id
+          ? { ...l, quantity_ordered: newQty }
+          : l,
+      ));
     } else {
       const data = await res?.json();
-      setEditError(data?.error || 'Failed to close');
-      setConfirmClose(false);
+      setLineErrors((e) => ({
+        ...e,
+        [line.po_line_id]: data?.error || 'Failed to update',
+      }));
     }
   }
 
-  async function reopenPO() {
-    setEditError('');
-    const res = await api.post(`/admin/purchase-orders/${editing.po_id}/reopen`, {});
+  async function removeLine(line) {
+    setLineErrors((e) => ({ ...e, [line.po_line_id]: '' }));
+    const res = await api.delete(
+      `/admin/purchase-orders/${editing.po_id}/lines/${line.po_line_id}`,
+    );
     if (res?.ok) {
-      setEditing(null);
-      loadOrders();
+      setEditLines((ls) => ls.filter((l) => l.po_line_id !== line.po_line_id));
     } else {
       const data = await res?.json();
-      setEditError(data?.error || 'Failed to reopen');
+      setLineErrors((e) => ({
+        ...e,
+        [line.po_line_id]: data?.error || 'Failed to remove',
+      }));
+    }
+  }
+
+  // Resolves a user-typed SKU to an item_id via a narrow server query
+  // and finds the exact case-insensitive match. Same pattern as
+  // Settings.jsx Create PO so behavior is consistent across surfaces.
+  async function resolveSku(sku) {
+    const key = String(sku || '').trim().toLowerCase();
+    if (!key) return null;
+    const res = await api.get(
+      `/admin/items?q=${encodeURIComponent(sku)}&per_page=10&active=true`,
+    );
+    if (!res?.ok) return null;
+    const data = await res.json();
+    return (data.items || []).find(
+      (i) => String(i.sku || '').trim().toLowerCase() === key,
+    ) || null;
+  }
+
+  async function addLine() {
+    setNewLineError('');
+    const sku = newLineSku.trim();
+    const qty = parseInt(newLineQty, 10);
+    if (!sku) {
+      setNewLineError('Enter a SKU');
+      return;
+    }
+    if (isNaN(qty) || qty <= 0) {
+      setNewLineError('Enter a positive quantity');
+      return;
+    }
+    setAddingLine(true);
+    try {
+      const item = await resolveSku(sku);
+      if (!item) {
+        setNewLineError(`Unknown SKU: ${sku}`);
+        return;
+      }
+      const res = await api.post(
+        `/admin/purchase-orders/${editing.po_id}/lines`,
+        { item_id: item.item_id, quantity_ordered: qty },
+      );
+      if (res?.ok) {
+        const created = await res.json();
+        setEditLines((ls) => [
+          ...ls,
+          { ...created, item_name: item.item_name, upc: item.upc },
+        ]);
+        setNewLineSku('');
+        setNewLineQty('');
+      } else {
+        const data = await res?.json();
+        setNewLineError(data?.error || 'Failed to add line');
+      }
+    } finally {
+      setAddingLine(false);
     }
   }
 
@@ -172,6 +298,17 @@ export default function PurchaseOrders() {
           value={search}
           onChange={(e) => { setSearch(e.target.value); setPage(1); }}
         />
+        <label style={{
+          display: 'flex', alignItems: 'center', gap: 6,
+          fontSize: 13, color: 'var(--text-secondary)', cursor: 'pointer',
+        }}>
+          <input
+            type="checkbox"
+            checked={showArchived}
+            onChange={(e) => { setShowArchived(e.target.checked); setPage(1); }}
+          />
+          Show Archived
+        </label>
       </div>
 
       <DataTable
@@ -198,7 +335,7 @@ export default function PurchaseOrders() {
           <section className="section">
             <div className="section-title">PO Summary</div>
             <div className="detail-grid detail-grid-2col" style={{ marginBottom: 0 }}>
-              <span className="detail-label">Vendor</span><span>{selectedPO.vendor || '-'}</span>
+              <span className="detail-label">Vendor</span><span>{selectedPO.vendor_name || '-'}</span>
               <span className="detail-label">Status</span><span><StatusTag status={selectedPO.status} /></span>
               <span className="detail-label">Expected Date</span><span className="mono">{selectedPO.expected_date ? new Date(selectedPO.expected_date).toLocaleDateString() : '-'}</span>
               <span className="detail-label">Notes</span><span>{selectedPO.notes || '-'}</span>
@@ -243,62 +380,220 @@ export default function PurchaseOrders() {
       {editing && (
         <Modal
           title={`Edit PO ${editing.po_number}`}
-          onClose={() => { setEditing(null); setConfirmClose(false); }}
+          onClose={closeEdit}
           footer={
             <>
-              {editing.status === 'CLOSED' ? (
-                <button className="btn" onClick={reopenPO}>Reopen Purchase Order</button>
-              ) : (
-                <button className="btn btn-danger" onClick={() => setConfirmClose(true)}>Close Purchase Order</button>
-              )}
-              <button className="btn" onClick={() => setEditing(null)}>Cancel</button>
-              <button className="btn btn-primary" onClick={saveEdit} disabled={editing.status === 'CLOSED'}>Save</button>
+              <button className="btn" onClick={closeEdit}>Cancel</button>
+              <button className="btn btn-primary" onClick={saveEdit}>Save</button>
             </>
           }
+          size="wide"
         >
           {editError && <div className="form-error" style={{ marginBottom: 12 }}>{editError}</div>}
-          <p style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
-            PO header fields only. Line items (items + quantities) are fixed after PO
-            create and are read-only here. Editing is restricted to POs in OPEN status.
-          </p>
-          <div className="form-row">
-            <div className="form-group">
-              <label>PO Number</label>
-              <input className="form-input" value={editForm.po_number} onChange={(e) => setEditForm({ ...editForm, po_number: e.target.value })} />
-            </div>
-            <div className="form-group">
-              <label>Vendor</label>
-              <input className="form-input" value={editForm.vendor_name} onChange={(e) => setEditForm({ ...editForm, vendor_name: e.target.value })} />
-            </div>
-          </div>
-          <div className="form-group">
-            <label>Expected Date</label>
-            <input className="form-input" type="date" value={editForm.expected_date} onChange={(e) => setEditForm({ ...editForm, expected_date: e.target.value })} />
-          </div>
-          <div className="form-group">
-            <label>Notes</label>
-            <textarea className="form-input" rows={3} value={editForm.notes} onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })} />
-          </div>
-        </Modal>
-      )}
 
-      {confirmClose && editing && (
-        <Modal
-          title={`Close PO ${editing.po_number}?`}
-          onClose={() => setConfirmClose(false)}
-          footer={
-            <>
-              <button className="btn" onClick={() => setConfirmClose(false)}>Cancel</button>
-              <button className="btn btn-danger" onClick={closePO}>Close Purchase Order</button>
-            </>
-          }
-        >
-          <p style={{ fontSize: 13 }}>
-            Close this PO? It will no longer appear in active receiving lists. This
-            can be reversed by reopening.
-          </p>
+          <section className="section">
+            <div className="section-title">Header</div>
+            <div className="form-row">
+              <div className="form-group">
+                <label>PO Number</label>
+                <input
+                  className="form-input"
+                  value={editForm.po_number}
+                  disabled={EDIT_LOCKED_STATUSES.has(editing.status)}
+                  onChange={(e) => setEditForm({ ...editForm, po_number: e.target.value })}
+                />
+              </div>
+              <div className="form-group">
+                <label>Vendor</label>
+                <input
+                  className="form-input"
+                  value={editForm.vendor_name}
+                  disabled={EDIT_LOCKED_STATUSES.has(editing.status)}
+                  onChange={(e) => setEditForm({ ...editForm, vendor_name: e.target.value })}
+                />
+              </div>
+            </div>
+            <div className="form-row">
+              <div className="form-group">
+                <label>Expected Date</label>
+                <input
+                  className="form-input"
+                  type="date"
+                  value={editForm.expected_date}
+                  disabled={EDIT_LOCKED_STATUSES.has(editing.status)}
+                  onChange={(e) => setEditForm({ ...editForm, expected_date: e.target.value })}
+                />
+              </div>
+              <div className="form-group">
+                <label>Status</label>
+                <select
+                  className="form-select"
+                  value={editForm.status}
+                  onChange={(e) => setEditForm({ ...editForm, status: e.target.value })}
+                >
+                  {statusDropdownOptions(editing.status).map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="form-group">
+              <label>Notes</label>
+              <textarea
+                className="form-input"
+                rows={2}
+                value={editForm.notes}
+                disabled={EDIT_LOCKED_STATUSES.has(editing.status)}
+                onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
+              />
+            </div>
+            {EDIT_LOCKED_STATUSES.has(editing.status) && (
+              <p style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                Header + line edits are locked while the PO is {editing.status}.
+                Move the status off {editing.status} via the dropdown to resume editing.
+              </p>
+            )}
+          </section>
+
+          <section className="section">
+            <div className="section-title">Line Items</div>
+            {editLines.length > 0 ? (
+              <table className="lines-table">
+                <thead>
+                  <tr>
+                    <th>SKU</th>
+                    <th>Item Name</th>
+                    <th style={{ textAlign: 'right' }}>Ordered</th>
+                    <th style={{ textAlign: 'right' }}>Received</th>
+                    <th style={{ textAlign: 'right' }}>Variance</th>
+                    <th style={{ width: 40 }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {editLines.map((l) => {
+                    const variance = (l.quantity_ordered || 0) - (l.quantity_received || 0);
+                    const lineLocked = EDIT_LOCKED_STATUSES.has(editing.status);
+                    const removable = !lineLocked && (l.quantity_received || 0) === 0;
+                    return (
+                      <tr key={l.po_line_id}>
+                        <td className="mono">{l.sku}</td>
+                        <td style={{ color: 'var(--text-secondary)' }}>{l.item_name}</td>
+                        <td style={{ textAlign: 'right' }}>
+                          <LineQtyInput
+                            line={l}
+                            disabled={lineLocked}
+                            onCommit={updateLineQty}
+                          />
+                          {lineErrors[l.po_line_id] && (
+                            <div className="form-error" style={{ fontSize: 11, marginTop: 4, textAlign: 'right' }}>
+                              {lineErrors[l.po_line_id]}
+                            </div>
+                          )}
+                        </td>
+                        <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_received || 0}</td>
+                        <td className="mono" style={{ textAlign: 'right', color: variance > 0 ? 'var(--copper)' : 'var(--text-secondary)', fontWeight: variance > 0 ? 600 : 400 }}>
+                          {variance}
+                        </td>
+                        <td style={{ textAlign: 'right' }}>
+                          <button
+                            className="btn btn-sm btn-danger"
+                            onClick={() => removeLine(l)}
+                            disabled={!removable}
+                            title={!removable
+                              ? (lineLocked ? 'Locked while PO is ' + editing.status : 'Line has received units; reverse receipts first')
+                              : 'Remove line'}
+                            aria-label="Remove line"
+                          >&#10005;</button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            ) : (
+              <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>No line items yet.</p>
+            )}
+
+            {!EDIT_LOCKED_STATUSES.has(editing.status) && (
+              <div style={{
+                marginTop: 12, padding: 12,
+                background: 'var(--surface)',
+                borderRadius: 'var(--radius)',
+                display: 'flex', alignItems: 'flex-start', gap: 8,
+              }}>
+                <div style={{ flex: '0 0 200px' }}>
+                  <label style={{ fontSize: 11, color: 'var(--text-secondary)', fontWeight: 500 }}>SKU</label>
+                  <input
+                    className="form-input"
+                    placeholder="Enter SKU"
+                    value={newLineSku}
+                    onChange={(e) => setNewLineSku(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') addLine(); }}
+                  />
+                </div>
+                <div style={{ flex: '0 0 120px' }}>
+                  <label style={{ fontSize: 11, color: 'var(--text-secondary)', fontWeight: 500 }}>Quantity</label>
+                  <input
+                    className="form-input"
+                    type="number"
+                    min={1}
+                    placeholder="0"
+                    value={newLineQty}
+                    onChange={(e) => setNewLineQty(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') addLine(); }}
+                  />
+                </div>
+                <div style={{ flexGrow: 1 }} />
+                <button
+                  className="btn btn-primary"
+                  onClick={addLine}
+                  disabled={addingLine}
+                  style={{ marginTop: 16 }}
+                >
+                  {addingLine ? 'Adding...' : 'Add Line'}
+                </button>
+              </div>
+            )}
+            {newLineError && <div className="form-error" style={{ marginTop: 8 }}>{newLineError}</div>}
+          </section>
         </Modal>
       )}
     </div>
+  );
+}
+
+function LineQtyInput({ line, disabled, onCommit }) {
+  const [val, setVal] = useState(String(line.quantity_ordered));
+  const [saving, setSaving] = useState(false);
+
+  // Sync local state when the parent updates after a successful PATCH
+  // or after a refresh-from-server.
+  useEffect(() => {
+    setVal(String(line.quantity_ordered));
+  }, [line.quantity_ordered]);
+
+  async function commit() {
+    const n = parseInt(val, 10);
+    if (isNaN(n) || n <= 0 || n === line.quantity_ordered) {
+      setVal(String(line.quantity_ordered));
+      return;
+    }
+    setSaving(true);
+    await onCommit(line, n);
+    setSaving(false);
+  }
+
+  return (
+    <input
+      type="number"
+      min={1}
+      className="form-input mono"
+      style={{ width: 88, textAlign: 'right', padding: '4px 8px' }}
+      value={val}
+      disabled={disabled || saving}
+      onChange={(e) => setVal(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => { if (e.key === 'Enter') e.target.blur(); }}
+    />
   );
 }

--- a/admin/src/pages/PurchaseOrders.jsx
+++ b/admin/src/pages/PurchaseOrders.jsx
@@ -109,6 +109,42 @@ export default function PurchaseOrders() {
     }
   }
 
+  // Variance = ordered - received per line. Columns match the
+  // reconciliation report ops uses to chase short shipments with the
+  // vendor; receiving has the same five columns in the same order so
+  // an exported CSV slots directly into that workflow.
+  function exportPOCsv() {
+    if (!selectedPO || poLines.length === 0) return;
+    const csvEscape = (v) => {
+      if (v == null) return '';
+      const s = String(v);
+      return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    };
+    const headers = ['SKU', 'Item Name', 'Ordered', 'Received', 'Variance'];
+    const lines = [headers.join(',')];
+    for (const l of poLines) {
+      const ordered = l.quantity_ordered || 0;
+      const received = l.quantity_received || 0;
+      lines.push([
+        csvEscape(l.sku),
+        csvEscape(l.item_name),
+        csvEscape(ordered),
+        csvEscape(received),
+        csvEscape(ordered - received),
+      ].join(','));
+    }
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    const today = new Date().toISOString().split('T')[0];
+    link.download = `po_${selectedPO.po_number}_${today}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
   const columns = [
     { key: 'po_number', label: 'PO Number', mono: true },
     { key: 'vendor_name', label: 'Vendor' },
@@ -151,7 +187,12 @@ export default function PurchaseOrders() {
         <Modal
           title={`PO ${selectedPO.po_number}`}
           onClose={() => { setSelectedPO(null); setPOLines([]); }}
-          footer={<button className="btn" onClick={() => { setSelectedPO(null); setPOLines([]); }}>Close</button>}
+          footer={
+            <>
+              <button className="btn" onClick={exportPOCsv} disabled={poLines.length === 0}>Export CSV</button>
+              <button className="btn" onClick={() => { setSelectedPO(null); setPOLines([]); }}>Close</button>
+            </>
+          }
           size="wide"
         >
           <section className="section">

--- a/admin/src/pages/Receiving.jsx
+++ b/admin/src/pages/Receiving.jsx
@@ -5,11 +5,22 @@ import PageHeader from '../components/PageHeader.jsx';
 import StatusTag from '../components/StatusTag.jsx';
 import Modal from '../components/Modal.jsx';
 
+// /api/receiving/receive only accepts OPEN or PARTIAL POs. Mirror
+// that constraint in the UI so the operator never sees a 400 from
+// the server for a finished PO.
+const RECEIVABLE_PO_STATUSES = new Set(['OPEN', 'PARTIAL']);
+
 export default function Receiving() {
   const [pos, setPos] = useState([]);
   const [selected, setSelected] = useState(null);
   const [detail, setDetail] = useState(null);
   const [statusFilter, setStatusFilter] = useState('active');
+  // Bins scoped to the selected PO's warehouse; populated when a PO
+  // is opened. Receive form's bin dropdown reads from here.
+  const [warehouseBins, setWarehouseBins] = useState([]);
+  const [defaultBinId, setDefaultBinId] = useState(null);
+  // Per-line draft state: { [po_line_id]: { qty, bin_id, error, saving } }
+  const [lineDrafts, setLineDrafts] = useState({});
 
   useEffect(() => {
     loadPOs();
@@ -44,28 +55,102 @@ export default function Receiving() {
     setSelected(po);
     const id = po.po_id || po.id;
     const res = await api.get(`/admin/purchase-orders/${id}`);
+    if (!res?.ok) return;
+    const data = await res.json();
+    setDetail(data);
+
+    const warehouseId = data.purchase_order?.warehouse_id;
+    if (warehouseId) {
+      const binsRes = await api.get(
+        `/admin/bins?warehouse_id=${warehouseId}&per_page=500`,
+      );
+      if (binsRes?.ok) {
+        const bdata = await binsRes.json();
+        const bins = bdata.bins || [];
+        setWarehouseBins(bins);
+        // Default to the first Staging bin in the warehouse so the
+        // common receive-to-staging-then-putaway flow is one click.
+        // Fall back to the first bin overall if no Staging bins
+        // exist (small / unusual warehouse layouts).
+        const staging = bins.find((b) => b.bin_type === 'Staging');
+        const fallback = bins[0];
+        setDefaultBinId((staging || fallback)?.bin_id || null);
+      } else {
+        setWarehouseBins([]);
+        setDefaultBinId(null);
+      }
+    }
+    setLineDrafts({});
+  }
+
+  function closeDetail() {
+    setSelected(null);
+    setDetail(null);
+    setWarehouseBins([]);
+    setDefaultBinId(null);
+    setLineDrafts({});
+  }
+
+  async function refreshDetail() {
+    if (!detail?.purchase_order) return;
+    const res = await api.get(`/admin/purchase-orders/${detail.purchase_order.po_id}`);
     if (res?.ok) {
       setDetail(await res.json());
+    }
+  }
+
+  function updateDraft(lineId, patch) {
+    setLineDrafts((d) => ({
+      ...d,
+      [lineId]: { ...(d[lineId] || {}), ...patch },
+    }));
+  }
+
+  async function receiveLine(line) {
+    const draft = lineDrafts[line.po_line_id] || {};
+    const qty = parseInt(draft.qty, 10);
+    const binId = parseInt(draft.bin_id ?? defaultBinId, 10);
+    if (isNaN(qty) || qty <= 0) {
+      updateDraft(line.po_line_id, { error: 'Enter a positive quantity' });
+      return;
+    }
+    if (!binId) {
+      updateDraft(line.po_line_id, { error: 'Pick a bin' });
+      return;
+    }
+    updateDraft(line.po_line_id, { saving: true, error: '' });
+    const res = await api.post('/receiving/receive', {
+      po_id: detail.purchase_order.po_id,
+      items: [{ item_id: line.item_id, quantity: qty, bin_id: binId }],
+    });
+    if (res?.ok) {
+      // Clear this line's draft and pull the updated PO so the
+      // received counter + status reflect the change.
+      setLineDrafts((d) => {
+        const next = { ...d };
+        delete next[line.po_line_id];
+        return next;
+      });
+      await refreshDetail();
+      loadPOs();
+    } else {
+      const data = await res?.json();
+      updateDraft(line.po_line_id, {
+        saving: false,
+        error: data?.error || 'Failed to receive',
+      });
     }
   }
 
   const columns = [
     { key: 'po_number', label: 'PO Number', mono: true },
     { key: 'vendor_name', label: 'Vendor' },
-    { key: 'lines', label: 'Lines', render: (r) => r.lines?.length ?? '-' },
     { key: 'expected_date', label: 'Expected Date', mono: true, render: (r) => r.expected_date || '-' },
     { key: 'status', label: 'Status', render: (r) => <StatusTag status={r.status} /> },
   ];
 
-  const lineCols = [
-    { key: 'sku', label: 'SKU', mono: true },
-    { key: 'item_name', label: 'Item' },
-    { key: 'quantity_ordered', label: 'Ordered' },
-    { key: 'quantity_received', label: 'Received' },
-    { key: 'remaining', label: 'Remaining', render: (r) => (r.quantity_ordered || 0) - (r.quantity_received || 0) },
-  ];
-
-  const po = detail?.purchase_order || detail;
+  const po = detail?.purchase_order;
+  const canReceive = po && RECEIVABLE_PO_STATUSES.has(po.status);
 
   return (
     <div>
@@ -83,17 +168,124 @@ export default function Receiving() {
       <DataTable columns={columns} data={pos} onRowClick={viewPO} emptyMessage="No purchase orders" />
 
       {selected && detail && (
-        <Modal title={`PO ${po?.po_number || selected.po_number}`} onClose={() => { setSelected(null); setDetail(null); }}>
-          <div className="detail-grid">
-            <span className="detail-label">Vendor</span>
-            <span>{po?.vendor_name}</span>
-            <span className="detail-label">Status</span>
-            <span><StatusTag status={po?.status} /></span>
-            <span className="detail-label">Expected</span>
-            <span className="mono">{po?.expected_date || '-'}</span>
-          </div>
-          <div className="section-title">Lines</div>
-          <DataTable columns={lineCols} data={detail.lines || []} />
+        <Modal
+          title={`PO ${po?.po_number || selected.po_number}`}
+          onClose={closeDetail}
+          footer={<button className="btn" onClick={closeDetail}>Close</button>}
+          size="wide"
+        >
+          <section className="section">
+            <div className="section-title">PO Summary</div>
+            <div className="detail-grid detail-grid-2col" style={{ marginBottom: 0 }}>
+              <span className="detail-label">Vendor</span><span>{po?.vendor_name || '-'}</span>
+              <span className="detail-label">Status</span><span><StatusTag status={po?.status} /></span>
+              <span className="detail-label">Expected Date</span><span className="mono">{po?.expected_date || '-'}</span>
+              <span className="detail-label">Warehouse</span><span className="mono">{po?.warehouse_id ?? '-'}</span>
+            </div>
+          </section>
+
+          <section className="section" style={{ marginBottom: 0 }}>
+            <div className="section-title">Line Items</div>
+            {!canReceive && (
+              <p style={{
+                fontSize: 12, color: 'var(--text-secondary)',
+                marginBottom: 8, fontStyle: 'italic',
+              }}>
+                PO status is {po?.status}; receiving is disabled until the
+                PO is OPEN or PARTIAL.
+              </p>
+            )}
+            {(detail.lines || []).length > 0 ? (
+              <table className="lines-table">
+                <thead>
+                  <tr>
+                    <th>SKU</th>
+                    <th>Item</th>
+                    <th style={{ textAlign: 'right' }}>Ordered</th>
+                    <th style={{ textAlign: 'right' }}>Received</th>
+                    <th style={{ textAlign: 'right' }}>Remaining</th>
+                    {canReceive && (
+                      <>
+                        <th style={{ width: 90, textAlign: 'right' }}>Qty</th>
+                        <th style={{ width: 220 }}>Bin</th>
+                        <th style={{ width: 110 }}></th>
+                      </>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {(detail.lines || []).map((l) => {
+                    const remaining = (l.quantity_ordered || 0) - (l.quantity_received || 0);
+                    const draft = lineDrafts[l.po_line_id] || {};
+                    const lineReceivable = canReceive && remaining > 0;
+                    return (
+                      <tr key={l.po_line_id}>
+                        <td className="mono">{l.sku}</td>
+                        <td style={{ color: 'var(--text-secondary)' }}>{l.item_name}</td>
+                        <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_ordered}</td>
+                        <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_received}</td>
+                        <td className="mono" style={{
+                          textAlign: 'right',
+                          color: remaining > 0 ? 'var(--copper)' : 'var(--text-secondary)',
+                          fontWeight: remaining > 0 ? 600 : 400,
+                        }}>{remaining}</td>
+                        {canReceive && (
+                          <>
+                            <td style={{ textAlign: 'right' }}>
+                              <input
+                                type="number" min={1} max={remaining}
+                                className="form-input mono"
+                                style={{ width: 76, textAlign: 'right', padding: '4px 8px' }}
+                                value={draft.qty ?? ''}
+                                disabled={!lineReceivable || draft.saving}
+                                placeholder={lineReceivable ? '0' : ''}
+                                onChange={(e) => updateDraft(l.po_line_id, { qty: e.target.value })}
+                              />
+                            </td>
+                            <td>
+                              <select
+                                className="form-select"
+                                style={{ padding: '4px 8px' }}
+                                value={draft.bin_id ?? defaultBinId ?? ''}
+                                disabled={!lineReceivable || draft.saving}
+                                onChange={(e) => updateDraft(l.po_line_id, { bin_id: e.target.value })}
+                              >
+                                {warehouseBins.map((b) => (
+                                  <option key={b.bin_id} value={b.bin_id}>
+                                    {b.bin_code}{b.bin_type ? ` (${b.bin_type})` : ''}
+                                  </option>
+                                ))}
+                              </select>
+                            </td>
+                            <td style={{ textAlign: 'right' }}>
+                              <button
+                                className="btn btn-sm btn-primary"
+                                disabled={!lineReceivable || draft.saving}
+                                onClick={() => receiveLine(l)}
+                              >
+                                {draft.saving ? 'Receiving...' : 'Receive'}
+                              </button>
+                            </td>
+                          </>
+                        )}
+                      </tr>
+                    );
+                  })}
+                  {Object.entries(lineDrafts).filter(([, d]) => d.error).map(([lineId, d]) => (
+                    <tr key={`err-${lineId}`}>
+                      <td colSpan={canReceive ? 8 : 5}>
+                        <div className="form-error" style={{ fontSize: 12, padding: '4px 0' }}>
+                          Line {lineId}: {d.error}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>No line items</p>
+            )}
+          </section>
         </Modal>
       )}
     </div>

--- a/api/constants.py
+++ b/api/constants.py
@@ -9,6 +9,10 @@ PO_OPEN = "OPEN"
 PO_PARTIAL = "PARTIAL"
 PO_RECEIVED = "RECEIVED"
 PO_CLOSED = "CLOSED"
+# ARCHIVED: terminal status for POs the operator wants out of the
+# active list. Hidden from /admin/purchase-orders by default; only
+# reachable via the status dropdown when the PO is already CLOSED.
+PO_ARCHIVED = "ARCHIVED"
 
 # Purchase Order Line statuses
 POL_PENDING = "PENDING"
@@ -141,6 +145,17 @@ ACTION_WEBHOOK_SUBSCRIPTION_AUTO_PAUSE = "WEBHOOK_SUBSCRIPTION_AUTO_PAUSE"
 # 16-column row diff. PII-careful: only changed fields are recorded,
 # not the full address.
 ACTION_SO_ADDRESS_EDITED = "SO_ADDRESS_EDITED"
+
+# PO line edit + status surfaces. One audit row per mutation so the
+# historical record of what was ordered survives later edits. Status
+# transitions get their own action so the audit query "when did this
+# PO move from OPEN to RECEIVED" stays answerable. Line CRUD carries
+# {sku, quantity_ordered, quantity_received} in details so a deleted
+# line can still be reconstructed.
+ACTION_PO_STATUS_CHANGED = "PO_STATUS_CHANGED"
+ACTION_PO_LINE_ADDED = "PO_LINE_ADDED"
+ACTION_PO_LINE_UPDATED = "PO_LINE_UPDATED"
+ACTION_PO_LINE_REMOVED = "PO_LINE_REMOVED"
 
 # v1.8.0 (#290) transfer order lifecycle. Same audit shape as the
 # cycle count adjustment surface: one row per state transition;

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -9,10 +9,15 @@ from flask import g, jsonify, request
 from sqlalchemy import text
 
 from constants import (
-    PO_OPEN, PO_CLOSED, SO_OPEN, SO_PICKED, SO_PACKED, SO_SHIPPED, SO_CANCELLED,
+    PO_OPEN, PO_PARTIAL, PO_RECEIVED, PO_CLOSED, PO_ARCHIVED,
+    SO_OPEN, SO_PICKED, SO_PACKED, SO_SHIPPED, SO_CANCELLED,
     TASK_PENDING, ADJ_PENDING,
     COMPANY_TIMEZONE,
     ACTION_PICK,
+    ACTION_PO_STATUS_CHANGED,
+    ACTION_PO_LINE_ADDED,
+    ACTION_PO_LINE_UPDATED,
+    ACTION_PO_LINE_REMOVED,
     ACTION_SO_ADDRESS_EDITED,
     ACTION_SO_HEADER_EDITED,
     ACTION_SO_LINE_ADDED,
@@ -30,7 +35,12 @@ from middleware.auth_middleware import (
 )
 from middleware.db import with_db
 from routes.admin import admin_bp
-from schemas.purchase_orders import CreatePurchaseOrderRequest, UpdatePurchaseOrderRequest
+from schemas.purchase_orders import (
+    AddPOLineRequest,
+    CreatePurchaseOrderRequest,
+    UpdatePOLineRequest,
+    UpdatePurchaseOrderRequest,
+)
 from schemas.sales_orders import (
     ADDRESS_FIELD_NAMES,
     AddSalesOrderLineRequest,
@@ -69,9 +79,16 @@ def list_purchase_orders():
     status = request.args.get("status")
     warehouse_id = request.args.get("warehouse_id", type=int)
     search = (request.args.get("q") or "").strip()
+    # ARCHIVED is hidden by default so the active list stays focused
+    # on POs that still need work. Caller opts in by passing
+    # include_archived=true OR by setting status=ARCHIVED explicitly.
+    include_archived = request.args.get("include_archived", "false").lower() == "true"
     if status:
         where_clauses.append("status = :status")
         params["status"] = status
+    elif not include_archived:
+        where_clauses.append("status <> :archived")
+        params["archived"] = PO_ARCHIVED
     if warehouse_id:
         where_clauses.append("warehouse_id = :wid")
         params["wid"] = warehouse_id
@@ -200,6 +217,10 @@ def create_purchase_order(validated):
     return response
 
 
+PO_STATUS_VALUES = {PO_OPEN, PO_PARTIAL, PO_RECEIVED, PO_CLOSED, PO_ARCHIVED}
+PO_EDIT_BLOCKED_STATUSES = {PO_CLOSED, PO_ARCHIVED}
+
+
 @admin_bp.route("/purchase-orders/<int:po_id>", methods=["PUT"])
 @require_auth
 @require_admin_or_page_permission("purchase-orders")
@@ -208,23 +229,63 @@ def create_purchase_order(validated):
 def update_purchase_order(po_id, validated):
     data = validated.model_dump(exclude_unset=True)
 
-    po = g.db.execute(text("SELECT po_id, status FROM purchase_orders WHERE po_id = :pid"), {"pid": po_id}).fetchone()
+    po = g.db.execute(
+        text("SELECT po_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
+        {"pid": po_id},
+    ).fetchone()
     if not po:
         return jsonify({"error": "Purchase order not found"}), 404
-    if po.status != PO_OPEN:
-        return jsonify({"error": f"Can only update POs with OPEN status. Current: {po.status}"}), 400
 
-    ALLOWED_FIELDS = {"po_number", "po_barcode", "vendor_name", "expected_date", "notes"}
-    fields, params = [], {"pid": po_id}
-    for col in ALLOWED_FIELDS:
-        if col in data:
-            fields.append(f"{col} = :{col}")
-            params[col] = data[col]
+    new_status = data.get("status")
+    if new_status is not None:
+        if new_status not in PO_STATUS_VALUES:
+            return jsonify({"error": f"Invalid status: {new_status}"}), 400
+        # ARCHIVED is reachable only from CLOSED so an active PO cannot
+        # be hidden by a single dropdown change. All other transitions
+        # (including ARCHIVED -> any other) are allowed; admins use the
+        # dropdown to un-archive when needed.
+        if new_status == PO_ARCHIVED and po.status != PO_CLOSED:
+            return jsonify({
+                "error": "PO must be CLOSED before it can be ARCHIVED",
+            }), 400
 
-    if not fields:
+    HEADER_FIELDS = {"po_number", "po_barcode", "vendor_name", "expected_date", "notes"}
+    header_data = {k: v for k, v in data.items() if k in HEADER_FIELDS}
+    # Header edits are blocked when the PO is locked (CLOSED or
+    # ARCHIVED). The status field itself is still editable so an admin
+    # can transition out of CLOSED before resuming line work.
+    if header_data and po.status in PO_EDIT_BLOCKED_STATUSES:
+        return jsonify({
+            "error": f"Header edits are not allowed while the PO is {po.status}",
+        }), 400
+
+    set_fragments, params = [], {"pid": po_id}
+    for col, val in header_data.items():
+        set_fragments.append(f"{col} = :{col}")
+        params[col] = val
+    if new_status is not None and new_status != po.status:
+        set_fragments.append("status = :status")
+        params["status"] = new_status
+
+    if not set_fragments:
         return jsonify({"error": "No valid fields provided"}), 400
 
-    g.db.execute(text(f"UPDATE purchase_orders SET {', '.join(fields)} WHERE po_id = :pid"), params)
+    g.db.execute(
+        text(f"UPDATE purchase_orders SET {', '.join(set_fragments)} WHERE po_id = :pid"),
+        params,
+    )
+
+    if new_status is not None and new_status != po.status:
+        write_audit_log(
+            g.db,
+            ACTION_PO_STATUS_CHANGED,
+            "PO",
+            po_id,
+            g.current_user["user_id"],
+            po.warehouse_id,
+            details={"old_status": po.status, "new_status": new_status},
+        )
+
     g.db.commit()
 
     row = g.db.execute(
@@ -238,6 +299,219 @@ def update_purchase_order(po_id, validated):
         "warehouse_id": row.warehouse_id, "notes": row.notes,
         "created_at": row.created_at.isoformat() if row.created_at else None,
     })
+
+
+# ── Purchase Order Lines (add / update / remove) ─────────────────────────────
+
+@admin_bp.route("/purchase-orders/<int:po_id>/lines", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("purchase-orders")
+@validate_body(AddPOLineRequest)
+@with_db
+def add_purchase_order_line(po_id, validated):
+    data = validated.model_dump()
+
+    po = g.db.execute(
+        text("SELECT po_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
+        {"pid": po_id},
+    ).fetchone()
+    if not po:
+        return jsonify({"error": "Purchase order not found"}), 404
+    if po.status in PO_EDIT_BLOCKED_STATUSES:
+        return jsonify({
+            "error": f"Cannot add lines while the PO is {po.status}",
+        }), 400
+
+    item = g.db.execute(
+        text("SELECT item_id, sku FROM items WHERE item_id = :iid"),
+        {"iid": data["item_id"]},
+    ).fetchone()
+    if not item:
+        return jsonify({"error": f"Item {data['item_id']} not found"}), 400
+
+    # Reject duplicate items on the same PO; the receive endpoint
+    # already does LIMIT 1 against (po_id, item_id) and would not be
+    # able to disambiguate two lines with the same item_id.
+    dup = g.db.execute(
+        text("SELECT 1 FROM purchase_order_lines WHERE po_id = :pid AND item_id = :iid"),
+        {"pid": po_id, "iid": data["item_id"]},
+    ).fetchone()
+    if dup:
+        return jsonify({"error": f"Item {item.sku} is already on this PO"}), 400
+
+    next_ln = g.db.execute(
+        text("SELECT COALESCE(MAX(line_number), 0) + 1 FROM purchase_order_lines WHERE po_id = :pid"),
+        {"pid": po_id},
+    ).scalar()
+
+    result = g.db.execute(
+        text(
+            """
+            INSERT INTO purchase_order_lines
+                (po_id, item_id, quantity_ordered, unit_cost, line_number)
+            VALUES (:pid, :iid, :qty, :cost, :ln)
+            RETURNING po_line_id
+            """
+        ),
+        {
+            "pid": po_id, "iid": data["item_id"],
+            "qty": data["quantity_ordered"],
+            "cost": float(data["unit_cost"]) if data.get("unit_cost") is not None else None,
+            "ln": next_ln,
+        },
+    )
+    po_line_id = result.fetchone()[0]
+
+    write_audit_log(
+        g.db,
+        ACTION_PO_LINE_ADDED,
+        "PO_LINE",
+        po_line_id,
+        g.current_user["user_id"],
+        po.warehouse_id,
+        details={
+            "po_id": po_id, "sku": item.sku,
+            "quantity_ordered": data["quantity_ordered"],
+        },
+    )
+    g.db.commit()
+
+    return jsonify({
+        "po_line_id": po_line_id,
+        "po_id": po_id,
+        "item_id": data["item_id"],
+        "sku": item.sku,
+        "quantity_ordered": data["quantity_ordered"],
+        "quantity_received": 0,
+        "line_number": next_ln,
+    }), 201
+
+
+@admin_bp.route("/purchase-orders/<int:po_id>/lines/<int:po_line_id>", methods=["PATCH"])
+@require_auth
+@require_admin_or_page_permission("purchase-orders")
+@validate_body(UpdatePOLineRequest)
+@with_db
+def update_purchase_order_line(po_id, po_line_id, validated):
+    data = validated.model_dump()
+
+    po = g.db.execute(
+        text("SELECT po_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
+        {"pid": po_id},
+    ).fetchone()
+    if not po:
+        return jsonify({"error": "Purchase order not found"}), 404
+    if po.status in PO_EDIT_BLOCKED_STATUSES:
+        return jsonify({
+            "error": f"Cannot edit lines while the PO is {po.status}",
+        }), 400
+
+    line = g.db.execute(
+        text(
+            """
+            SELECT pol.po_line_id, pol.quantity_ordered, pol.quantity_received, i.sku
+            FROM purchase_order_lines pol JOIN items i ON i.item_id = pol.item_id
+            WHERE pol.po_line_id = :plid AND pol.po_id = :pid
+            """
+        ),
+        {"plid": po_line_id, "pid": po_id},
+    ).fetchone()
+    if not line:
+        return jsonify({"error": "Line not found"}), 404
+
+    new_qty = data["quantity_ordered"]
+    # Blocking ordered<received keeps variance non-negative. The
+    # operator either reverses receipts first or leaves the line as-is.
+    if new_qty < line.quantity_received:
+        return jsonify({
+            "error": (
+                f"quantity_ordered ({new_qty}) cannot be less than "
+                f"quantity_received ({line.quantity_received})"
+            ),
+        }), 400
+
+    g.db.execute(
+        text("UPDATE purchase_order_lines SET quantity_ordered = :qty WHERE po_line_id = :plid"),
+        {"qty": new_qty, "plid": po_line_id},
+    )
+
+    write_audit_log(
+        g.db,
+        ACTION_PO_LINE_UPDATED,
+        "PO_LINE",
+        po_line_id,
+        g.current_user["user_id"],
+        po.warehouse_id,
+        details={
+            "po_id": po_id, "sku": line.sku,
+            "old_quantity_ordered": line.quantity_ordered,
+            "new_quantity_ordered": new_qty,
+        },
+    )
+    g.db.commit()
+    return jsonify({"po_line_id": po_line_id, "quantity_ordered": new_qty})
+
+
+@admin_bp.route("/purchase-orders/<int:po_id>/lines/<int:po_line_id>", methods=["DELETE"])
+@require_auth
+@require_admin_or_page_permission("purchase-orders")
+@with_db
+def delete_purchase_order_line(po_id, po_line_id):
+    po = g.db.execute(
+        text("SELECT po_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
+        {"pid": po_id},
+    ).fetchone()
+    if not po:
+        return jsonify({"error": "Purchase order not found"}), 404
+    if po.status in PO_EDIT_BLOCKED_STATUSES:
+        return jsonify({
+            "error": f"Cannot remove lines while the PO is {po.status}",
+        }), 400
+
+    line = g.db.execute(
+        text(
+            """
+            SELECT pol.po_line_id, pol.quantity_ordered, pol.quantity_received, i.sku
+            FROM purchase_order_lines pol JOIN items i ON i.item_id = pol.item_id
+            WHERE pol.po_line_id = :plid AND pol.po_id = :pid
+            """
+        ),
+        {"plid": po_line_id, "pid": po_id},
+    ).fetchone()
+    if not line:
+        return jsonify({"error": "Line not found"}), 404
+
+    # Blocking removal of lines with received qty preserves inventory
+    # history. To remove, operator first reverses receipts via a
+    # separate workflow; the soft-close-by-setting-qty-equal-to-
+    # received path is intentionally not exposed here.
+    if line.quantity_received > 0:
+        return jsonify({
+            "error": (
+                f"Line has {line.quantity_received} received units; "
+                "remove the receipts before deleting the line"
+            ),
+        }), 400
+
+    g.db.execute(
+        text("DELETE FROM purchase_order_lines WHERE po_line_id = :plid"),
+        {"plid": po_line_id},
+    )
+
+    write_audit_log(
+        g.db,
+        ACTION_PO_LINE_REMOVED,
+        "PO_LINE",
+        po_line_id,
+        g.current_user["user_id"],
+        po.warehouse_id,
+        details={
+            "po_id": po_id, "sku": line.sku,
+            "quantity_ordered": line.quantity_ordered,
+        },
+    )
+    g.db.commit()
+    return jsonify({"po_line_id": po_line_id, "deleted": True})
 
 
 @admin_bp.route("/purchase-orders/<int:po_id>/close", methods=["POST"])

--- a/api/schemas/purchase_orders.py
+++ b/api/schemas/purchase_orders.py
@@ -29,3 +29,17 @@ class UpdatePurchaseOrderRequest(BaseModel):
     vendor_name: Optional[str] = Field(None, max_length=256)
     expected_date: Optional[str] = Field(None, max_length=32)
     notes: Optional[str] = Field(None, max_length=1000)
+    # status: optional dropdown change. Allowed values validated in
+    # the route so the schema does not have to know the lifecycle
+    # rules (e.g. ARCHIVED only reachable from CLOSED).
+    status: Optional[str] = Field(None, max_length=20)
+
+
+class AddPOLineRequest(BaseModel):
+    item_id: int = Field(..., gt=0)
+    quantity_ordered: int = Field(..., gt=0, le=1000000)
+    unit_cost: Optional[Decimal] = Field(None, ge=0)
+
+
+class UpdatePOLineRequest(BaseModel):
+    quantity_ordered: int = Field(..., gt=0, le=1000000)

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -328,11 +328,265 @@ class TestPurchaseOrders:
         assert resp.status_code == 200
         assert resp.get_json()["vendor_name"] == "Updated Vendor"
 
-    def test_update_purchase_order_not_open(self, client, auth_headers):
-        # Close the PO first
+    def test_update_purchase_order_blocked_when_closed(self, client, auth_headers):
+        # Closing the PO blocks header edits. The status field is the
+        # one path that still works (so an admin can re-open via the
+        # dropdown); plain header edits return 400.
         client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)
         resp = client.put("/api/admin/purchase-orders/1", json={"vendor_name": "Fail"}, headers=auth_headers)
         assert resp.status_code == 400
+
+
+class TestPurchaseOrderStatusChange:
+    """PUT /admin/purchase-orders/<id> with a status field reaches the
+    state machine: anywhere -> anywhere except CLOSED -> ARCHIVED is
+    the only direct path to ARCHIVED."""
+
+    def test_status_change_open_to_partial(self, client, auth_headers):
+        resp = client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "PARTIAL"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "PARTIAL"
+
+    def test_status_change_unblocks_closed_for_header_edits(self, client, auth_headers):
+        # Close, then reopen via the dropdown, then header edit lands.
+        client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)
+        reopen = client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "OPEN"},
+            headers=auth_headers,
+        )
+        assert reopen.status_code == 200
+        assert reopen.get_json()["status"] == "OPEN"
+        resp = client.put(
+            "/api/admin/purchase-orders/1",
+            json={"vendor_name": "Reopened Vendor"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["vendor_name"] == "Reopened Vendor"
+
+    def test_archive_requires_closed_first(self, client, auth_headers):
+        resp = client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "ARCHIVED"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "CLOSED" in resp.get_json()["error"]
+
+    def test_archive_after_close_succeeds(self, client, auth_headers):
+        client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)
+        resp = client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "ARCHIVED"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "ARCHIVED"
+
+    def test_unarchive_from_archived_is_allowed(self, client, auth_headers):
+        # ARCHIVED is not terminal; a status dropdown change can move
+        # the PO back to any other status so an admin can resume work.
+        client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)
+        client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "ARCHIVED"},
+            headers=auth_headers,
+        )
+        resp = client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "OPEN"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "OPEN"
+
+    def test_invalid_status_rejected(self, client, auth_headers):
+        resp = client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "BOGUS"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+
+class TestPurchaseOrderArchivedFiltering:
+    """ARCHIVED POs drop out of the default list view and resurface
+    via include_archived=true or an explicit status=ARCHIVED filter."""
+
+    def test_archived_hidden_by_default(self, client, auth_headers):
+        client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)
+        client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "ARCHIVED"},
+            headers=auth_headers,
+        )
+        resp = client.get("/api/admin/purchase-orders", headers=auth_headers)
+        po_ids = [po["po_id"] for po in resp.get_json()["purchase_orders"]]
+        assert 1 not in po_ids
+
+    def test_archived_visible_with_include_archived(self, client, auth_headers):
+        client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)
+        client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "ARCHIVED"},
+            headers=auth_headers,
+        )
+        resp = client.get(
+            "/api/admin/purchase-orders?include_archived=true",
+            headers=auth_headers,
+        )
+        po_ids = [po["po_id"] for po in resp.get_json()["purchase_orders"]]
+        assert 1 in po_ids
+
+    def test_status_archived_filter_returns_archived(self, client, auth_headers):
+        client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)
+        client.put(
+            "/api/admin/purchase-orders/1",
+            json={"status": "ARCHIVED"},
+            headers=auth_headers,
+        )
+        resp = client.get(
+            "/api/admin/purchase-orders?status=ARCHIVED",
+            headers=auth_headers,
+        )
+        data = resp.get_json()
+        assert all(po["status"] == "ARCHIVED" for po in data["purchase_orders"])
+        assert any(po["po_id"] == 1 for po in data["purchase_orders"])
+
+
+class TestPurchaseOrderLineCRUD:
+    """POST / PATCH / DELETE on /admin/purchase-orders/<po_id>/lines."""
+
+    def test_add_line_succeeds(self, client, auth_headers):
+        # Item 11 (TST-011) is not on PO 1 in the seed.
+        resp = client.post(
+            "/api/admin/purchase-orders/1/lines",
+            json={"item_id": 11, "quantity_ordered": 25},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["quantity_ordered"] == 25
+        assert data["quantity_received"] == 0
+        assert data["sku"] == "TST-011"
+
+    def test_add_duplicate_line_rejected(self, client, auth_headers):
+        # PO 1 already has item 1 on it in the seed.
+        resp = client.post(
+            "/api/admin/purchase-orders/1/lines",
+            json={"item_id": 1, "quantity_ordered": 5},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "already on this PO" in resp.get_json()["error"]
+
+    def test_add_line_rejects_unknown_item(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/purchase-orders/1/lines",
+            json={"item_id": 9999, "quantity_ordered": 5},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_add_line_blocked_when_closed(self, client, auth_headers):
+        client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)
+        resp = client.post(
+            "/api/admin/purchase-orders/1/lines",
+            json={"item_id": 11, "quantity_ordered": 5},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "CLOSED" in resp.get_json()["error"]
+
+    def test_update_line_quantity(self, client, auth_headers):
+        # PO 1 line 1 has quantity_ordered = 100 in seed; raise to 150.
+        detail = client.get("/api/admin/purchase-orders/1", headers=auth_headers).get_json()
+        po_line_id = detail["lines"][0]["po_line_id"]
+        resp = client.patch(
+            f"/api/admin/purchase-orders/1/lines/{po_line_id}",
+            json={"quantity_ordered": 150},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["quantity_ordered"] == 150
+
+    def test_update_line_rejects_qty_below_received(self, client, auth_headers):
+        # Receive part of line 1 first, then try to drop ordered below
+        # received and confirm the guard fires.
+        detail = client.get("/api/admin/purchase-orders/1", headers=auth_headers).get_json()
+        po_line = detail["lines"][0]
+        client.post(
+            "/api/receiving/receive",
+            json={
+                "po_id": 1,
+                "items": [{
+                    "item_id": po_line["item_id"],
+                    "quantity": 10,
+                    "bin_id": 1,
+                }],
+            },
+            headers=auth_headers,
+        )
+        resp = client.patch(
+            f"/api/admin/purchase-orders/1/lines/{po_line['po_line_id']}",
+            json={"quantity_ordered": 5},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "less than" in resp.get_json()["error"]
+
+    def test_remove_line_succeeds_when_no_receipts(self, client, auth_headers):
+        # Add a fresh line, then remove it without receiving against it.
+        add = client.post(
+            "/api/admin/purchase-orders/1/lines",
+            json={"item_id": 11, "quantity_ordered": 10},
+            headers=auth_headers,
+        )
+        po_line_id = add.get_json()["po_line_id"]
+        resp = client.delete(
+            f"/api/admin/purchase-orders/1/lines/{po_line_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["deleted"] is True
+
+    def test_remove_line_blocked_when_received(self, client, auth_headers):
+        detail = client.get("/api/admin/purchase-orders/1", headers=auth_headers).get_json()
+        po_line = detail["lines"][0]
+        client.post(
+            "/api/receiving/receive",
+            json={
+                "po_id": 1,
+                "items": [{
+                    "item_id": po_line["item_id"],
+                    "quantity": 5,
+                    "bin_id": 1,
+                }],
+            },
+            headers=auth_headers,
+        )
+        resp = client.delete(
+            f"/api/admin/purchase-orders/1/lines/{po_line['po_line_id']}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "received units" in resp.get_json()["error"]
+
+    def test_remove_line_blocked_when_closed(self, client, auth_headers):
+        detail = client.get("/api/admin/purchase-orders/1", headers=auth_headers).get_json()
+        po_line_id = detail["lines"][-1]["po_line_id"]
+        client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)
+        resp = client.delete(
+            f"/api/admin/purchase-orders/1/lines/{po_line_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "CLOSED" in resp.get_json()["error"]
 
     def test_close_purchase_order(self, client, auth_headers):
         resp = client.post("/api/admin/purchase-orders/1/close", headers=auth_headers)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -128,7 +128,7 @@ CREATE TABLE purchase_orders (
     po_barcode VARCHAR(100),               -- scannable PO barcode
     vendor_name VARCHAR(200),
     vendor_id VARCHAR(50),
-    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PARTIAL', 'RECEIVED', 'CLOSED'
+    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PARTIAL', 'RECEIVED', 'CLOSED', 'ARCHIVED'
     expected_date DATE,
     warehouse_id INT NOT NULL REFERENCES warehouses(warehouse_id),
     notes TEXT,


### PR DESCRIPTION
Re-establishes purchase-order management on the web admin: editable
line items, a status lifecycle, CSV export, and inline receiving.

- Backend: a new ARCHIVED status (hidden from the active list by
  default), PUT status transitions with the ARCHIVED-from-CLOSED gate
  and un-archive, and POST/PATCH/DELETE line endpoints with
  duplicate-item rejection, a qty-below-received guard, and a
  received-units removal block. One audit row per mutation.
- PO Edit modal: a status dropdown replaces the Close/Reopen buttons,
  editable line quantities commit per line, a Remove button per line,
  and an Add Line row with a debounced SKU typeahead, live resolution
  preview, and inline errors. Header fields lock while CLOSED/ARCHIVED.
- Validation errors surface field-level detail and pin to a sticky
  banner at the top of the modal.
- PO detail exports to CSV (SKU, Name, Ordered, Received, Variance).
- Receiving page gains an inline per-line receive control (qty + bin,
  defaulting to the first Staging bin) against the existing
  /receiving/receive endpoint, refetching the PO on success.

Stacked on the admin data-consolidation branch (#374).