### PR TITLE
feat(admin): POS Activity dashboard behind a settings toggle

### DIFF
--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -35,6 +35,7 @@ import Integrations from './pages/Integrations.jsx';
 import Adjustments from './pages/Adjustments.jsx';
 import InterWarehouseTransfers from './pages/InterWarehouseTransfers.jsx';
 import TransferOrders from './pages/TransferOrders.jsx';
+import POSActivity from './pages/POSActivity.jsx';
 
 function ProtectedRoute({ children }) {
   const { user, loading } = useAuth();
@@ -93,6 +94,7 @@ export default function App() {
         <Route path="/purchase-orders" element={<ErrorBoundary fallbackMessage="Could not load purchase orders."><PurchaseOrders /></ErrorBoundary>} />
         <Route path="/putaway" element={<ErrorBoundary fallbackMessage="Could not load put-away."><PutAway /></ErrorBoundary>} />
         <Route path="/sales-orders" element={<ErrorBoundary fallbackMessage="Could not load sales orders."><SalesOrders /></ErrorBoundary>} />
+        <Route path="/pos-activity" element={<ErrorBoundary fallbackMessage="Could not load POS activity."><POSActivity /></ErrorBoundary>} />
         <Route path="/picking-tickets" element={<ErrorBoundary fallbackMessage="Could not load picking tickets."><PickingTickets /></ErrorBoundary>} />
         {/* The /picking, /packing, /shipping admin pages were retired:
             the workflow lives on the handheld scanners, and the

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -32,6 +32,7 @@ const NAV = [
     label: 'Outbound',
     items: [
       { to: '/sales-orders', label: 'Sales Orders', pageKey: 'sales-orders' },
+      { to: '/pos-activity', label: 'POS Activity' },
       { to: '/picking-tickets', label: 'Picking Tickets', pageKey: 'picking-tickets' },
       // Picking/Packing/Shipping are mobile-only: the admin-side
       // mirrors were retired. Supervisors use Sales Orders + Picking

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -75,6 +75,25 @@ export default function Sidebar() {
   const { user } = useAuth();
   const { warehouseId } = useWarehouse();
   const [counts, setCounts] = useState({});
+  // The POS Activity tab is opt-in via the pos_activity_enabled setting
+  // so non-POS deployments never see it. Default false: the entry is
+  // hidden until an operator turns it on in Settings > POS. Silent on
+  // permission denial so a USER without the settings grant just gets
+  // the default (hidden) rather than a Permissions Error popup.
+  const [posActivityEnabled, setPosActivityEnabled] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.get(
+      '/admin/settings/pos_activity_enabled',
+      { silentPermissionDenied: true },
+    ).then(async (res) => {
+      if (!res?.ok || cancelled) return;
+      const data = await res.json();
+      setPosActivityEnabled(data?.value === 'true');
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     if (!warehouseId) return;
@@ -103,7 +122,12 @@ export default function Sidebar() {
     });
   }, [location.pathname, warehouseId]);
 
-  const navGroups = NAV;
+  const navGroups = posActivityEnabled
+    ? NAV
+    : NAV.map((group) => ({
+        ...group,
+        items: group.items.filter((item) => item.to !== '/pos-activity'),
+      }));
 
   return (
     <nav className="sidebar">

--- a/admin/src/pages/Adjustments.jsx
+++ b/admin/src/pages/Adjustments.jsx
@@ -5,8 +5,14 @@ import PageHeader from '../components/PageHeader.jsx';
 
 export default function Adjustments() {
   const { warehouseId } = useWarehouse();
-  const [bins, setBins] = useState([]);
-  const [items, setItems] = useState([]);
+  // Bin + item lookups switched from
+  // "load every row client-side and filter in JS" to debounced
+  // server-side search. The old loadBins() defaulted to per_page=50
+  // so a 3000-bin warehouse only showed the first batch; loadItems()
+  // capped at 1000 which broke at 30K SKUs in production. Both now
+  // hit the server's ILIKE :q index path on each keystroke.
+  const [binResults, setBinResults] = useState([]);
+  const [itemResults, setItemResults] = useState([]);
   const [adjustments, setAdjustments] = useState([]);
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -15,8 +21,10 @@ export default function Adjustments() {
 
   const [binSearch, setBinSearch] = useState('');
   const [binOpen, setBinOpen] = useState(false);
+  const [binSearching, setBinSearching] = useState(false);
   const [itemSearch, setItemSearch] = useState('');
   const [itemOpen, setItemOpen] = useState(false);
+  const [itemSearching, setItemSearching] = useState(false);
   const binRef = useRef(null);
   const itemRef = useRef(null);
 
@@ -39,26 +47,59 @@ export default function Adjustments() {
   }, []);
 
   useEffect(() => {
-    loadBins();
-    loadItems();
     loadAdjustments();
-  }, [warehouseId]);
+    // Clear selections when the warehouse switches so the operator
+    // does not accidentally apply an adjustment to a bin in a
+    // warehouse they no longer have on screen.
+    setForm((p) => ({ ...p, bin_id: '', item_id: '' }));
+    setBinSearch('');
+    setItemSearch('');
+    setBinResults([]);
+    setItemResults([]);
+  }, [warehouseId]);  // eslint-disable-line react-hooks/exhaustive-deps
 
-  async function loadBins() {
-    const res = await api.get(`/admin/bins?warehouse_id=${warehouseId}`);
-    if (res?.ok) {
-      const data = await res.json();
-      setBins(data.bins || []);
+  // Debounced bin search. Triggers when the operator types in the
+  // bin field; ignores empty / one-char queries to avoid round-tripping
+  // on every focus. 200 ms matches the PO line typeahead.
+  useEffect(() => {
+    const q = binSearch.trim();
+    if (!warehouseId || q.length < 1 || form.bin_id) {
+      setBinResults([]);
+      return;
     }
-  }
+    setBinSearching(true);
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/bins?warehouse_id=${warehouseId}&q=${encodeURIComponent(q)}&per_page=25`,
+      );
+      setBinSearching(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setBinResults(data.bins || []);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [binSearch, warehouseId, form.bin_id]);
 
-  async function loadItems() {
-    const res = await api.get(`/admin/items?warehouse_id=${warehouseId}&per_page=1000`);
-    if (res?.ok) {
-      const data = await res.json();
-      setItems(data.items || []);
+  // Same shape for items. Three-char minimum keeps the 30K-SKU
+  // catalog from returning huge result sets on a two-letter prefix.
+  useEffect(() => {
+    const q = itemSearch.trim();
+    if (q.length < 2 || form.item_id) {
+      setItemResults([]);
+      return;
     }
-  }
+    setItemSearching(true);
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/items?q=${encodeURIComponent(q)}&per_page=25&active=true`,
+      );
+      setItemSearching(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setItemResults(data.items || []);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [itemSearch, form.item_id]);
 
   async function loadAdjustments() {
     setLoading(true);
@@ -85,15 +126,6 @@ export default function Adjustments() {
     setItemSearch(`${item.sku}  -  ${item.item_name}`);
     setItemOpen(false);
   }
-
-  const filteredBins = bins.filter((b) =>
-    b.bin_code.toLowerCase().includes(binSearch.toLowerCase())
-  );
-
-  const filteredItems = items.filter((i) => {
-    const q = itemSearch.toLowerCase();
-    return i.sku.toLowerCase().includes(q) || (i.item_name || '').toLowerCase().includes(q);
-  });
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -165,43 +197,53 @@ export default function Adjustments() {
         <form onSubmit={handleSubmit}>
           <div className="form-row">
             <div className="form-group" ref={binRef} style={{ position: 'relative' }}>
-              <label>Bin</label>
+              <label>Bin {binSearching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
               <input
-                className="form-input"
-                placeholder="Search bins..."
+                className="form-input mono"
+                placeholder="Type bin code to search"
                 value={binSearch}
                 onChange={(e) => { setBinSearch(e.target.value); updateForm('bin_id', ''); setBinOpen(true); }}
                 onFocus={() => setBinOpen(true)}
                 autoComplete="off"
               />
-              {binOpen && filteredBins.length > 0 && (
+              {binOpen && binResults.length > 0 && (
                 <div style={dropdownStyle}>
-                  {filteredBins.slice(0, 50).map((b) => (
+                  {binResults.map((b) => (
                     <div key={b.bin_id} style={dropdownItemStyle} onMouseDown={() => selectBin(b)}>
-                      {b.bin_code} {b.bin_type ? `(${b.bin_type})` : ''}
+                      <span className="mono">{b.bin_code}</span> {b.bin_type ? `(${b.bin_type})` : ''}
                     </div>
                   ))}
+                </div>
+              )}
+              {binOpen && !binSearching && binSearch.trim().length >= 1 && !form.bin_id && binResults.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No bins match "{binSearch.trim()}" in this warehouse.
                 </div>
               )}
             </div>
 
             <div className="form-group" ref={itemRef} style={{ position: 'relative' }}>
-              <label>Item</label>
+              <label>Item {itemSearching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
               <input
                 className="form-input"
-                placeholder="Search SKU or name..."
+                placeholder="Type SKU or item name (min 2 chars)"
                 value={itemSearch}
                 onChange={(e) => { setItemSearch(e.target.value); updateForm('item_id', ''); setItemOpen(true); }}
                 onFocus={() => setItemOpen(true)}
                 autoComplete="off"
               />
-              {itemOpen && filteredItems.length > 0 && (
+              {itemOpen && itemResults.length > 0 && (
                 <div style={dropdownStyle}>
-                  {filteredItems.slice(0, 50).map((i) => (
+                  {itemResults.map((i) => (
                     <div key={i.item_id} style={dropdownItemStyle} onMouseDown={() => selectItem(i)}>
-                      <strong>{i.sku}</strong>  -  {i.item_name}
+                      <strong className="mono">{i.sku}</strong>  -  {i.item_name}
                     </div>
                   ))}
+                </div>
+              )}
+              {itemOpen && !itemSearching && itemSearch.trim().length >= 2 && !form.item_id && itemResults.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No items match "{itemSearch.trim()}".
                 </div>
               )}
             </div>

--- a/admin/src/pages/Bins.jsx
+++ b/admin/src/pages/Bins.jsx
@@ -13,6 +13,8 @@ export default function Bins() {
   const [searchParams] = useSearchParams();
   const [search, setSearch] = useState(searchParams.get('q') || '');
   const [bins, setBins] = useState([]);
+  const [pagination, setPagination] = useState(null);
+  const [page, setPage] = useState(1);
   const [zones, setZones] = useState([]);
   const [selected, setSelected] = useState(null);
   const [detail, setDetail] = useState(null);
@@ -21,16 +23,76 @@ export default function Bins() {
   const [form, setForm] = useState({});
   const [error, setError] = useState('');
   const [deleteTarget, setDeleteTarget] = useState(null);
+  const [exporting, setExporting] = useState(false);
 
-  useEffect(() => { if (warehouseId) { loadBins(); loadZones(); } }, [warehouseId, search]);  // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { if (warehouseId) { loadBins(); loadZones(); } }, [warehouseId, search, page]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   async function loadBins() {
-    const params = new URLSearchParams({ warehouse_id: String(warehouseId) });
+    const params = new URLSearchParams({ warehouse_id: String(warehouseId), page, per_page: 50 });
     if (search) params.set('q', search);
     const res = await api.get(`/admin/bins?${params}`);
     if (res?.ok) {
       const data = await res.json();
       setBins(data.bins || []);
+      setPagination({ page: data.page, pages: data.pages, total: data.total, per_page: data.per_page });
+    }
+  }
+
+  // Walks all pages and downloads the full result set as CSV. Sentry's
+  // admin/bins endpoint caps page_size at 50 regardless of `per_page`,
+  // so we paginate server-side and concat client-side. CSV mirrors the
+  // BinImportRow schema (bin_code, bin_barcode, zone, warehouse_id,
+  // bin_type, aisle, pick_sequence, putaway_sequence, description) so
+  // an exported file is round-trip-importable via /admin/import/bins.
+  async function exportCsv() {
+    setExporting(true);
+    try {
+      const all = [];
+      let p = 1;
+      // Hard stop at 200 pages (=10k bins) to avoid runaway
+      while (p <= 200) {
+        const params = new URLSearchParams({ warehouse_id: String(warehouseId), page: p, per_page: 50 });
+        if (search) params.set('q', search);
+        const res = await api.get(`/admin/bins?${params}`);
+        if (!res?.ok) break;
+        const data = await res.json();
+        all.push(...(data.bins || []));
+        if (p >= (data.pages || 1)) break;
+        p += 1;
+      }
+      const headers = ['bin_code','bin_barcode','zone','warehouse_id','bin_type','aisle','pick_sequence','putaway_sequence','description'];
+      const csvEscape = (v) => {
+        if (v == null) return '';
+        const s = String(v);
+        return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+      };
+      const lines = [headers.join(',')];
+      for (const b of all) {
+        lines.push([
+          csvEscape(b.bin_code),
+          csvEscape(b.bin_barcode),
+          csvEscape(b.zone_name || b.zone || ''),
+          csvEscape(b.warehouse_id ?? warehouseId),
+          csvEscape(b.bin_type),
+          csvEscape(b.aisle ?? ''),
+          csvEscape(b.pick_sequence ?? ''),
+          csvEscape(b.putaway_sequence ?? ''),
+          csvEscape(b.description ?? ''),
+        ].join(','));
+      }
+      const csv = lines.join('\n');
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      const today = new Date().toISOString().split('T')[0];
+      link.download = `bins_warehouse${warehouseId}_${today}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } finally {
+      setExporting(false);
     }
   }
 
@@ -173,11 +235,20 @@ export default function Bins() {
           style={{ maxWidth: 320, marginRight: 8 }}
           placeholder="Search by bin code or barcode"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
         />
+        <button
+          className="btn"
+          onClick={exportCsv}
+          disabled={exporting || !pagination?.total}
+          style={{ marginRight: 8 }}
+          title="Export current filter to CSV"
+        >
+          {exporting ? 'Exporting…' : 'Export CSV'}
+        </button>
         <button className="btn btn-primary" onClick={() => { setForm({ is_active: true }); setShowCreate(true); setError(''); }}>New Bin</button>
       </PageHeader>
-      <DataTable columns={columns} data={bins} onRowClick={viewBin} />
+      <DataTable columns={columns} data={bins} pagination={pagination} onPageChange={setPage} onRowClick={viewBin} />
 
       {selected && detail && !editing && (
         <Modal title={`Bin ${detail.bin_code}`} onClose={() => { setSelected(null); setDetail(null); setError(''); }}

--- a/admin/src/pages/InterWarehouseTransfers.jsx
+++ b/admin/src/pages/InterWarehouseTransfers.jsx
@@ -1,12 +1,61 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { api } from '../api.js';
 import PageHeader from '../components/PageHeader.jsx';
 
+// Bin + item lookups switched from preloaded
+// dropdowns to debounced server-side search so 30K SKUs and 3K bins
+// stop hiding past the per_page cutoff. Same pattern as Adjustments.
+// The two bin pickers (source + dest) operate independently
+// so a transfer between two large warehouses no longer blocks on a
+// 50-row default.
+
+const dropdownStyle = {
+  position: 'absolute',
+  top: '100%',
+  left: 0,
+  right: 0,
+  maxHeight: 200,
+  overflowY: 'auto',
+  background: '#fff',
+  border: '1px solid #ddd',
+  borderRadius: 8,
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+  zIndex: 100,
+};
+
+const dropdownItemStyle = {
+  padding: '8px 12px',
+  cursor: 'pointer',
+  borderBottom: '1px solid #f0f0f0',
+  fontSize: 13,
+};
+
+function useDebouncedBinSearch(warehouseId, query, selectedId) {
+  const [results, setResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  useEffect(() => {
+    const q = (query || '').trim();
+    if (!warehouseId || q.length < 1 || selectedId) {
+      setResults([]);
+      return;
+    }
+    setSearching(true);
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/bins?warehouse_id=${warehouseId}&q=${encodeURIComponent(q)}&per_page=25`,
+      );
+      setSearching(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setResults(data.bins || []);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [warehouseId, query, selectedId]);
+  return { results, searching };
+}
+
 export default function InterWarehouseTransfers() {
   const [warehouses, setWarehouses] = useState([]);
-  const [sourceBins, setSourceBins] = useState([]);
-  const [destBins, setDestBins] = useState([]);
-  const [items, setItems] = useState([]);
   const [transfers, setTransfers] = useState([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -21,31 +70,74 @@ export default function InterWarehouseTransfers() {
     quantity: '',
   });
 
+  // Typeahead state per lookup field.
+  const [sourceBinSearch, setSourceBinSearch] = useState('');
+  const [sourceBinOpen, setSourceBinOpen] = useState(false);
+  const [destBinSearch, setDestBinSearch] = useState('');
+  const [destBinOpen, setDestBinOpen] = useState(false);
+  const [itemSearch, setItemSearch] = useState('');
+  const [itemOpen, setItemOpen] = useState(false);
+  const [itemResults, setItemResults] = useState([]);
+  const [itemSearching, setItemSearching] = useState(false);
+  const sourceBinRef = useRef(null);
+  const destBinRef = useRef(null);
+  const itemRef = useRef(null);
+
+  const sourceBinQuery = useDebouncedBinSearch(
+    form.source_warehouse_id, sourceBinSearch, form.source_bin_id,
+  );
+  const destBinQuery = useDebouncedBinSearch(
+    form.destination_warehouse_id, destBinSearch, form.destination_bin_id,
+  );
+
+  // Item search is warehouse-agnostic at the catalog level - the
+  // transfer endpoint validates that the chosen item actually has
+  // inventory in the source bin, so an unrelated catalog match just
+  // bounces back with a clear error.
+  useEffect(() => {
+    const q = itemSearch.trim();
+    if (q.length < 2 || form.item_id) {
+      setItemResults([]);
+      return;
+    }
+    setItemSearching(true);
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/items?q=${encodeURIComponent(q)}&per_page=25&active=true`,
+      );
+      setItemSearching(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setItemResults(data.items || []);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [itemSearch, form.item_id]);
+
+  useEffect(() => {
+    function handleClick(e) {
+      if (sourceBinRef.current && !sourceBinRef.current.contains(e.target)) setSourceBinOpen(false);
+      if (destBinRef.current && !destBinRef.current.contains(e.target)) setDestBinOpen(false);
+      if (itemRef.current && !itemRef.current.contains(e.target)) setItemOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
   useEffect(() => {
     loadWarehouses();
     loadTransfers();
   }, []);
 
-  // Load source bins and items when source warehouse changes
+  // Reset source bin selection when source warehouse changes so a
+  // stale (warehouse A, bin from B) state cannot reach the submit.
   useEffect(() => {
-    if (form.source_warehouse_id) {
-      loadBins(form.source_warehouse_id, 'source');
-      loadItems(form.source_warehouse_id);
-    } else {
-      setSourceBins([]);
-      setItems([]);
-    }
-    setForm((f) => ({ ...f, source_bin_id: '', item_id: '' }));
+    setForm((f) => ({ ...f, source_bin_id: '' }));
+    setSourceBinSearch('');
   }, [form.source_warehouse_id]);
 
-  // Load dest bins when destination warehouse changes
   useEffect(() => {
-    if (form.destination_warehouse_id) {
-      loadBins(form.destination_warehouse_id, 'dest');
-    } else {
-      setDestBins([]);
-    }
     setForm((f) => ({ ...f, destination_bin_id: '' }));
+    setDestBinSearch('');
   }, [form.destination_warehouse_id]);
 
   async function loadWarehouses() {
@@ -53,23 +145,6 @@ export default function InterWarehouseTransfers() {
     if (res?.ok) {
       const data = await res.json();
       setWarehouses(data.warehouses || []);
-    }
-  }
-
-  async function loadBins(warehouseId, target) {
-    const res = await api.get(`/admin/bins?warehouse_id=${warehouseId}`);
-    if (res?.ok) {
-      const data = await res.json();
-      if (target === 'source') setSourceBins(data.bins || []);
-      else setDestBins(data.bins || []);
-    }
-  }
-
-  async function loadItems(warehouseId) {
-    const res = await api.get(`/admin/items?warehouse_id=${warehouseId}&per_page=1000`);
-    if (res?.ok) {
-      const data = await res.json();
-      setItems(data.items || []);
     }
   }
 
@@ -83,6 +158,24 @@ export default function InterWarehouseTransfers() {
 
   function updateField(key, value) {
     setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  function selectSourceBin(b) {
+    setForm((f) => ({ ...f, source_bin_id: b.bin_id }));
+    setSourceBinSearch(b.bin_code);
+    setSourceBinOpen(false);
+  }
+
+  function selectDestBin(b) {
+    setForm((f) => ({ ...f, destination_bin_id: b.bin_id }));
+    setDestBinSearch(b.bin_code);
+    setDestBinOpen(false);
+  }
+
+  function selectItem(i) {
+    setForm((f) => ({ ...f, item_id: i.item_id }));
+    setItemSearch(`${i.sku}  -  ${i.item_name}`);
+    setItemOpen(false);
   }
 
   async function handleSubmit(e) {
@@ -115,6 +208,9 @@ export default function InterWarehouseTransfers() {
         const data = await res.json();
         setSuccess(data.message || 'Transfer created successfully.');
         setForm({ source_warehouse_id: '', source_bin_id: '', destination_warehouse_id: '', destination_bin_id: '', item_id: '', quantity: '' });
+        setSourceBinSearch('');
+        setDestBinSearch('');
+        setItemSearch('');
         loadTransfers();
       } else {
         const data = await res.json().catch(() => null);
@@ -157,14 +253,31 @@ export default function InterWarehouseTransfers() {
                 ))}
               </select>
             </div>
-            <div className="form-group">
-              <label>Source Bin</label>
-              <select className="form-select" value={form.source_bin_id} onChange={(e) => updateField('source_bin_id', e.target.value)} disabled={!form.source_warehouse_id}>
-                <option value="">Select bin...</option>
-                {sourceBins.map((b) => (
-                  <option key={b.bin_id} value={b.bin_id}>{b.bin_code} ({b.bin_type})</option>
-                ))}
-              </select>
+            <div className="form-group" ref={sourceBinRef} style={{ position: 'relative' }}>
+              <label>Source Bin {sourceBinQuery.searching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
+              <input
+                className="form-input mono"
+                placeholder={form.source_warehouse_id ? 'Type bin code to search' : 'Pick warehouse first'}
+                value={sourceBinSearch}
+                onChange={(e) => { setSourceBinSearch(e.target.value); updateField('source_bin_id', ''); setSourceBinOpen(true); }}
+                onFocus={() => setSourceBinOpen(true)}
+                disabled={!form.source_warehouse_id}
+                autoComplete="off"
+              />
+              {sourceBinOpen && sourceBinQuery.results.length > 0 && (
+                <div style={dropdownStyle}>
+                  {sourceBinQuery.results.map((b) => (
+                    <div key={b.bin_id} style={dropdownItemStyle} onMouseDown={() => selectSourceBin(b)}>
+                      <span className="mono">{b.bin_code}</span> {b.bin_type ? `(${b.bin_type})` : ''}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {sourceBinOpen && !sourceBinQuery.searching && sourceBinSearch.trim().length >= 1 && !form.source_bin_id && sourceBinQuery.results.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No bins match "{sourceBinSearch.trim()}" in this warehouse.
+                </div>
+              )}
             </div>
           </div>
 
@@ -178,26 +291,59 @@ export default function InterWarehouseTransfers() {
                 ))}
               </select>
             </div>
-            <div className="form-group">
-              <label>Destination Bin</label>
-              <select className="form-select" value={form.destination_bin_id} onChange={(e) => updateField('destination_bin_id', e.target.value)} disabled={!form.destination_warehouse_id}>
-                <option value="">Select bin...</option>
-                {destBins.map((b) => (
-                  <option key={b.bin_id} value={b.bin_id}>{b.bin_code} ({b.bin_type})</option>
-                ))}
-              </select>
+            <div className="form-group" ref={destBinRef} style={{ position: 'relative' }}>
+              <label>Destination Bin {destBinQuery.searching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
+              <input
+                className="form-input mono"
+                placeholder={form.destination_warehouse_id ? 'Type bin code to search' : 'Pick warehouse first'}
+                value={destBinSearch}
+                onChange={(e) => { setDestBinSearch(e.target.value); updateField('destination_bin_id', ''); setDestBinOpen(true); }}
+                onFocus={() => setDestBinOpen(true)}
+                disabled={!form.destination_warehouse_id}
+                autoComplete="off"
+              />
+              {destBinOpen && destBinQuery.results.length > 0 && (
+                <div style={dropdownStyle}>
+                  {destBinQuery.results.map((b) => (
+                    <div key={b.bin_id} style={dropdownItemStyle} onMouseDown={() => selectDestBin(b)}>
+                      <span className="mono">{b.bin_code}</span> {b.bin_type ? `(${b.bin_type})` : ''}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {destBinOpen && !destBinQuery.searching && destBinSearch.trim().length >= 1 && !form.destination_bin_id && destBinQuery.results.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No bins match "{destBinSearch.trim()}" in this warehouse.
+                </div>
+              )}
             </div>
           </div>
 
           <div className="form-row">
-            <div className="form-group">
-              <label>Item</label>
-              <select className="form-select" value={form.item_id} onChange={(e) => updateField('item_id', e.target.value)} disabled={!form.source_warehouse_id}>
-                <option value="">Select item...</option>
-                {items.map((i) => (
-                  <option key={i.item_id} value={i.item_id}>{i.sku}  -  {i.item_name}</option>
-                ))}
-              </select>
+            <div className="form-group" ref={itemRef} style={{ position: 'relative' }}>
+              <label>Item {itemSearching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
+              <input
+                className="form-input"
+                placeholder="Type SKU or item name (min 2 chars)"
+                value={itemSearch}
+                onChange={(e) => { setItemSearch(e.target.value); updateField('item_id', ''); setItemOpen(true); }}
+                onFocus={() => setItemOpen(true)}
+                autoComplete="off"
+              />
+              {itemOpen && itemResults.length > 0 && (
+                <div style={dropdownStyle}>
+                  {itemResults.map((i) => (
+                    <div key={i.item_id} style={dropdownItemStyle} onMouseDown={() => selectItem(i)}>
+                      <strong className="mono">{i.sku}</strong>  -  {i.item_name}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {itemOpen && !itemSearching && itemSearch.trim().length >= 2 && !form.item_id && itemResults.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No items match "{itemSearch.trim()}".
+                </div>
+              )}
             </div>
             <div className="form-group">
               <label>Quantity</label>

--- a/admin/src/pages/Inventory.jsx
+++ b/admin/src/pages/Inventory.jsx
@@ -4,8 +4,21 @@ import { useWarehouse } from '../warehouse.jsx';
 import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 
+// Page-level warehouse + bin filters were added on 2026-05-10 because the
+// global topbar warehouse-picker was unreliable for some users (couldn't
+// click into the dropdown), making cross-warehouse inventory inspection
+// impossible. The page-level filters seed from the topbar context (so
+// existing behavior is unchanged for users who were using the topbar) but
+// can be independently changed without affecting global state. Bin filter
+// is new - the underlying API endpoint already supports bin_id query
+// param; the UI just never exposed it.
+
 export default function Inventory() {
-  const { warehouseId } = useWarehouse();
+  const { warehouseId: topbarWarehouseId } = useWarehouse();
+  const [warehouses, setWarehouses] = useState([]);
+  const [bins, setBins] = useState([]);
+  const [warehouseFilter, setWarehouseFilter] = useState(topbarWarehouseId || null);
+  const [binFilter, setBinFilter] = useState(null);
   const [data, setData] = useState([]);
   const [pagination, setPagination] = useState(null);
   const [page, setPage] = useState(1);
@@ -13,18 +26,63 @@ export default function Inventory() {
   const [search, setSearch] = useState('');
   const [sortKey, setSortKey] = useState(null);
   const [sortDir, setSortDir] = useState('asc');
+  const [loading, setLoading] = useState(false);
 
+  // Load all warehouses once for the filter dropdown. Independent of topbar
+  // context so the page-level filter works even if topbar picker doesn't.
   useEffect(() => {
-    if (!warehouseId) return;
-    const params = new URLSearchParams({ warehouse_id: warehouseId, page, per_page: 50 });
+    api.get('/admin/warehouses').then(async (res) => {
+      if (!res?.ok) return;
+      const json = await res.json();
+      const list = json.warehouses || [];
+      setWarehouses(list);
+      // If the topbar didn't set a warehouseId but warehouses are available,
+      // default to the first one so the inventory query has a target.
+      if (!warehouseFilter && list.length > 0) {
+        const firstId = list[0].warehouse_id || list[0].id;
+        setWarehouseFilter(firstId);
+      }
+    });
+  }, []);
+
+  // Load bins for the selected warehouse so the bin-filter dropdown is
+  // scoped (avoids showing bins from other warehouses that don't apply).
+  useEffect(() => {
+    if (!warehouseFilter) {
+      setBins([]);
+      setBinFilter(null);
+      return;
+    }
+    const params = new URLSearchParams({ warehouse_id: warehouseFilter, per_page: 200 });
+    api.get(`/admin/bins?${params}`).then(async (res) => {
+      if (!res?.ok) return;
+      const json = await res.json();
+      setBins(json.bins || []);
+      // Reset bin filter if the previously-selected bin doesn't belong to
+      // the new warehouse (prevents stale filter rejecting all results).
+      if (binFilter) {
+        const list = json.bins || [];
+        const stillValid = list.some((b) => (b.bin_id || b.id) === binFilter);
+        if (!stillValid) setBinFilter(null);
+      }
+    });
+  }, [warehouseFilter]);
+
+  // Run the inventory query whenever any filter changes.
+  useEffect(() => {
+    if (!warehouseFilter) return;
+    const params = new URLSearchParams({ warehouse_id: warehouseFilter, page, per_page: 50 });
+    if (binFilter) params.set('bin_id', binFilter);
     if (search) params.set('q', search);
+    setLoading(true);
     api.get(`/admin/inventory?${params}`).then(async (res) => {
+      setLoading(false);
       if (!res?.ok) return;
       const json = await res.json();
       setData(json.inventory || []);
       setPagination({ page: json.page, pages: json.pages, total: json.total, per_page: json.per_page });
     });
-  }, [page, search, warehouseId]);
+  }, [page, search, warehouseFilter, binFilter]);
 
   function commitSearch() {
     setSearch(searchInput);
@@ -67,7 +125,40 @@ export default function Inventory() {
   return (
     <div>
       <PageHeader title="Inventory" />
-      <div className="filter-bar">
+      <div className="filter-bar" style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+        <select
+          className="form-input"
+          value={warehouseFilter || ''}
+          onChange={(e) => { setWarehouseFilter(Number(e.target.value) || null); setPage(1); }}
+          style={{ minWidth: 180 }}
+        >
+          <option value="">- Select warehouse -</option>
+          {warehouses.map((w) => {
+            const wId = w.warehouse_id || w.id;
+            return (
+              <option key={wId} value={wId}>
+                {(w.warehouse_code || w.code)} - {(w.warehouse_name || w.name)}
+              </option>
+            );
+          })}
+        </select>
+        <select
+          className="form-input"
+          value={binFilter || ''}
+          onChange={(e) => { setBinFilter(Number(e.target.value) || null); setPage(1); }}
+          style={{ minWidth: 200 }}
+          disabled={!warehouseFilter || bins.length === 0}
+        >
+          <option value="">- All bins in warehouse -</option>
+          {bins.map((b) => {
+            const bId = b.bin_id || b.id;
+            return (
+              <option key={bId} value={bId}>
+                {b.bin_code}{b.zone_name ? ` (${b.zone_name})` : ''}
+              </option>
+            );
+          })}
+        </select>
         <input
           className="form-input"
           placeholder="Search by SKU or item name (press Enter)"
@@ -75,17 +166,26 @@ export default function Inventory() {
           onChange={(e) => setSearchInput(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') commitSearch(); }}
           onBlur={commitSearch}
+          style={{ minWidth: 280, flex: 1 }}
         />
+        {loading && <span style={{ color: 'rgba(255,255,255,0.5)', fontSize: 12 }}>Loading…</span>}
       </div>
-      <DataTable
-        columns={columns}
-        data={sorted}
-        pagination={pagination}
-        onPageChange={setPage}
-        sortKey={sortKey}
-        sortDir={sortDir}
-        onSort={handleSort}
-      />
+      {!warehouseFilter && (
+        <div style={{ padding: 24, color: 'rgba(255,255,255,0.5)', fontSize: 13 }}>
+          Select a warehouse to view inventory.
+        </div>
+      )}
+      {warehouseFilter && (
+        <DataTable
+          columns={columns}
+          data={sorted}
+          pagination={pagination}
+          onPageChange={setPage}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={handleSort}
+        />
+      )}
     </div>
   );
 }

--- a/admin/src/pages/Inventory.jsx
+++ b/admin/src/pages/Inventory.jsx
@@ -9,9 +9,7 @@ import PageHeader from '../components/PageHeader.jsx';
 // click into the dropdown), making cross-warehouse inventory inspection
 // impossible. The page-level filters seed from the topbar context (so
 // existing behavior is unchanged for users who were using the topbar) but
-// can be independently changed without affecting global state. Bin filter
-// is new - the underlying API endpoint already supports bin_id query
-// param; the UI just never exposed it.
+// can be independently changed without affecting global state.
 
 export default function Inventory() {
   const { warehouseId: topbarWarehouseId } = useWarehouse();

--- a/admin/src/pages/Items.jsx
+++ b/admin/src/pages/Items.jsx
@@ -24,14 +24,35 @@ export default function Items() {
   const [form, setForm] = useState({});
   const [error, setError] = useState('');
 
-  useEffect(() => { loadItems(); }, [page, search, filter]);
+  // Debounce typed search and guard against out-of-order responses.
+  // Each run owns an AbortController; the cleanup cancels a pending
+  // debounce timer (rapid typing) AND aborts an in-flight request (a
+  // superseded query), so only the latest query's response reaches
+  // setItems. Without this, slow broad-prefix queries (e.g. "1" matches
+  // 23k items) resolve late and overwrite the narrow result, leaving
+  // stale "floater" rows from earlier keystrokes. Page/filter changes
+  // are discrete clicks, so they fire immediately (no debounce delay).
+  useEffect(() => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => loadItems(controller.signal), search ? 250 : 0);
+    return () => { clearTimeout(timer); controller.abort(); };
+  }, [page, search, filter]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  async function loadItems() {
+  // signal is supplied by the debounced effect so a superseded query
+  // aborts mid-flight. The mutation handlers (save/delete/archive) call
+  // loadItems() with no signal and refetch unconditionally.
+  async function loadItems(signal) {
     const params = new URLSearchParams({ page, per_page: 50 });
     if (search) params.set('q', search);
     if (filter === 'active') params.set('active', 'true');
     else if (filter === 'archived') params.set('active', 'false');
-    const res = await api.get(`/admin/items?${params}`);
+    let res;
+    try {
+      res = await api.get(`/admin/items?${params}`, { signal });
+    } catch (err) {
+      if (err?.name === 'AbortError') return; // superseded by a newer query
+      throw err;
+    }
     if (res?.ok) {
       const data = await res.json();
       const mapped = (data.items || []).map((item) => ({

--- a/admin/src/pages/POSActivity.jsx
+++ b/admin/src/pages/POSActivity.jsx
@@ -1,0 +1,196 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api.js';
+import DataTable from '../components/DataTable.jsx';
+import PageHeader from '../components/PageHeader.jsx';
+
+// POS Activity dashboard: monitor in-store retail POS sales orders +
+// daily KPIs. Sentry stores POS-specific facts (cashier_id, terminal_id,
+// total_cents, payment_method) in audit_log.details JSONB rather than
+// dedicated columns (v1.10.0 design: pricing stays out of Sentry, lives
+// in audit_log for archival). The /api/admin/pos/* backend endpoints
+// surface those facts back to this page via LEFT JOIN audit_log.
+
+const STATUS_OPTIONS = ['', 'OPEN', 'ALLOCATED', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED'];
+const ORDER_TYPE_OPTIONS = ['sale', 'refund', 'all'];
+
+function centsToUsd(cents) {
+  if (cents == null) return '-';
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatTs(iso) {
+  if (!iso) return '-';
+  try {
+    return new Date(iso).toLocaleString('en-US', {
+      year: 'numeric', month: 'short', day: 'numeric',
+      hour: 'numeric', minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export default function POSActivity() {
+  const [summary, setSummary] = useState(null);
+  const [salesOrders, setSalesOrders] = useState([]);
+  const [pagination, setPagination] = useState(null);
+  const [page, setPage] = useState(1);
+  const [orderType, setOrderType] = useState('sale');
+  const [status, setStatus] = useState('');
+  const [terminalFilter, setTerminalFilter] = useState('');
+  const [cashierFilter, setCashierFilter] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  // Refresh summary every load + after page/filter changes that imply new data.
+  // Cheap - single SQL query w/ 1-day window.
+  function loadSummary() {
+    api.get('/admin/pos/summary').then(async (res) => {
+      if (!res?.ok) return;
+      const data = await res.json();
+      setSummary(data);
+    });
+  }
+
+  function loadOrders() {
+    const params = new URLSearchParams({ page, per_page: 50, order_type: orderType });
+    if (status) params.set('status', status);
+    if (terminalFilter) params.set('terminal_id', terminalFilter);
+    if (cashierFilter) params.set('cashier_id', cashierFilter);
+    setLoading(true);
+    api.get(`/admin/pos/sales-orders?${params}`).then(async (res) => {
+      setLoading(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setSalesOrders(data.sales_orders || []);
+      setPagination({ page: data.page, pages: data.pages, total: data.total, per_page: data.per_page });
+    });
+  }
+
+  useEffect(() => { loadSummary(); }, []);
+  useEffect(() => { loadOrders(); }, [page, orderType, status, terminalFilter, cashierFilter]);
+
+  function refresh() {
+    loadSummary();
+    loadOrders();
+  }
+
+  const columns = [
+    { key: 'so_number', label: 'SO #', mono: true },
+    { key: 'order_date', label: 'Date', render: (r) => formatTs(r.order_date) },
+    { key: 'order_type', label: 'Type' },
+    { key: 'status', label: 'Status' },
+    { key: 'cashier_id', label: 'Cashier', render: (r) => r.cashier_id || '-' },
+    { key: 'terminal_id', label: 'Terminal', mono: true, render: (r) => r.terminal_id || '-' },
+    { key: 'customer_name', label: 'Customer', render: (r) => r.customer_name || '(walk-in)' },
+    { key: 'total_cents', label: 'Total', render: (r) => centsToUsd(r.total_cents) },
+    { key: 'payment_method', label: 'Tender', render: (r) => r.payment_method || '-' },
+    { key: 'external_txn_ref', label: 'Windcave Ref', mono: true, render: (r) => r.external_txn_ref || '-' },
+  ];
+
+  const today = summary?.today || {};
+  const terminals = summary?.active_terminals || [];
+
+  return (
+    <div>
+      <PageHeader title="POS Activity">
+        <button className="btn" onClick={refresh}>Refresh</button>
+      </PageHeader>
+
+      {/* KPI Bar */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+        gap: 12,
+        marginBottom: 16,
+      }}>
+        <KpiCard
+          label="Today's Sales"
+          value={today.sales_count ?? '-'}
+          sub={centsToUsd(today.sales_total_cents)}
+        />
+        <KpiCard
+          label="Today's Refunds"
+          value={today.refund_count ?? '-'}
+          sub={centsToUsd(today.refund_total_cents)}
+        />
+        <KpiCard
+          label="Net Revenue Today"
+          value={centsToUsd((today.sales_total_cents || 0) - (today.refund_total_cents || 0))}
+          sub={`${today.sales_count || 0} sales − ${today.refund_count || 0} refunds`}
+        />
+        <KpiCard
+          label="Active Terminals (24h)"
+          value={terminals.length || '-'}
+          sub={terminals.join(', ') || 'none'}
+        />
+      </div>
+
+      {/* Filter bar */}
+      <div className="filter-bar" style={{ marginBottom: 12 }}>
+        <select
+          className="form-select"
+          value={orderType}
+          onChange={(e) => { setOrderType(e.target.value); setPage(1); }}
+          style={{ width: 'auto' }}
+        >
+          {ORDER_TYPE_OPTIONS.map((v) => (
+            <option key={v} value={v}>{v === 'all' ? 'All Types' : (v[0].toUpperCase() + v.slice(1))}</option>
+          ))}
+        </select>
+        <select
+          className="form-select"
+          value={status}
+          onChange={(e) => { setStatus(e.target.value); setPage(1); }}
+          style={{ width: 'auto' }}
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s} value={s}>{s || 'All Statuses'}</option>
+          ))}
+        </select>
+        <input
+          className="form-input"
+          placeholder="Terminal ID (e.g., REG-01)"
+          value={terminalFilter}
+          onChange={(e) => { setTerminalFilter(e.target.value); setPage(1); }}
+          style={{ maxWidth: 200 }}
+        />
+        <input
+          className="form-input"
+          placeholder="Cashier ID"
+          value={cashierFilter}
+          onChange={(e) => { setCashierFilter(e.target.value); setPage(1); }}
+          style={{ maxWidth: 200 }}
+        />
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={salesOrders}
+        pagination={pagination}
+        onPageChange={setPage}
+        emptyMessage={loading ? 'Loading…' : 'No POS orders match the current filters.'}
+      />
+    </div>
+  );
+}
+
+function KpiCard({ label, value, sub }) {
+  return (
+    <div style={{
+      background: 'var(--card-bg, #ffffff)',
+      border: '1px solid var(--border, #e5e7eb)',
+      borderRadius: 8,
+      padding: '12px 16px',
+    }}>
+      <div style={{
+        fontSize: 11,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+        color: 'var(--text-secondary, #6b7280)',
+        marginBottom: 4,
+      }}>{label}</div>
+      <div style={{ fontSize: 24, fontWeight: 600, marginBottom: 2 }}>{value}</div>
+      <div style={{ fontSize: 12, color: 'var(--text-secondary, #6b7280)' }}>{sub}</div>
+    </div>
+  );
+}

--- a/admin/src/pages/PutAway.jsx
+++ b/admin/src/pages/PutAway.jsx
@@ -1,34 +1,195 @@
 import { useState, useEffect } from 'react';
 import { api } from '../api.js';
 import { useWarehouse } from '../warehouse.jsx';
-import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
+
+// Dashboard view of staging bins for the
+// supervisor. Each staging bin shows its SKU count + total qty; the
+// row expands to the per-item breakdown. CSV exports cover both the
+// single-bin view (workpaper for the operator walking that aisle) and
+// the warehouse-wide view (reconciliation / inventory analysis).
+
+function csvEscape(v) {
+  if (v === null || v === undefined) return '';
+  const s = String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function downloadCsv(filename, headerRow, dataRows) {
+  const lines = [headerRow.join(',')];
+  for (const r of dataRows) lines.push(r.map(csvEscape).join(','));
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
 
 export default function PutAway() {
   const { warehouseId } = useWarehouse();
-  const [items, setItems] = useState([]);
+  const [bins, setBins] = useState([]);
+  const [expanded, setExpanded] = useState({});
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!warehouseId) return;
-    api.get(`/putaway/pending/${warehouseId}`).then(async (res) => {
+    setLoading(true);
+    api.get(`/putaway/staging-summary/${warehouseId}`).then(async (res) => {
+      setLoading(false);
       if (!res?.ok) return;
       const data = await res.json();
-      setItems(data.pending_items || []);
-    });
+      setBins(data.bins || []);
+    }).catch(() => setLoading(false));
   }, [warehouseId]);
 
-  const columns = [
-    { key: 'sku', label: 'SKU', mono: true },
-    { key: 'item_name', label: 'Item Name' },
-    { key: 'quantity', label: 'Qty in Staging', render: (r) => r.quantity_on_hand || r.quantity || '-' },
-    { key: 'bin_code', label: 'Bin Code', mono: true },
-    { key: 'suggested_bin', label: 'Suggested Bin', mono: true, render: (r) => r.suggested_bin || r.default_bin_code || '-' },
-  ];
+  function toggle(binId) {
+    setExpanded((e) => ({ ...e, [binId]: !e[binId] }));
+  }
+
+  function exportAll() {
+    const header = ['Bin', 'SKU', 'Item Name', 'UPC', 'Quantity', 'Suggested Bin', 'Lot'];
+    const rows = [];
+    for (const b of bins) {
+      for (const item of b.items) {
+        rows.push([
+          b.bin_code, item.sku, item.item_name, item.upc || '',
+          item.quantity_on_hand, item.suggested_bin || '', item.lot_number || '',
+        ]);
+      }
+    }
+    const stamp = new Date().toISOString().slice(0, 10);
+    downloadCsv(`putaway-staging-wh${warehouseId}-${stamp}.csv`, header, rows);
+  }
+
+  function exportBin(bin) {
+    const header = ['SKU', 'Item Name', 'UPC', 'Quantity', 'Suggested Bin', 'Lot'];
+    const rows = bin.items.map((item) => [
+      item.sku, item.item_name, item.upc || '',
+      item.quantity_on_hand, item.suggested_bin || '', item.lot_number || '',
+    ]);
+    const stamp = new Date().toISOString().slice(0, 10);
+    downloadCsv(`putaway-${bin.bin_code}-${stamp}.csv`, header, rows);
+  }
+
+  const totalSkus = bins.reduce((acc, b) => acc + b.sku_count, 0);
+  const totalQty = bins.reduce((acc, b) => acc + b.total_qty, 0);
+  const binsWithItems = bins.reduce((acc, b) => acc + (b.sku_count > 0 ? 1 : 0), 0);
 
   return (
     <div>
-      <PageHeader title="Put-Away" />
-      <DataTable columns={columns} data={items} emptyMessage="No items awaiting put-away" />
+      <PageHeader title="Put-Away">
+        <button
+          className="btn"
+          onClick={exportAll}
+          disabled={bins.length === 0}
+          title="Export every staging bin and its items to CSV"
+        >
+          Export All (CSV)
+        </button>
+      </PageHeader>
+
+      <div style={{
+        display: 'flex', gap: 16, marginBottom: 16, fontSize: 13,
+        color: 'var(--text-secondary)',
+      }}>
+        <span>
+          <strong style={{ color: 'var(--text)' }}>{binsWithItems}</strong>
+          {' / '}{bins.length} staging bins with items
+        </span>
+        <span><strong style={{ color: 'var(--text)' }}>{totalSkus}</strong> total SKU rows</span>
+        <span><strong style={{ color: 'var(--text)' }}>{totalQty}</strong> total units</span>
+      </div>
+
+      {loading && (
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>Loading…</p>
+      )}
+      {!loading && bins.length === 0 && (
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+          No staging bins exist in this warehouse.
+        </p>
+      )}
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {bins.map((b) => {
+          const isEmpty = b.sku_count === 0;
+          // Empty staging bins still render so the supervisor
+          // sees the full layout, but they are non-expandable and
+          // visually muted so the worklist signal stays clear.
+          const open = !isEmpty && !!expanded[b.bin_id];
+          return (
+            <div
+              key={b.bin_id}
+              className="card"
+              style={{ padding: 0, opacity: isEmpty ? 0.55 : 1 }}
+            >
+              <div
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                  padding: '10px 14px',
+                  cursor: isEmpty ? 'default' : 'pointer',
+                  borderBottom: open ? '1px solid var(--border-dark)' : 'none',
+                }}
+                onClick={isEmpty ? undefined : () => toggle(b.bin_id)}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                  <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                    {isEmpty ? '·' : (open ? '▾' : '▸')}
+                  </span>
+                  <span className="mono" style={{ fontSize: 14, fontWeight: 600 }}>
+                    {b.bin_code}
+                  </span>
+                  <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                    {isEmpty
+                      ? 'empty'
+                      : `${b.sku_count} ${b.sku_count === 1 ? 'SKU' : 'SKUs'} - ${b.total_qty} units`}
+                  </span>
+                </div>
+                {!isEmpty && (
+                  <button
+                    className="btn btn-sm"
+                    onClick={(e) => { e.stopPropagation(); exportBin(b); }}
+                    title={`Export ${b.bin_code} to CSV`}
+                  >
+                    CSV
+                  </button>
+                )}
+              </div>
+              {open && (
+                <div style={{ padding: '10px 14px' }}>
+                  <table className="lines-table">
+                    <thead>
+                      <tr>
+                        <th>SKU</th>
+                        <th>Item Name</th>
+                        <th>UPC</th>
+                        <th style={{ textAlign: 'right' }}>Qty</th>
+                        <th>Suggested Bin</th>
+                        <th>Lot</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {b.items.map((it) => (
+                        <tr key={it.inventory_id}>
+                          <td className="mono">{it.sku}</td>
+                          <td style={{ color: 'var(--text-secondary)' }}>{it.item_name}</td>
+                          <td className="mono">{it.upc || '-'}</td>
+                          <td className="mono" style={{ textAlign: 'right' }}>{it.quantity_on_hand}</td>
+                          <td className="mono">{it.suggested_bin || '-'}</td>
+                          <td className="mono">{it.lot_number || '-'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -127,6 +127,11 @@ export default function Settings() {
   // lines can accept an SKU (what operators memorize) instead of a
   // raw item_id (a database autoincrement). Loaded lazily when either
   // modal opens so Settings' first paint does not fetch /admin/items.
+  //
+  // The cache holds the first 1000 active items for instant typeahead
+  // and autocomplete; catalogues larger than 1000 fall back to a
+  // per-SKU server lookup in resolveSku so a less-common SKU at line
+  // submit time still resolves correctly instead of silently failing.
   async function ensureItemsLoaded() {
     if (itemsLoaded) return;
     const res = await api.get('/admin/items?per_page=1000&active=true', { silentPermissionDenied: true });
@@ -141,8 +146,20 @@ export default function Settings() {
     }
   }
 
-  function resolveSku(sku) {
-    return itemsBySku.get(String(sku || '').trim().toLowerCase());
+  async function resolveSku(sku) {
+    const key = String(sku || '').trim().toLowerCase();
+    if (!key) return null;
+    if (itemsBySku.has(key)) return itemsBySku.get(key);
+    // Cache miss: catalogue > 1000 items or the SKU is brand new. A
+    // narrow server-side query backs the cache so submit does not
+    // depend on the pre-loaded slice.
+    const res = await api.get(`/admin/items?q=${encodeURIComponent(sku)}&per_page=10&active=true`);
+    if (!res?.ok) return null;
+    const data = await res.json();
+    const match = (data.items || []).find(
+      (i) => String(i.sku || '').trim().toLowerCase() === key,
+    );
+    return match ? match.item_id : null;
   }
 
   function openPoModal() {
@@ -183,14 +200,18 @@ export default function Settings() {
 
   async function createPO() {
     setFormError(''); setFormSuccess('');
+    const entries = poForm.lines.filter((x) => x.sku);
+    // Resolve all SKUs in parallel so a multi-line PO does not pay
+    // a round-trip per line when the cache misses.
+    const ids = await Promise.all(entries.map((l) => resolveSku(l.sku)));
     const resolved = [];
-    for (const l of poForm.lines.filter((x) => x.sku)) {
-      const itemId = resolveSku(l.sku);
+    for (let i = 0; i < entries.length; i++) {
+      const itemId = ids[i];
       if (!itemId) {
-        setFormError(`Unknown SKU: ${l.sku}`);
+        setFormError(`Unknown SKU: ${entries[i].sku}`);
         return;
       }
-      resolved.push({ item_id: itemId, quantity_ordered: Number(l.quantity_ordered) });
+      resolved.push({ item_id: itemId, quantity_ordered: Number(entries[i].quantity_ordered) });
     }
     const body = {
       po_number: poForm.po_number,
@@ -221,14 +242,16 @@ export default function Settings() {
   async function createSO() {
     setFormError(''); setFormSuccess('');
     const shipAddress = [soForm.address_line_1, soForm.address_line_2, soForm.city, soForm.state, soForm.zip].filter(Boolean).join(', ');
+    const entries = soForm.lines.filter((x) => x.sku);
+    const ids = await Promise.all(entries.map((l) => resolveSku(l.sku)));
     const resolved = [];
-    for (const l of soForm.lines.filter((x) => x.sku)) {
-      const itemId = resolveSku(l.sku);
+    for (let i = 0; i < entries.length; i++) {
+      const itemId = ids[i];
       if (!itemId) {
-        setFormError(`Unknown SKU: ${l.sku}`);
+        setFormError(`Unknown SKU: ${entries[i].sku}`);
         return;
       }
-      resolved.push({ item_id: itemId, quantity_ordered: Number(l.quantity_ordered) });
+      resolved.push({ item_id: itemId, quantity_ordered: Number(entries[i].quantity_ordered) });
     }
     const body = {
       so_number: soForm.order_number,

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -55,6 +55,7 @@ export default function Settings() {
       api.get('/admin/settings/picking_ticket_company_address'),
       api.get('/admin/settings/picking_ticket_logo_url'),
       api.get('/admin/settings/picking_ticket_returns_text'),
+      api.get('/admin/settings/pos_activity_enabled'),
     ]).then(async (responses) => {
       const initial = {};
       for (const res of responses) {
@@ -76,6 +77,9 @@ export default function Settings() {
       if (!('picking_ticket_company_address' in initial)) initial.picking_ticket_company_address = '';
       if (!('picking_ticket_logo_url' in initial)) initial.picking_ticket_logo_url = '';
       if (!('picking_ticket_returns_text' in initial)) initial.picking_ticket_returns_text = '';
+      // POS Activity tab is hidden by default; deployments using the POS
+      // checkout surface opt in. Sidebar reads the same key to gate the nav.
+      if (!('pos_activity_enabled' in initial)) initial.pos_activity_enabled = 'false';
       setSavedSettings({ ...initial });
       setDraftSettings({ ...initial });
     });
@@ -402,6 +406,21 @@ export default function Settings() {
           </label>
         </div>
         <p className="settings-note">When enabled, the admin who performed a cycle count cannot approve the resulting adjustments. A different admin must review and approve.</p>
+      </div>
+
+      <div className="settings-section">
+        <h3>POS</h3>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 0' }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: 13 }}>
+            <input
+              type="checkbox"
+              checked={toBool(draftSettings.pos_activity_enabled)}
+              onChange={(e) => updateDraft('pos_activity_enabled', String(e.target.checked))}
+            />
+            Show the POS Activity dashboard
+          </label>
+        </div>
+        <p className="settings-note">Adds a POS Activity tab to the Outbound nav with point-of-sale order activity and daily KPIs. Off by default; enable it for deployments that use the POS checkout surface.</p>
       </div>
 
       {/* Picking Ticket branding */}

--- a/api/routes/admin/__init__.py
+++ b/api/routes/admin/__init__.py
@@ -53,6 +53,7 @@ from routes.admin import (  # noqa: E402, F401
     admin_items,
     admin_orders,
     admin_pick_batches,
+    admin_pos,
     admin_search,
     admin_tokens,
     admin_transfer_orders,

--- a/api/routes/admin/admin_items.py
+++ b/api/routes/admin/admin_items.py
@@ -51,7 +51,17 @@ def list_items():
         where_clauses.append("i.is_active = :active")
         params["active"] = active.lower() == "true"
     if search:
-        where_clauses.append("(i.sku ILIKE :search OR i.item_name ILIKE :search OR i.upc ILIKE :search)")
+        # barcode_aliases is a JSONB array of alternate scannable
+        # barcodes (vendor packs, distributor labels, secondary UPCs).
+        # Operators who scan one of these expect the matching item to
+        # surface even though the primary UPC differs; without the
+        # alias match they have to look up the item manually.
+        where_clauses.append(
+            "(i.sku ILIKE :search OR i.item_name ILIKE :search "
+            "OR i.upc ILIKE :search OR EXISTS (SELECT 1 FROM "
+            "jsonb_array_elements_text(COALESCE(i.barcode_aliases, '[]'::jsonb)) "
+            "AS alias(code) WHERE alias.code ILIKE :search))"
+        )
         params["search"] = f"%{search}%"
 
     where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""

--- a/api/routes/admin/admin_items.py
+++ b/api/routes/admin/admin_items.py
@@ -305,6 +305,7 @@ def list_inventory():
     where_clauses, params = [], {}
     warehouse_id = request.args.get("warehouse_id", type=int)
     item_id = request.args.get("item_id", type=int)
+    bin_id = request.args.get("bin_id", type=int)
     search = (request.args.get("q") or "").strip()
     if warehouse_id:
         where_clauses.append("inv.warehouse_id = :wid")
@@ -312,14 +313,30 @@ def list_inventory():
     if item_id:
         where_clauses.append("inv.item_id = :iid")
         params["iid"] = item_id
+    if bin_id:
+        # The Inventory page surfaces a bin-scoped filter dropdown; the
+        # backend has to honor it so operators can drill into a single
+        # bin without scrolling through the full warehouse list.
+        where_clauses.append("inv.bin_id = :binid")
+        params["binid"] = bin_id
     if search:
-        # Join items so the SKU/name search can reach them. The main
-        # SELECT below also joins items and bins for display.
-        where_clauses.append("(i.sku ILIKE :search OR i.item_name ILIKE :search)")
+        # SKU, item name, UPC, and bin code all read like primary
+        # identifiers to a warehouse operator. Searching by any one
+        # of them should return the matching inventory row rather
+        # than forcing the operator to know which field the value
+        # lives in. The main SELECT below already joins items and
+        # bins for display.
+        where_clauses.append(
+            "(i.sku ILIKE :search OR i.item_name ILIKE :search "
+            "OR i.upc ILIKE :search OR b.bin_code ILIKE :search)"
+        )
         params["search"] = f"%{search}%"
 
     where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
-    count_join = "JOIN items i ON i.item_id = inv.item_id" if search else ""
+    count_join = (
+        "JOIN items i ON i.item_id = inv.item_id JOIN bins b ON b.bin_id = inv.bin_id"
+        if search else ""
+    )
     total = g.db.execute(
         text(f"SELECT COUNT(*) FROM inventory inv {count_join} {where_sql}"), params
     ).scalar()

--- a/api/routes/admin/admin_items.py
+++ b/api/routes/admin/admin_items.py
@@ -77,7 +77,20 @@ def list_items():
                    i.default_bin_id, i.is_active, i.created_at,
                    b.bin_code AS default_bin_code
             FROM items i
-            LEFT JOIN preferred_bins pb ON pb.item_id = i.item_id AND pb.priority = 1
+            -- An item can carry more than one priority-1 preferred_bins
+            -- row (the data allows it), and a plain join fans the item
+            -- out into duplicate result rows. Collapse to one
+            -- deterministic bin via LATERAL ... LIMIT 1 so each item
+            -- yields exactly one row. The COUNT(*) above joins nothing,
+            -- so the total was already correct; this aligns the row set
+            -- with it.
+            LEFT JOIN LATERAL (
+                SELECT pb.bin_id
+                FROM preferred_bins pb
+                WHERE pb.item_id = i.item_id AND pb.priority = 1
+                ORDER BY pb.bin_id
+                LIMIT 1
+            ) pb ON TRUE
             LEFT JOIN bins b ON b.bin_id = COALESCE(pb.bin_id, i.default_bin_id)
             {where_sql}
             ORDER BY i.item_id LIMIT :limit OFFSET :offset

--- a/api/routes/admin/admin_pos.py
+++ b/api/routes/admin/admin_pos.py
@@ -1,0 +1,253 @@
+"""POS admin endpoints - feeds the new admin/src/pages/POSActivity.jsx
+dashboard with sales-order activity + daily KPI counters.
+
+Data model note: Sentry intentionally does NOT store per-line prices or
+operator metadata in `sales_orders` columns. Per v1.10.0 design (POS
+endpoint surface release), pricing + cashier_id + terminal_id ride into
+the audit_log.details JSONB at POS_CHECKOUT time. So this module's
+queries LEFT JOIN audit_log to surface those fields back to the
+dashboard.
+
+Endpoints:
+    GET /api/admin/pos/sales-orders   - paginated POS SO list w/ filters
+    GET /api/admin/pos/summary        - today's KPI counters (sales /
+                                        revenue / refunds / terminals)
+
+Both gated by ADMIN role (same as the existing /admin/sales-orders).
+"""
+
+import math
+from datetime import date, datetime, timedelta
+from flask import g, jsonify, request
+from sqlalchemy import text
+
+from constants import ACTION_POS_CHECKOUT, ACTION_POS_REFUND
+from middleware.auth_middleware import require_auth, require_role
+from middleware.db import with_db
+from routes.admin import admin_bp
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/pos/sales-orders
+# ---------------------------------------------------------------------------
+
+
+@admin_bp.route("/pos/sales-orders", methods=["GET"])
+@require_auth
+@require_role("ADMIN")
+@with_db
+def list_pos_sales_orders():
+    """Paginated list of POS sales orders with the cashier/terminal/total
+    detail joined from audit_log.
+
+    Query params:
+        page         - 1-based page number, default 1
+        per_page     - page size, default 50, max 200
+        since        - YYYY-MM-DD (orders with order_date >= since at UTC midnight)
+        until        - YYYY-MM-DD (orders with order_date <  until at UTC midnight)
+        terminal_id  - filter on the audit_log JSONB 'terminal_id' field
+        cashier_id   - filter on the audit_log JSONB 'cashier_id' field (= sales_orders.created_by)
+        status       - sales_orders.status filter (OPEN/ALLOCATED/PICKED/PACKED/SHIPPED/CANCELLED)
+        order_type   - 'sale' (default) | 'refund' | 'all'
+    """
+    page = request.args.get("page", 1, type=int)
+    per_page = min(request.args.get("per_page", 50, type=int), 200)
+    since = request.args.get("since")
+    until = request.args.get("until")
+    terminal_id = request.args.get("terminal_id")
+    cashier_id = request.args.get("cashier_id")
+    so_status = request.args.get("status")
+    order_type = request.args.get("order_type", "sale").lower()
+
+    where_clauses = ["so.order_source = :pos_source"]
+    params = {"pos_source": "pos", "checkout_action": ACTION_POS_CHECKOUT}
+
+    if order_type == "sale":
+        where_clauses.append("so.order_type = :order_type")
+        params["order_type"] = "sale"
+    elif order_type == "refund":
+        where_clauses.append("so.order_type = :order_type")
+        params["order_type"] = "refund"
+    elif order_type != "all":
+        # unknown values are treated as 'sale' to fail safe
+        where_clauses.append("so.order_type = :order_type")
+        params["order_type"] = "sale"
+
+    if since:
+        where_clauses.append("so.order_date >= CAST(:since AS DATE)")
+        params["since"] = since
+    if until:
+        where_clauses.append("so.order_date < CAST(:until AS DATE)")
+        params["until"] = until
+    if so_status:
+        where_clauses.append("so.status = :so_status")
+        params["so_status"] = so_status
+    if terminal_id:
+        where_clauses.append("al.details->>'terminal_id' = :terminal_id")
+        params["terminal_id"] = terminal_id
+    if cashier_id:
+        where_clauses.append("al.user_id = :cashier_id")
+        params["cashier_id"] = cashier_id
+
+    where_sql = "WHERE " + " AND ".join(where_clauses)
+
+    # Count (de-duped via DISTINCT so multi-audit-row SOs don't inflate)
+    total = g.db.execute(
+        text(
+            f"""
+            SELECT COUNT(DISTINCT so.so_id)
+              FROM sales_orders so
+              LEFT JOIN audit_log al
+                ON al.entity_type = 'SO'
+               AND al.entity_id   = so.so_id
+               AND al.action_type = :checkout_action
+              {where_sql}
+            """
+        ),
+        params,
+    ).scalar()
+    pages = max(1, math.ceil((total or 0) / per_page))
+
+    params["limit"] = per_page
+    params["offset"] = (page - 1) * per_page
+
+    rows = g.db.execute(
+        text(
+            f"""
+            SELECT DISTINCT ON (so.so_id)
+                   so.so_id,
+                   so.so_number,
+                   so.status,
+                   so.order_type,
+                   so.order_date,
+                   so.customer_name,
+                   so.customer_phone,
+                   so.external_txn_ref,
+                   so.warehouse_id,
+                   al.user_id AS cashier_id,
+                   al.details->>'terminal_id' AS terminal_id,
+                   COALESCE((al.details->>'total_cents')::int, 0) AS total_cents,
+                   al.details->>'payment_method' AS payment_method,
+                   al.created_at AS checkout_at
+              FROM sales_orders so
+              LEFT JOIN audit_log al
+                ON al.entity_type = 'SO'
+               AND al.entity_id   = so.so_id
+               AND al.action_type = :checkout_action
+              {where_sql}
+             ORDER BY so.so_id DESC, al.created_at DESC
+             LIMIT :limit OFFSET :offset
+            """
+        ),
+        params,
+    ).fetchall()
+
+    return jsonify({
+        "sales_orders": [
+            {
+                "so_id": r.so_id,
+                "so_number": r.so_number,
+                "status": r.status,
+                "order_type": r.order_type,
+                "order_date": r.order_date.isoformat() if r.order_date else None,
+                "customer_name": r.customer_name,
+                "customer_phone": r.customer_phone,
+                "external_txn_ref": r.external_txn_ref,
+                "warehouse_id": r.warehouse_id,
+                "cashier_id": r.cashier_id,
+                "terminal_id": r.terminal_id,
+                "total_cents": r.total_cents,
+                "payment_method": r.payment_method,
+                "checkout_at": r.checkout_at.isoformat() if r.checkout_at else None,
+            }
+            for r in rows
+        ],
+        "total": total or 0,
+        "page": page,
+        "per_page": per_page,
+        "pages": pages,
+    })
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/pos/summary
+# ---------------------------------------------------------------------------
+
+
+@admin_bp.route("/pos/summary", methods=["GET"])
+@require_auth
+@require_role("ADMIN")
+@with_db
+def pos_summary():
+    """Today's KPI counters for the dashboard top bar.
+
+    Computed as of `now` in the server's timezone (UTC for ACA deploys -
+    document the offset if cashier-day boundaries become important).
+
+    Returns:
+        today: {sales_count, sales_total_cents, refund_count, refund_total_cents}
+        active_terminals: list of distinct terminal_id seen in the last 24h
+    """
+    # "Today" boundary: midnight UTC. For SLC retail store, that's ~6pm
+    # local the prior day -- if the user wants a Mountain-Time boundary,
+    # we'd switch this to AT TIME ZONE 'America/Denver'. Keeping UTC for
+    # now to match the rest of the admin surface.
+    today_start_utc = "DATE_TRUNC('day', NOW() AT TIME ZONE 'UTC')"
+
+    row = g.db.execute(
+        text(
+            f"""
+            SELECT
+              COUNT(*) FILTER (WHERE so.order_type = 'sale')
+                AS sales_count,
+              COUNT(*) FILTER (WHERE so.order_type = 'refund')
+                AS refund_count,
+              COALESCE(SUM(
+                CASE WHEN so.order_type = 'sale'
+                  THEN COALESCE((al.details->>'total_cents')::int, 0)
+                  ELSE 0
+                END
+              ), 0) AS sales_total_cents,
+              COALESCE(SUM(
+                CASE WHEN so.order_type = 'refund'
+                  THEN COALESCE((al.details->>'total_cents')::int, 0)
+                  ELSE 0
+                END
+              ), 0) AS refund_total_cents
+            FROM sales_orders so
+            LEFT JOIN audit_log al
+              ON al.entity_type = 'SO'
+             AND al.entity_id   = so.so_id
+             AND al.action_type = :checkout_action
+            WHERE so.order_source = 'pos'
+              AND so.order_date >= {today_start_utc}
+            """
+        ),
+        {"checkout_action": ACTION_POS_CHECKOUT},
+    ).fetchone()
+
+    # Active terminals in the last 24h (a "registered today" pulse).
+    twenty_four_hours_ago = "(NOW() - INTERVAL '24 hours')"
+    terminals = g.db.execute(
+        text(
+            f"""
+            SELECT DISTINCT al.details->>'terminal_id' AS terminal_id
+              FROM audit_log al
+             WHERE al.action_type = :checkout_action
+               AND al.created_at >= {twenty_four_hours_ago}
+               AND al.details->>'terminal_id' IS NOT NULL
+             ORDER BY terminal_id
+            """
+        ),
+        {"checkout_action": ACTION_POS_CHECKOUT},
+    ).fetchall()
+
+    return jsonify({
+        "today": {
+            "sales_count": row.sales_count or 0,
+            "sales_total_cents": int(row.sales_total_cents or 0),
+            "refund_count": row.refund_count or 0,
+            "refund_total_cents": int(row.refund_total_cents or 0),
+        },
+        "active_terminals": [t.terminal_id for t in terminals if t.terminal_id],
+    })

--- a/api/routes/putaway.py
+++ b/api/routes/putaway.py
@@ -70,6 +70,119 @@ def pending_putaway(warehouse_id):
     })
 
 
+@putaway_bp.route("/staging-summary/<int:warehouse_id>")
+@require_auth
+@with_db
+def staging_summary(warehouse_id):
+    """Put-Away dashboard backing query.
+
+    Returns every staging-type bin in the warehouse (including empty
+    ones), alphabetised by bin_code, with the distinct-SKU count and
+    the per-item breakdown so the dashboard can expand a bin in-place
+    without a second round trip. Empty bins surface as zero-count
+    cards so the operator sees the full staging-bin map at a glance,
+    not just the worklist.
+
+    Same bin-type filter as /pending/<warehouse_id> so the two
+    surfaces are always in agreement on what counts as "needs
+    putaway".
+    """
+    ok, denied = check_warehouse_access(warehouse_id)
+    if not ok:
+        return denied
+
+    # Two-pass query: first the full set of staging bins so empty
+    # bins still render as cards, then the inventory rows joined to
+    # those bins. Joining inventory + items via LEFT JOIN would also
+    # work but the per-row JSON shape stays simpler with two passes.
+    bin_rows = g.db.execute(
+        text(
+            """
+            SELECT b.bin_id, b.bin_code
+              FROM bins b
+             WHERE b.warehouse_id = :warehouse_id
+               AND b.bin_type IN (:bin_staging, :bin_pickable_staging)
+             ORDER BY b.bin_code
+            """
+        ),
+        {
+            "warehouse_id": warehouse_id,
+            "bin_staging": BIN_STAGING,
+            "bin_pickable_staging": BIN_PICKABLE_STAGING,
+        },
+    ).fetchall()
+
+    inv_rows = g.db.execute(
+        text(
+            """
+            SELECT b.bin_id,
+                   inv.inventory_id, inv.item_id,
+                   i.sku, i.item_name, i.upc,
+                   inv.quantity_on_hand,
+                   inv.lot_number,
+                   COALESCE(
+                       (SELECT pbb.bin_code
+                        FROM preferred_bins pb
+                        JOIN bins pbb ON pbb.bin_id = pb.bin_id
+                        WHERE pb.item_id = inv.item_id
+                          AND pbb.warehouse_id = :warehouse_id
+                        ORDER BY pb.priority ASC
+                        LIMIT 1),
+                       (SELECT db.bin_code
+                        FROM bins db
+                        WHERE db.bin_id = i.default_bin_id
+                          AND db.warehouse_id = :warehouse_id)
+                   ) AS suggested_bin
+              FROM bins b
+              JOIN inventory inv ON inv.bin_id = b.bin_id
+              JOIN items i ON i.item_id = inv.item_id
+             WHERE b.warehouse_id = :warehouse_id
+               AND b.bin_type IN (:bin_staging, :bin_pickable_staging)
+               AND inv.quantity_on_hand > 0
+             ORDER BY b.bin_code, i.sku
+            """
+        ),
+        {
+            "warehouse_id": warehouse_id,
+            "bin_staging": BIN_STAGING,
+            "bin_pickable_staging": BIN_PICKABLE_STAGING,
+        },
+    ).fetchall()
+
+    bins_by_id = {
+        b.bin_id: {
+            "bin_id": b.bin_id,
+            "bin_code": b.bin_code,
+            "sku_count": 0,
+            "total_qty": 0,
+            "items": [],
+        }
+        for b in bin_rows
+    }
+
+    for r in inv_rows:
+        b = bins_by_id.get(r.bin_id)
+        if not b:
+            continue
+        b["sku_count"] += 1
+        b["total_qty"] += int(r.quantity_on_hand or 0)
+        b["items"].append({
+            "inventory_id": r.inventory_id,
+            "item_id": r.item_id,
+            "sku": r.sku,
+            "item_name": r.item_name,
+            "upc": r.upc,
+            "quantity_on_hand": r.quantity_on_hand,
+            "lot_number": r.lot_number,
+            "suggested_bin": r.suggested_bin,
+        })
+
+    return jsonify({
+        "warehouse_id": warehouse_id,
+        "bins": [bins_by_id[b.bin_id] for b in bin_rows],
+    })
+
+
 @putaway_bp.route("/suggest/<int:item_id>")
 @require_auth
 @with_db

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -1935,6 +1935,50 @@ class TestBinDelete:
         assert resp.status_code == 404
 
 
+class TestItemsSearchQ:
+    """The Items page search must reach the identifiers an operator
+    will type or scan: SKU, item name, primary UPC, and any entry in
+    the barcode_aliases JSONB array."""
+
+    def test_q_matches_sku(self, client, auth_headers):
+        resp = client.get("/api/admin/items?q=TST-005", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 1
+        assert all(i["sku"] == "TST-005" for i in data["items"])
+
+    def test_q_matches_upc(self, client, auth_headers):
+        # TST-005 has UPC 100000000005 in the seed.
+        resp = client.get("/api/admin/items?q=100000000005", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 1
+        assert any(i["sku"] == "TST-005" for i in data["items"])
+
+    def test_q_matches_barcode_alias(self, client, auth_headers):
+        # Attach an alternate barcode to TST-001 and confirm the
+        # search resolves it. Direct SQL because the admin create
+        # / update endpoints do not surface barcode_aliases yet.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE items SET barcode_aliases = %s::jsonb WHERE sku = 'TST-001'",
+            ('["ALT-9999-A", "ALT-9999-B"]',),
+        )
+        cur.close()
+
+        resp = client.get("/api/admin/items?q=ALT-9999-B", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 1
+        assert data["items"][0]["sku"] == "TST-001"
+
+    def test_q_no_match_returns_empty(self, client, auth_headers):
+        resp = client.get("/api/admin/items?q=no-such-thing-zzz", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.get_json()["total"] == 0
+
+
 class TestInventorySearchQ:
     """Issue #82: /admin/inventory must honour the `q` query parameter
     so the admin panel's SKU / item-name search actually filters rows."""

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -2012,6 +2012,63 @@ class TestInventorySearchQ:
         assert resp.status_code == 200
         assert resp.get_json()["total"] == baseline
 
+    def test_q_matches_upc(self, client, auth_headers):
+        # TST-005 has UPC 100000000005 in the seed. Operators scanning a
+        # barcode at the inventory page expect the row to surface even
+        # though the SKU is different.
+        resp = client.get(
+            "/api/admin/inventory?warehouse_id=1&q=100000000005",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 1
+        assert all(r["sku"] == "TST-005" for r in data["inventory"])
+
+    def test_q_matches_bin_code(self, client, auth_headers):
+        # TST-005 lives in bin A-02-02 per seed. Searching by the bin
+        # code returns the rows physically in that bin.
+        resp = client.get(
+            "/api/admin/inventory?warehouse_id=1&q=A-02-02",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 1
+        assert all(r["bin_code"] == "A-02-02" for r in data["inventory"])
+
+
+class TestInventoryBinFilter:
+    """The Inventory page exposes a bin-scoped dropdown that sends
+    bin_id; the backend has to honour it so the dropdown narrows the
+    list instead of being a silent no-op."""
+
+    def test_bin_id_filter_narrows_to_single_bin(self, client, auth_headers):
+        # Bin 11 (B-01-03) holds TST-009 and TST-010 per the shared-bin
+        # seed line; the filter should return exactly those rows.
+        resp = client.get(
+            "/api/admin/inventory?warehouse_id=1&bin_id=11",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 2
+        assert all(r["bin_id"] == 11 for r in data["inventory"])
+        skus = {r["sku"] for r in data["inventory"]}
+        assert {"TST-009", "TST-010"}.issubset(skus)
+
+    def test_bin_id_filter_with_search_intersects(self, client, auth_headers):
+        # bin_id and q must AND together: bin 11 + sku TST-010 returns
+        # only TST-010, not TST-009 which shares the bin.
+        resp = client.get(
+            "/api/admin/inventory?warehouse_id=1&bin_id=11&q=TST-010",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 1
+        assert data["inventory"][0]["sku"] == "TST-010"
+
 
 class TestVendorsCRUD:
     """Admin CRUD over the canonical vendors table: validates

--- a/api/tests/test_admin_pos.py
+++ b/api/tests/test_admin_pos.py
@@ -1,0 +1,31 @@
+"""Smoke coverage for the POS Activity admin endpoints. These are
+read-only reporting surfaces (paginated POS sales-order list + daily
+KPI counters) that LEFT JOIN audit_log for POS_CHECKOUT metadata, so
+the value here is confirming the routes register and the SQL runs and
+returns the expected shape regardless of how much POS data exists."""
+
+
+class TestPosActivityAdmin:
+    def test_pos_sales_orders_list_shape(self, client, auth_headers):
+        resp = client.get("/api/admin/pos/sales-orders", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data["sales_orders"], list)
+        for key in ("total", "page", "per_page", "pages"):
+            assert key in data
+
+    def test_pos_summary_shape(self, client, auth_headers):
+        resp = client.get("/api/admin/pos/summary", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        today = data["today"]
+        for key in (
+            "sales_count", "sales_total_cents",
+            "refund_count", "refund_total_cents",
+        ):
+            assert isinstance(today[key], int)
+        assert isinstance(data["active_terminals"], list)
+
+    def test_pos_summary_requires_auth(self, client):
+        # Unauthenticated requests are rejected before reaching the query.
+        assert client.get("/api/admin/pos/summary").status_code in (401, 403)

--- a/api/tests/test_putaway.py
+++ b/api/tests/test_putaway.py
@@ -38,6 +38,29 @@ class TestPendingPutaway:
         assert len(data["pending_items"]) == 0
 
 
+class TestStagingSummary:
+    def test_empty_staging_bins_still_render(self, client, auth_headers):
+        # Fresh seed: nothing received. The dashboard still lists every
+        # staging bin so the supervisor sees the full map, each as a
+        # zero-count card rather than an empty worklist.
+        resp = client.get("/api/putaway/staging-summary/1", headers=auth_headers)
+        assert resp.status_code == 200
+        bins = resp.get_json()["bins"]
+        assert len(bins) >= 1
+        assert all(b["sku_count"] == 0 and b["items"] == [] for b in bins)
+
+    def test_staging_summary_counts_received_inventory(self, client, auth_headers):
+        _receive_to_staging(client, auth_headers, item_id=1, quantity=10, bin_id=1)
+        resp = client.get("/api/putaway/staging-summary/1", headers=auth_headers)
+        assert resp.status_code == 200
+        bins = resp.get_json()["bins"]
+        filled = [b for b in bins if b["sku_count"] > 0]
+        assert len(filled) == 1
+        assert filled[0]["bin_id"] == 1
+        assert filled[0]["total_qty"] == 10
+        assert "TST-001" in [it["sku"] for it in filled[0]["items"]]
+
+
 class TestBinSuggestion:
     def test_suggest_returns_default_bin(self, client, auth_headers):
         # Item 1 (TST-001) has default_bin_id = 3 (A-01-01)


### PR DESCRIPTION
Adds a POS Activity admin dashboard: a paginated POS sales-order list
(order-type / terminal / cashier / date filters) and a daily KPI strip
(sales, revenue, refunds, active terminals), backed by two read-only
endpoints that LEFT JOIN audit_log for the POS_CHECKOUT metadata
(pricing / cashier / terminal).

The tab is opt-in: a pos_activity_enabled setting (default off, in
Settings > POS) gates the Outbound nav entry, so non-POS deployments
never see it.

Note: stacked on feat/admin-search-scale (#379); its commits show here
until #379 merges, after which this reduces to the two POS commits.

Skipped the fork's test-alignment commit (5a8e80b): both changes align
to AvidMax-side changes not present upstream (an inventory_update inbound
resource; an nginx.conf -> nginx.conf.template rename), so neither
applies to this repo.