### PR TITLE
feat(fraud-review): Outbound Fraud queue with opt-in address heuristic

### DIFF
--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -35,6 +35,7 @@ import Integrations from './pages/Integrations.jsx';
 import Adjustments from './pages/Adjustments.jsx';
 import InterWarehouseTransfers from './pages/InterWarehouseTransfers.jsx';
 import TransferOrders from './pages/TransferOrders.jsx';
+import POSActivity from './pages/POSActivity.jsx';
 
 function ProtectedRoute({ children }) {
   const { user, loading } = useAuth();
@@ -93,6 +94,7 @@ export default function App() {
         <Route path="/purchase-orders" element={<ErrorBoundary fallbackMessage="Could not load purchase orders."><PurchaseOrders /></ErrorBoundary>} />
         <Route path="/putaway" element={<ErrorBoundary fallbackMessage="Could not load put-away."><PutAway /></ErrorBoundary>} />
         <Route path="/sales-orders" element={<ErrorBoundary fallbackMessage="Could not load sales orders."><SalesOrders /></ErrorBoundary>} />
+        <Route path="/pos-activity" element={<ErrorBoundary fallbackMessage="Could not load POS activity."><POSActivity /></ErrorBoundary>} />
         <Route path="/picking-tickets" element={<ErrorBoundary fallbackMessage="Could not load picking tickets."><PickingTickets /></ErrorBoundary>} />
         {/* The /picking, /packing, /shipping admin pages were retired:
             the workflow lives on the handheld scanners, and the

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -36,6 +36,7 @@ import Adjustments from './pages/Adjustments.jsx';
 import InterWarehouseTransfers from './pages/InterWarehouseTransfers.jsx';
 import TransferOrders from './pages/TransferOrders.jsx';
 import POSActivity from './pages/POSActivity.jsx';
+import Fraud from './pages/Fraud.jsx';
 
 function ProtectedRoute({ children }) {
   const { user, loading } = useAuth();
@@ -95,6 +96,7 @@ export default function App() {
         <Route path="/putaway" element={<ErrorBoundary fallbackMessage="Could not load put-away."><PutAway /></ErrorBoundary>} />
         <Route path="/sales-orders" element={<ErrorBoundary fallbackMessage="Could not load sales orders."><SalesOrders /></ErrorBoundary>} />
         <Route path="/pos-activity" element={<ErrorBoundary fallbackMessage="Could not load POS activity."><POSActivity /></ErrorBoundary>} />
+        <Route path="/fraud" element={<ErrorBoundary fallbackMessage="Could not load fraud queue."><Fraud /></ErrorBoundary>} />
         <Route path="/picking-tickets" element={<ErrorBoundary fallbackMessage="Could not load picking tickets."><PickingTickets /></ErrorBoundary>} />
         {/* The /picking, /packing, /shipping admin pages were retired:
             the workflow lives on the handheld scanners, and the

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -33,6 +33,7 @@ const NAV = [
     items: [
       { to: '/sales-orders', label: 'Sales Orders', pageKey: 'sales-orders' },
       { to: '/pos-activity', label: 'POS Activity' },
+      { to: '/fraud', label: 'Fraud', pageKey: 'fraud' },
       { to: '/picking-tickets', label: 'Picking Tickets', pageKey: 'picking-tickets' },
       // Picking/Packing/Shipping are mobile-only: the admin-side
       // mirrors were retired. Supervisors use Sales Orders + Picking

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -32,6 +32,7 @@ const NAV = [
     label: 'Outbound',
     items: [
       { to: '/sales-orders', label: 'Sales Orders', pageKey: 'sales-orders' },
+      { to: '/pos-activity', label: 'POS Activity' },
       { to: '/picking-tickets', label: 'Picking Tickets', pageKey: 'picking-tickets' },
       // Picking/Packing/Shipping are mobile-only: the admin-side
       // mirrors were retired. Supervisors use Sales Orders + Picking

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -75,6 +75,25 @@ export default function Sidebar() {
   const { user } = useAuth();
   const { warehouseId } = useWarehouse();
   const [counts, setCounts] = useState({});
+  // The POS Activity tab is opt-in via the pos_activity_enabled setting
+  // so non-POS deployments never see it. Default false: the entry is
+  // hidden until an operator turns it on in Settings > POS. Silent on
+  // permission denial so a USER without the settings grant just gets
+  // the default (hidden) rather than a Permissions Error popup.
+  const [posActivityEnabled, setPosActivityEnabled] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.get(
+      '/admin/settings/pos_activity_enabled',
+      { silentPermissionDenied: true },
+    ).then(async (res) => {
+      if (!res?.ok || cancelled) return;
+      const data = await res.json();
+      setPosActivityEnabled(data?.value === 'true');
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     if (!warehouseId) return;
@@ -103,7 +122,12 @@ export default function Sidebar() {
     });
   }, [location.pathname, warehouseId]);
 
-  const navGroups = NAV;
+  const navGroups = posActivityEnabled
+    ? NAV
+    : NAV.map((group) => ({
+        ...group,
+        items: group.items.filter((item) => item.to !== '/pos-activity'),
+      }));
 
   return (
     <nav className="sidebar">

--- a/admin/src/pages/Adjustments.jsx
+++ b/admin/src/pages/Adjustments.jsx
@@ -5,8 +5,14 @@ import PageHeader from '../components/PageHeader.jsx';
 
 export default function Adjustments() {
   const { warehouseId } = useWarehouse();
-  const [bins, setBins] = useState([]);
-  const [items, setItems] = useState([]);
+  // Bin + item lookups switched from
+  // "load every row client-side and filter in JS" to debounced
+  // server-side search. The old loadBins() defaulted to per_page=50
+  // so a 3000-bin warehouse only showed the first batch; loadItems()
+  // capped at 1000 which broke at 30K SKUs in production. Both now
+  // hit the server's ILIKE :q index path on each keystroke.
+  const [binResults, setBinResults] = useState([]);
+  const [itemResults, setItemResults] = useState([]);
   const [adjustments, setAdjustments] = useState([]);
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -15,8 +21,10 @@ export default function Adjustments() {
 
   const [binSearch, setBinSearch] = useState('');
   const [binOpen, setBinOpen] = useState(false);
+  const [binSearching, setBinSearching] = useState(false);
   const [itemSearch, setItemSearch] = useState('');
   const [itemOpen, setItemOpen] = useState(false);
+  const [itemSearching, setItemSearching] = useState(false);
   const binRef = useRef(null);
   const itemRef = useRef(null);
 
@@ -39,26 +47,59 @@ export default function Adjustments() {
   }, []);
 
   useEffect(() => {
-    loadBins();
-    loadItems();
     loadAdjustments();
-  }, [warehouseId]);
+    // Clear selections when the warehouse switches so the operator
+    // does not accidentally apply an adjustment to a bin in a
+    // warehouse they no longer have on screen.
+    setForm((p) => ({ ...p, bin_id: '', item_id: '' }));
+    setBinSearch('');
+    setItemSearch('');
+    setBinResults([]);
+    setItemResults([]);
+  }, [warehouseId]);  // eslint-disable-line react-hooks/exhaustive-deps
 
-  async function loadBins() {
-    const res = await api.get(`/admin/bins?warehouse_id=${warehouseId}`);
-    if (res?.ok) {
-      const data = await res.json();
-      setBins(data.bins || []);
+  // Debounced bin search. Triggers when the operator types in the
+  // bin field; ignores empty / one-char queries to avoid round-tripping
+  // on every focus. 200 ms matches the PO line typeahead.
+  useEffect(() => {
+    const q = binSearch.trim();
+    if (!warehouseId || q.length < 1 || form.bin_id) {
+      setBinResults([]);
+      return;
     }
-  }
+    setBinSearching(true);
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/bins?warehouse_id=${warehouseId}&q=${encodeURIComponent(q)}&per_page=25`,
+      );
+      setBinSearching(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setBinResults(data.bins || []);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [binSearch, warehouseId, form.bin_id]);
 
-  async function loadItems() {
-    const res = await api.get(`/admin/items?warehouse_id=${warehouseId}&per_page=1000`);
-    if (res?.ok) {
-      const data = await res.json();
-      setItems(data.items || []);
+  // Same shape for items. Three-char minimum keeps the 30K-SKU
+  // catalog from returning huge result sets on a two-letter prefix.
+  useEffect(() => {
+    const q = itemSearch.trim();
+    if (q.length < 2 || form.item_id) {
+      setItemResults([]);
+      return;
     }
-  }
+    setItemSearching(true);
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/items?q=${encodeURIComponent(q)}&per_page=25&active=true`,
+      );
+      setItemSearching(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setItemResults(data.items || []);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [itemSearch, form.item_id]);
 
   async function loadAdjustments() {
     setLoading(true);
@@ -85,15 +126,6 @@ export default function Adjustments() {
     setItemSearch(`${item.sku}  -  ${item.item_name}`);
     setItemOpen(false);
   }
-
-  const filteredBins = bins.filter((b) =>
-    b.bin_code.toLowerCase().includes(binSearch.toLowerCase())
-  );
-
-  const filteredItems = items.filter((i) => {
-    const q = itemSearch.toLowerCase();
-    return i.sku.toLowerCase().includes(q) || (i.item_name || '').toLowerCase().includes(q);
-  });
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -165,43 +197,53 @@ export default function Adjustments() {
         <form onSubmit={handleSubmit}>
           <div className="form-row">
             <div className="form-group" ref={binRef} style={{ position: 'relative' }}>
-              <label>Bin</label>
+              <label>Bin {binSearching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
               <input
-                className="form-input"
-                placeholder="Search bins..."
+                className="form-input mono"
+                placeholder="Type bin code to search"
                 value={binSearch}
                 onChange={(e) => { setBinSearch(e.target.value); updateForm('bin_id', ''); setBinOpen(true); }}
                 onFocus={() => setBinOpen(true)}
                 autoComplete="off"
               />
-              {binOpen && filteredBins.length > 0 && (
+              {binOpen && binResults.length > 0 && (
                 <div style={dropdownStyle}>
-                  {filteredBins.slice(0, 50).map((b) => (
+                  {binResults.map((b) => (
                     <div key={b.bin_id} style={dropdownItemStyle} onMouseDown={() => selectBin(b)}>
-                      {b.bin_code} {b.bin_type ? `(${b.bin_type})` : ''}
+                      <span className="mono">{b.bin_code}</span> {b.bin_type ? `(${b.bin_type})` : ''}
                     </div>
                   ))}
+                </div>
+              )}
+              {binOpen && !binSearching && binSearch.trim().length >= 1 && !form.bin_id && binResults.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No bins match "{binSearch.trim()}" in this warehouse.
                 </div>
               )}
             </div>
 
             <div className="form-group" ref={itemRef} style={{ position: 'relative' }}>
-              <label>Item</label>
+              <label>Item {itemSearching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
               <input
                 className="form-input"
-                placeholder="Search SKU or name..."
+                placeholder="Type SKU or item name (min 2 chars)"
                 value={itemSearch}
                 onChange={(e) => { setItemSearch(e.target.value); updateForm('item_id', ''); setItemOpen(true); }}
                 onFocus={() => setItemOpen(true)}
                 autoComplete="off"
               />
-              {itemOpen && filteredItems.length > 0 && (
+              {itemOpen && itemResults.length > 0 && (
                 <div style={dropdownStyle}>
-                  {filteredItems.slice(0, 50).map((i) => (
+                  {itemResults.map((i) => (
                     <div key={i.item_id} style={dropdownItemStyle} onMouseDown={() => selectItem(i)}>
-                      <strong>{i.sku}</strong>  -  {i.item_name}
+                      <strong className="mono">{i.sku}</strong>  -  {i.item_name}
                     </div>
                   ))}
+                </div>
+              )}
+              {itemOpen && !itemSearching && itemSearch.trim().length >= 2 && !form.item_id && itemResults.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No items match "{itemSearch.trim()}".
                 </div>
               )}
             </div>

--- a/admin/src/pages/Bins.jsx
+++ b/admin/src/pages/Bins.jsx
@@ -13,6 +13,8 @@ export default function Bins() {
   const [searchParams] = useSearchParams();
   const [search, setSearch] = useState(searchParams.get('q') || '');
   const [bins, setBins] = useState([]);
+  const [pagination, setPagination] = useState(null);
+  const [page, setPage] = useState(1);
   const [zones, setZones] = useState([]);
   const [selected, setSelected] = useState(null);
   const [detail, setDetail] = useState(null);
@@ -21,16 +23,76 @@ export default function Bins() {
   const [form, setForm] = useState({});
   const [error, setError] = useState('');
   const [deleteTarget, setDeleteTarget] = useState(null);
+  const [exporting, setExporting] = useState(false);
 
-  useEffect(() => { if (warehouseId) { loadBins(); loadZones(); } }, [warehouseId, search]);  // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { if (warehouseId) { loadBins(); loadZones(); } }, [warehouseId, search, page]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   async function loadBins() {
-    const params = new URLSearchParams({ warehouse_id: String(warehouseId) });
+    const params = new URLSearchParams({ warehouse_id: String(warehouseId), page, per_page: 50 });
     if (search) params.set('q', search);
     const res = await api.get(`/admin/bins?${params}`);
     if (res?.ok) {
       const data = await res.json();
       setBins(data.bins || []);
+      setPagination({ page: data.page, pages: data.pages, total: data.total, per_page: data.per_page });
+    }
+  }
+
+  // Walks all pages and downloads the full result set as CSV. Sentry's
+  // admin/bins endpoint caps page_size at 50 regardless of `per_page`,
+  // so we paginate server-side and concat client-side. CSV mirrors the
+  // BinImportRow schema (bin_code, bin_barcode, zone, warehouse_id,
+  // bin_type, aisle, pick_sequence, putaway_sequence, description) so
+  // an exported file is round-trip-importable via /admin/import/bins.
+  async function exportCsv() {
+    setExporting(true);
+    try {
+      const all = [];
+      let p = 1;
+      // Hard stop at 200 pages (=10k bins) to avoid runaway
+      while (p <= 200) {
+        const params = new URLSearchParams({ warehouse_id: String(warehouseId), page: p, per_page: 50 });
+        if (search) params.set('q', search);
+        const res = await api.get(`/admin/bins?${params}`);
+        if (!res?.ok) break;
+        const data = await res.json();
+        all.push(...(data.bins || []));
+        if (p >= (data.pages || 1)) break;
+        p += 1;
+      }
+      const headers = ['bin_code','bin_barcode','zone','warehouse_id','bin_type','aisle','pick_sequence','putaway_sequence','description'];
+      const csvEscape = (v) => {
+        if (v == null) return '';
+        const s = String(v);
+        return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+      };
+      const lines = [headers.join(',')];
+      for (const b of all) {
+        lines.push([
+          csvEscape(b.bin_code),
+          csvEscape(b.bin_barcode),
+          csvEscape(b.zone_name || b.zone || ''),
+          csvEscape(b.warehouse_id ?? warehouseId),
+          csvEscape(b.bin_type),
+          csvEscape(b.aisle ?? ''),
+          csvEscape(b.pick_sequence ?? ''),
+          csvEscape(b.putaway_sequence ?? ''),
+          csvEscape(b.description ?? ''),
+        ].join(','));
+      }
+      const csv = lines.join('\n');
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      const today = new Date().toISOString().split('T')[0];
+      link.download = `bins_warehouse${warehouseId}_${today}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } finally {
+      setExporting(false);
     }
   }
 
@@ -173,11 +235,20 @@ export default function Bins() {
           style={{ maxWidth: 320, marginRight: 8 }}
           placeholder="Search by bin code or barcode"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
         />
+        <button
+          className="btn"
+          onClick={exportCsv}
+          disabled={exporting || !pagination?.total}
+          style={{ marginRight: 8 }}
+          title="Export current filter to CSV"
+        >
+          {exporting ? 'Exporting…' : 'Export CSV'}
+        </button>
         <button className="btn btn-primary" onClick={() => { setForm({ is_active: true }); setShowCreate(true); setError(''); }}>New Bin</button>
       </PageHeader>
-      <DataTable columns={columns} data={bins} onRowClick={viewBin} />
+      <DataTable columns={columns} data={bins} pagination={pagination} onPageChange={setPage} onRowClick={viewBin} />
 
       {selected && detail && !editing && (
         <Modal title={`Bin ${detail.bin_code}`} onClose={() => { setSelected(null); setDetail(null); setError(''); }}

--- a/admin/src/pages/Fraud.jsx
+++ b/admin/src/pages/Fraud.jsx
@@ -1,0 +1,170 @@
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '../api.js';
+import { useWarehouse } from '../warehouse.jsx';
+import DataTable from '../components/DataTable.jsx';
+import PageHeader from '../components/PageHeader.jsx';
+
+// Renders one address as a 2-line summary -- street on line 1, city
+// state postal on line 2. Used inline in the fraud row so the CSR
+// can eyeball the mismatch without opening anything.
+function AddressSummary({ line1, line2, city, state, postalCode }) {
+  const street = [line1, line2].filter(Boolean).join(', ');
+  const cityLine = [city, state, postalCode].filter(Boolean).join(' ');
+  if (!street && !cityLine) return <span style={{ color: '#999' }}>(blank)</span>;
+  return (
+    <div style={{ fontSize: 12, lineHeight: 1.35 }}>
+      {street && <div>{street}</div>}
+      {cityLine && <div>{cityLine}</div>}
+    </div>
+  );
+}
+
+function MemoCell({ soId, initial, onSaved }) {
+  const [value, setValue] = useState(initial || '');
+  const [savedValue, setSavedValue] = useState(initial || '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  async function commit() {
+    if (value === savedValue) return;
+    setSaving(true);
+    setError('');
+    const res = await api.patch(`/admin/sales-orders/${soId}/memo`, { memo: value });
+    setSaving(false);
+    if (!res?.ok) {
+      setError('Save failed');
+      return;
+    }
+    setSavedValue(value);
+    onSaved?.(value);
+  }
+
+  return (
+    <div onClick={(e) => e.stopPropagation()}>
+      <textarea
+        className="form-input"
+        rows={2}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        placeholder="CSR notes…"
+        style={{ width: '100%', minWidth: 240, fontSize: 12, resize: 'vertical' }}
+      />
+      {saving && <div style={{ fontSize: 11, color: '#666' }}>Saving…</div>}
+      {error && <div className="form-error" style={{ fontSize: 11 }}>{error}</div>}
+    </div>
+  );
+}
+
+export default function Fraud() {
+  const { warehouseId } = useWarehouse();
+  const [orders, setOrders] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [actionError, setActionError] = useState('');
+
+  const load = useCallback(async () => {
+    if (!warehouseId) return;
+    setLoading(true);
+    const qs = new URLSearchParams({
+      status: 'FRAUD_REVIEW',
+      warehouse_id: String(warehouseId),
+      per_page: '100',
+    });
+    const res = await api.get(`/admin/sales-orders?${qs.toString()}`);
+    if (res?.ok) {
+      const data = await res.json();
+      setOrders(data.sales_orders || []);
+    }
+    setLoading(false);
+  }, [warehouseId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function pushToQueue(soId) {
+    setActionError('');
+    const res = await api.post(`/admin/sales-orders/${soId}/push-to-queue`);
+    if (!res?.ok) {
+      setActionError(`Could not push order ${soId} to queue.`);
+      return;
+    }
+    setOrders((prev) => prev.filter((o) => o.so_id !== soId));
+  }
+
+  const columns = [
+    { key: 'so_number', label: 'SO Number', mono: true },
+    { key: 'customer_name', label: 'Customer' },
+    {
+      key: 'billing',
+      label: 'Billing',
+      render: (r) => (
+        <AddressSummary
+          line1={r.billing_address_line1}
+          line2={r.billing_address_line2}
+          city={r.billing_address_city}
+          state={r.billing_address_state}
+          postalCode={r.billing_address_postal_code}
+        />
+      ),
+    },
+    {
+      key: 'shipping',
+      label: 'Shipping',
+      render: (r) => (
+        <AddressSummary
+          line1={r.shipping_address_line1}
+          line2={r.shipping_address_line2}
+          city={r.shipping_address_city}
+          state={r.shipping_address_state}
+          postalCode={r.shipping_address_postal_code}
+        />
+      ),
+    },
+    {
+      key: 'memo',
+      label: 'Memo',
+      render: (r) => (
+        <MemoCell
+          soId={r.so_id}
+          initial={r.memo}
+          onSaved={(v) => setOrders((prev) => prev.map(
+            (o) => (o.so_id === r.so_id ? { ...o, memo: v } : o),
+          ))}
+        />
+      ),
+    },
+    {
+      key: 'actions',
+      label: '',
+      render: (r) => (
+        <button
+          className="btn btn-sm btn-primary"
+          onClick={(e) => {
+            e.stopPropagation();
+            pushToQueue(r.so_id);
+          }}
+        >Push to queue</button>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <PageHeader title="Fraud Review" />
+      {actionError && (
+        <div className="section">
+          <div className="form-error">{actionError}</div>
+        </div>
+      )}
+      <div className="section">
+        <div className="section-title">
+          Orders flagged at ingest{!loading && ` (${orders.length})`}
+        </div>
+        <DataTable
+          columns={columns}
+          data={orders}
+          emptyMessage={loading ? 'Loading…' : 'No flagged orders'}
+        />
+      </div>
+    </div>
+  );
+}

--- a/admin/src/pages/InterWarehouseTransfers.jsx
+++ b/admin/src/pages/InterWarehouseTransfers.jsx
@@ -1,12 +1,61 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { api } from '../api.js';
 import PageHeader from '../components/PageHeader.jsx';
 
+// Bin + item lookups switched from preloaded
+// dropdowns to debounced server-side search so 30K SKUs and 3K bins
+// stop hiding past the per_page cutoff. Same pattern as Adjustments.
+// The two bin pickers (source + dest) operate independently
+// so a transfer between two large warehouses no longer blocks on a
+// 50-row default.
+
+const dropdownStyle = {
+  position: 'absolute',
+  top: '100%',
+  left: 0,
+  right: 0,
+  maxHeight: 200,
+  overflowY: 'auto',
+  background: '#fff',
+  border: '1px solid #ddd',
+  borderRadius: 8,
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+  zIndex: 100,
+};
+
+const dropdownItemStyle = {
+  padding: '8px 12px',
+  cursor: 'pointer',
+  borderBottom: '1px solid #f0f0f0',
+  fontSize: 13,
+};
+
+function useDebouncedBinSearch(warehouseId, query, selectedId) {
+  const [results, setResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  useEffect(() => {
+    const q = (query || '').trim();
+    if (!warehouseId || q.length < 1 || selectedId) {
+      setResults([]);
+      return;
+    }
+    setSearching(true);
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/bins?warehouse_id=${warehouseId}&q=${encodeURIComponent(q)}&per_page=25`,
+      );
+      setSearching(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setResults(data.bins || []);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [warehouseId, query, selectedId]);
+  return { results, searching };
+}
+
 export default function InterWarehouseTransfers() {
   const [warehouses, setWarehouses] = useState([]);
-  const [sourceBins, setSourceBins] = useState([]);
-  const [destBins, setDestBins] = useState([]);
-  const [items, setItems] = useState([]);
   const [transfers, setTransfers] = useState([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -21,31 +70,74 @@ export default function InterWarehouseTransfers() {
     quantity: '',
   });
 
+  // Typeahead state per lookup field.
+  const [sourceBinSearch, setSourceBinSearch] = useState('');
+  const [sourceBinOpen, setSourceBinOpen] = useState(false);
+  const [destBinSearch, setDestBinSearch] = useState('');
+  const [destBinOpen, setDestBinOpen] = useState(false);
+  const [itemSearch, setItemSearch] = useState('');
+  const [itemOpen, setItemOpen] = useState(false);
+  const [itemResults, setItemResults] = useState([]);
+  const [itemSearching, setItemSearching] = useState(false);
+  const sourceBinRef = useRef(null);
+  const destBinRef = useRef(null);
+  const itemRef = useRef(null);
+
+  const sourceBinQuery = useDebouncedBinSearch(
+    form.source_warehouse_id, sourceBinSearch, form.source_bin_id,
+  );
+  const destBinQuery = useDebouncedBinSearch(
+    form.destination_warehouse_id, destBinSearch, form.destination_bin_id,
+  );
+
+  // Item search is warehouse-agnostic at the catalog level - the
+  // transfer endpoint validates that the chosen item actually has
+  // inventory in the source bin, so an unrelated catalog match just
+  // bounces back with a clear error.
+  useEffect(() => {
+    const q = itemSearch.trim();
+    if (q.length < 2 || form.item_id) {
+      setItemResults([]);
+      return;
+    }
+    setItemSearching(true);
+    const handle = setTimeout(async () => {
+      const res = await api.get(
+        `/admin/items?q=${encodeURIComponent(q)}&per_page=25&active=true`,
+      );
+      setItemSearching(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setItemResults(data.items || []);
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [itemSearch, form.item_id]);
+
+  useEffect(() => {
+    function handleClick(e) {
+      if (sourceBinRef.current && !sourceBinRef.current.contains(e.target)) setSourceBinOpen(false);
+      if (destBinRef.current && !destBinRef.current.contains(e.target)) setDestBinOpen(false);
+      if (itemRef.current && !itemRef.current.contains(e.target)) setItemOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
   useEffect(() => {
     loadWarehouses();
     loadTransfers();
   }, []);
 
-  // Load source bins and items when source warehouse changes
+  // Reset source bin selection when source warehouse changes so a
+  // stale (warehouse A, bin from B) state cannot reach the submit.
   useEffect(() => {
-    if (form.source_warehouse_id) {
-      loadBins(form.source_warehouse_id, 'source');
-      loadItems(form.source_warehouse_id);
-    } else {
-      setSourceBins([]);
-      setItems([]);
-    }
-    setForm((f) => ({ ...f, source_bin_id: '', item_id: '' }));
+    setForm((f) => ({ ...f, source_bin_id: '' }));
+    setSourceBinSearch('');
   }, [form.source_warehouse_id]);
 
-  // Load dest bins when destination warehouse changes
   useEffect(() => {
-    if (form.destination_warehouse_id) {
-      loadBins(form.destination_warehouse_id, 'dest');
-    } else {
-      setDestBins([]);
-    }
     setForm((f) => ({ ...f, destination_bin_id: '' }));
+    setDestBinSearch('');
   }, [form.destination_warehouse_id]);
 
   async function loadWarehouses() {
@@ -53,23 +145,6 @@ export default function InterWarehouseTransfers() {
     if (res?.ok) {
       const data = await res.json();
       setWarehouses(data.warehouses || []);
-    }
-  }
-
-  async function loadBins(warehouseId, target) {
-    const res = await api.get(`/admin/bins?warehouse_id=${warehouseId}`);
-    if (res?.ok) {
-      const data = await res.json();
-      if (target === 'source') setSourceBins(data.bins || []);
-      else setDestBins(data.bins || []);
-    }
-  }
-
-  async function loadItems(warehouseId) {
-    const res = await api.get(`/admin/items?warehouse_id=${warehouseId}&per_page=1000`);
-    if (res?.ok) {
-      const data = await res.json();
-      setItems(data.items || []);
     }
   }
 
@@ -83,6 +158,24 @@ export default function InterWarehouseTransfers() {
 
   function updateField(key, value) {
     setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  function selectSourceBin(b) {
+    setForm((f) => ({ ...f, source_bin_id: b.bin_id }));
+    setSourceBinSearch(b.bin_code);
+    setSourceBinOpen(false);
+  }
+
+  function selectDestBin(b) {
+    setForm((f) => ({ ...f, destination_bin_id: b.bin_id }));
+    setDestBinSearch(b.bin_code);
+    setDestBinOpen(false);
+  }
+
+  function selectItem(i) {
+    setForm((f) => ({ ...f, item_id: i.item_id }));
+    setItemSearch(`${i.sku}  -  ${i.item_name}`);
+    setItemOpen(false);
   }
 
   async function handleSubmit(e) {
@@ -115,6 +208,9 @@ export default function InterWarehouseTransfers() {
         const data = await res.json();
         setSuccess(data.message || 'Transfer created successfully.');
         setForm({ source_warehouse_id: '', source_bin_id: '', destination_warehouse_id: '', destination_bin_id: '', item_id: '', quantity: '' });
+        setSourceBinSearch('');
+        setDestBinSearch('');
+        setItemSearch('');
         loadTransfers();
       } else {
         const data = await res.json().catch(() => null);
@@ -157,14 +253,31 @@ export default function InterWarehouseTransfers() {
                 ))}
               </select>
             </div>
-            <div className="form-group">
-              <label>Source Bin</label>
-              <select className="form-select" value={form.source_bin_id} onChange={(e) => updateField('source_bin_id', e.target.value)} disabled={!form.source_warehouse_id}>
-                <option value="">Select bin...</option>
-                {sourceBins.map((b) => (
-                  <option key={b.bin_id} value={b.bin_id}>{b.bin_code} ({b.bin_type})</option>
-                ))}
-              </select>
+            <div className="form-group" ref={sourceBinRef} style={{ position: 'relative' }}>
+              <label>Source Bin {sourceBinQuery.searching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
+              <input
+                className="form-input mono"
+                placeholder={form.source_warehouse_id ? 'Type bin code to search' : 'Pick warehouse first'}
+                value={sourceBinSearch}
+                onChange={(e) => { setSourceBinSearch(e.target.value); updateField('source_bin_id', ''); setSourceBinOpen(true); }}
+                onFocus={() => setSourceBinOpen(true)}
+                disabled={!form.source_warehouse_id}
+                autoComplete="off"
+              />
+              {sourceBinOpen && sourceBinQuery.results.length > 0 && (
+                <div style={dropdownStyle}>
+                  {sourceBinQuery.results.map((b) => (
+                    <div key={b.bin_id} style={dropdownItemStyle} onMouseDown={() => selectSourceBin(b)}>
+                      <span className="mono">{b.bin_code}</span> {b.bin_type ? `(${b.bin_type})` : ''}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {sourceBinOpen && !sourceBinQuery.searching && sourceBinSearch.trim().length >= 1 && !form.source_bin_id && sourceBinQuery.results.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No bins match "{sourceBinSearch.trim()}" in this warehouse.
+                </div>
+              )}
             </div>
           </div>
 
@@ -178,26 +291,59 @@ export default function InterWarehouseTransfers() {
                 ))}
               </select>
             </div>
-            <div className="form-group">
-              <label>Destination Bin</label>
-              <select className="form-select" value={form.destination_bin_id} onChange={(e) => updateField('destination_bin_id', e.target.value)} disabled={!form.destination_warehouse_id}>
-                <option value="">Select bin...</option>
-                {destBins.map((b) => (
-                  <option key={b.bin_id} value={b.bin_id}>{b.bin_code} ({b.bin_type})</option>
-                ))}
-              </select>
+            <div className="form-group" ref={destBinRef} style={{ position: 'relative' }}>
+              <label>Destination Bin {destBinQuery.searching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
+              <input
+                className="form-input mono"
+                placeholder={form.destination_warehouse_id ? 'Type bin code to search' : 'Pick warehouse first'}
+                value={destBinSearch}
+                onChange={(e) => { setDestBinSearch(e.target.value); updateField('destination_bin_id', ''); setDestBinOpen(true); }}
+                onFocus={() => setDestBinOpen(true)}
+                disabled={!form.destination_warehouse_id}
+                autoComplete="off"
+              />
+              {destBinOpen && destBinQuery.results.length > 0 && (
+                <div style={dropdownStyle}>
+                  {destBinQuery.results.map((b) => (
+                    <div key={b.bin_id} style={dropdownItemStyle} onMouseDown={() => selectDestBin(b)}>
+                      <span className="mono">{b.bin_code}</span> {b.bin_type ? `(${b.bin_type})` : ''}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {destBinOpen && !destBinQuery.searching && destBinSearch.trim().length >= 1 && !form.destination_bin_id && destBinQuery.results.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No bins match "{destBinSearch.trim()}" in this warehouse.
+                </div>
+              )}
             </div>
           </div>
 
           <div className="form-row">
-            <div className="form-group">
-              <label>Item</label>
-              <select className="form-select" value={form.item_id} onChange={(e) => updateField('item_id', e.target.value)} disabled={!form.source_warehouse_id}>
-                <option value="">Select item...</option>
-                {items.map((i) => (
-                  <option key={i.item_id} value={i.item_id}>{i.sku}  -  {i.item_name}</option>
-                ))}
-              </select>
+            <div className="form-group" ref={itemRef} style={{ position: 'relative' }}>
+              <label>Item {itemSearching && <span style={{ fontSize: 11, color: 'var(--text-secondary)' }}>(searching...)</span>}</label>
+              <input
+                className="form-input"
+                placeholder="Type SKU or item name (min 2 chars)"
+                value={itemSearch}
+                onChange={(e) => { setItemSearch(e.target.value); updateField('item_id', ''); setItemOpen(true); }}
+                onFocus={() => setItemOpen(true)}
+                autoComplete="off"
+              />
+              {itemOpen && itemResults.length > 0 && (
+                <div style={dropdownStyle}>
+                  {itemResults.map((i) => (
+                    <div key={i.item_id} style={dropdownItemStyle} onMouseDown={() => selectItem(i)}>
+                      <strong className="mono">{i.sku}</strong>  -  {i.item_name}
+                    </div>
+                  ))}
+                </div>
+              )}
+              {itemOpen && !itemSearching && itemSearch.trim().length >= 2 && !form.item_id && itemResults.length === 0 && (
+                <div style={{ ...dropdownStyle, padding: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+                  No items match "{itemSearch.trim()}".
+                </div>
+              )}
             </div>
             <div className="form-group">
               <label>Quantity</label>

--- a/admin/src/pages/Inventory.jsx
+++ b/admin/src/pages/Inventory.jsx
@@ -4,8 +4,21 @@ import { useWarehouse } from '../warehouse.jsx';
 import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 
+// Page-level warehouse + bin filters were added on 2026-05-10 because the
+// global topbar warehouse-picker was unreliable for some users (couldn't
+// click into the dropdown), making cross-warehouse inventory inspection
+// impossible. The page-level filters seed from the topbar context (so
+// existing behavior is unchanged for users who were using the topbar) but
+// can be independently changed without affecting global state. Bin filter
+// is new - the underlying API endpoint already supports bin_id query
+// param; the UI just never exposed it.
+
 export default function Inventory() {
-  const { warehouseId } = useWarehouse();
+  const { warehouseId: topbarWarehouseId } = useWarehouse();
+  const [warehouses, setWarehouses] = useState([]);
+  const [bins, setBins] = useState([]);
+  const [warehouseFilter, setWarehouseFilter] = useState(topbarWarehouseId || null);
+  const [binFilter, setBinFilter] = useState(null);
   const [data, setData] = useState([]);
   const [pagination, setPagination] = useState(null);
   const [page, setPage] = useState(1);
@@ -13,18 +26,63 @@ export default function Inventory() {
   const [search, setSearch] = useState('');
   const [sortKey, setSortKey] = useState(null);
   const [sortDir, setSortDir] = useState('asc');
+  const [loading, setLoading] = useState(false);
 
+  // Load all warehouses once for the filter dropdown. Independent of topbar
+  // context so the page-level filter works even if topbar picker doesn't.
   useEffect(() => {
-    if (!warehouseId) return;
-    const params = new URLSearchParams({ warehouse_id: warehouseId, page, per_page: 50 });
+    api.get('/admin/warehouses').then(async (res) => {
+      if (!res?.ok) return;
+      const json = await res.json();
+      const list = json.warehouses || [];
+      setWarehouses(list);
+      // If the topbar didn't set a warehouseId but warehouses are available,
+      // default to the first one so the inventory query has a target.
+      if (!warehouseFilter && list.length > 0) {
+        const firstId = list[0].warehouse_id || list[0].id;
+        setWarehouseFilter(firstId);
+      }
+    });
+  }, []);
+
+  // Load bins for the selected warehouse so the bin-filter dropdown is
+  // scoped (avoids showing bins from other warehouses that don't apply).
+  useEffect(() => {
+    if (!warehouseFilter) {
+      setBins([]);
+      setBinFilter(null);
+      return;
+    }
+    const params = new URLSearchParams({ warehouse_id: warehouseFilter, per_page: 200 });
+    api.get(`/admin/bins?${params}`).then(async (res) => {
+      if (!res?.ok) return;
+      const json = await res.json();
+      setBins(json.bins || []);
+      // Reset bin filter if the previously-selected bin doesn't belong to
+      // the new warehouse (prevents stale filter rejecting all results).
+      if (binFilter) {
+        const list = json.bins || [];
+        const stillValid = list.some((b) => (b.bin_id || b.id) === binFilter);
+        if (!stillValid) setBinFilter(null);
+      }
+    });
+  }, [warehouseFilter]);
+
+  // Run the inventory query whenever any filter changes.
+  useEffect(() => {
+    if (!warehouseFilter) return;
+    const params = new URLSearchParams({ warehouse_id: warehouseFilter, page, per_page: 50 });
+    if (binFilter) params.set('bin_id', binFilter);
     if (search) params.set('q', search);
+    setLoading(true);
     api.get(`/admin/inventory?${params}`).then(async (res) => {
+      setLoading(false);
       if (!res?.ok) return;
       const json = await res.json();
       setData(json.inventory || []);
       setPagination({ page: json.page, pages: json.pages, total: json.total, per_page: json.per_page });
     });
-  }, [page, search, warehouseId]);
+  }, [page, search, warehouseFilter, binFilter]);
 
   function commitSearch() {
     setSearch(searchInput);
@@ -67,7 +125,40 @@ export default function Inventory() {
   return (
     <div>
       <PageHeader title="Inventory" />
-      <div className="filter-bar">
+      <div className="filter-bar" style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+        <select
+          className="form-input"
+          value={warehouseFilter || ''}
+          onChange={(e) => { setWarehouseFilter(Number(e.target.value) || null); setPage(1); }}
+          style={{ minWidth: 180 }}
+        >
+          <option value="">- Select warehouse -</option>
+          {warehouses.map((w) => {
+            const wId = w.warehouse_id || w.id;
+            return (
+              <option key={wId} value={wId}>
+                {(w.warehouse_code || w.code)} - {(w.warehouse_name || w.name)}
+              </option>
+            );
+          })}
+        </select>
+        <select
+          className="form-input"
+          value={binFilter || ''}
+          onChange={(e) => { setBinFilter(Number(e.target.value) || null); setPage(1); }}
+          style={{ minWidth: 200 }}
+          disabled={!warehouseFilter || bins.length === 0}
+        >
+          <option value="">- All bins in warehouse -</option>
+          {bins.map((b) => {
+            const bId = b.bin_id || b.id;
+            return (
+              <option key={bId} value={bId}>
+                {b.bin_code}{b.zone_name ? ` (${b.zone_name})` : ''}
+              </option>
+            );
+          })}
+        </select>
         <input
           className="form-input"
           placeholder="Search by SKU or item name (press Enter)"
@@ -75,17 +166,26 @@ export default function Inventory() {
           onChange={(e) => setSearchInput(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') commitSearch(); }}
           onBlur={commitSearch}
+          style={{ minWidth: 280, flex: 1 }}
         />
+        {loading && <span style={{ color: 'rgba(255,255,255,0.5)', fontSize: 12 }}>Loading…</span>}
       </div>
-      <DataTable
-        columns={columns}
-        data={sorted}
-        pagination={pagination}
-        onPageChange={setPage}
-        sortKey={sortKey}
-        sortDir={sortDir}
-        onSort={handleSort}
-      />
+      {!warehouseFilter && (
+        <div style={{ padding: 24, color: 'rgba(255,255,255,0.5)', fontSize: 13 }}>
+          Select a warehouse to view inventory.
+        </div>
+      )}
+      {warehouseFilter && (
+        <DataTable
+          columns={columns}
+          data={sorted}
+          pagination={pagination}
+          onPageChange={setPage}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={handleSort}
+        />
+      )}
     </div>
   );
 }

--- a/admin/src/pages/Inventory.jsx
+++ b/admin/src/pages/Inventory.jsx
@@ -9,9 +9,7 @@ import PageHeader from '../components/PageHeader.jsx';
 // click into the dropdown), making cross-warehouse inventory inspection
 // impossible. The page-level filters seed from the topbar context (so
 // existing behavior is unchanged for users who were using the topbar) but
-// can be independently changed without affecting global state. Bin filter
-// is new - the underlying API endpoint already supports bin_id query
-// param; the UI just never exposed it.
+// can be independently changed without affecting global state.
 
 export default function Inventory() {
   const { warehouseId: topbarWarehouseId } = useWarehouse();

--- a/admin/src/pages/Items.jsx
+++ b/admin/src/pages/Items.jsx
@@ -24,14 +24,35 @@ export default function Items() {
   const [form, setForm] = useState({});
   const [error, setError] = useState('');
 
-  useEffect(() => { loadItems(); }, [page, search, filter]);
+  // Debounce typed search and guard against out-of-order responses.
+  // Each run owns an AbortController; the cleanup cancels a pending
+  // debounce timer (rapid typing) AND aborts an in-flight request (a
+  // superseded query), so only the latest query's response reaches
+  // setItems. Without this, slow broad-prefix queries (e.g. "1" matches
+  // 23k items) resolve late and overwrite the narrow result, leaving
+  // stale "floater" rows from earlier keystrokes. Page/filter changes
+  // are discrete clicks, so they fire immediately (no debounce delay).
+  useEffect(() => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => loadItems(controller.signal), search ? 250 : 0);
+    return () => { clearTimeout(timer); controller.abort(); };
+  }, [page, search, filter]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  async function loadItems() {
+  // signal is supplied by the debounced effect so a superseded query
+  // aborts mid-flight. The mutation handlers (save/delete/archive) call
+  // loadItems() with no signal and refetch unconditionally.
+  async function loadItems(signal) {
     const params = new URLSearchParams({ page, per_page: 50 });
     if (search) params.set('q', search);
     if (filter === 'active') params.set('active', 'true');
     else if (filter === 'archived') params.set('active', 'false');
-    const res = await api.get(`/admin/items?${params}`);
+    let res;
+    try {
+      res = await api.get(`/admin/items?${params}`, { signal });
+    } catch (err) {
+      if (err?.name === 'AbortError') return; // superseded by a newer query
+      throw err;
+    }
     if (res?.ok) {
       const data = await res.json();
       const mapped = (data.items || []).map((item) => ({

--- a/admin/src/pages/POSActivity.jsx
+++ b/admin/src/pages/POSActivity.jsx
@@ -1,0 +1,196 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api.js';
+import DataTable from '../components/DataTable.jsx';
+import PageHeader from '../components/PageHeader.jsx';
+
+// POS Activity dashboard: monitor in-store retail POS sales orders +
+// daily KPIs. Sentry stores POS-specific facts (cashier_id, terminal_id,
+// total_cents, payment_method) in audit_log.details JSONB rather than
+// dedicated columns (v1.10.0 design: pricing stays out of Sentry, lives
+// in audit_log for archival). The /api/admin/pos/* backend endpoints
+// surface those facts back to this page via LEFT JOIN audit_log.
+
+const STATUS_OPTIONS = ['', 'OPEN', 'ALLOCATED', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED'];
+const ORDER_TYPE_OPTIONS = ['sale', 'refund', 'all'];
+
+function centsToUsd(cents) {
+  if (cents == null) return '-';
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatTs(iso) {
+  if (!iso) return '-';
+  try {
+    return new Date(iso).toLocaleString('en-US', {
+      year: 'numeric', month: 'short', day: 'numeric',
+      hour: 'numeric', minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export default function POSActivity() {
+  const [summary, setSummary] = useState(null);
+  const [salesOrders, setSalesOrders] = useState([]);
+  const [pagination, setPagination] = useState(null);
+  const [page, setPage] = useState(1);
+  const [orderType, setOrderType] = useState('sale');
+  const [status, setStatus] = useState('');
+  const [terminalFilter, setTerminalFilter] = useState('');
+  const [cashierFilter, setCashierFilter] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  // Refresh summary every load + after page/filter changes that imply new data.
+  // Cheap - single SQL query w/ 1-day window.
+  function loadSummary() {
+    api.get('/admin/pos/summary').then(async (res) => {
+      if (!res?.ok) return;
+      const data = await res.json();
+      setSummary(data);
+    });
+  }
+
+  function loadOrders() {
+    const params = new URLSearchParams({ page, per_page: 50, order_type: orderType });
+    if (status) params.set('status', status);
+    if (terminalFilter) params.set('terminal_id', terminalFilter);
+    if (cashierFilter) params.set('cashier_id', cashierFilter);
+    setLoading(true);
+    api.get(`/admin/pos/sales-orders?${params}`).then(async (res) => {
+      setLoading(false);
+      if (!res?.ok) return;
+      const data = await res.json();
+      setSalesOrders(data.sales_orders || []);
+      setPagination({ page: data.page, pages: data.pages, total: data.total, per_page: data.per_page });
+    });
+  }
+
+  useEffect(() => { loadSummary(); }, []);
+  useEffect(() => { loadOrders(); }, [page, orderType, status, terminalFilter, cashierFilter]);
+
+  function refresh() {
+    loadSummary();
+    loadOrders();
+  }
+
+  const columns = [
+    { key: 'so_number', label: 'SO #', mono: true },
+    { key: 'order_date', label: 'Date', render: (r) => formatTs(r.order_date) },
+    { key: 'order_type', label: 'Type' },
+    { key: 'status', label: 'Status' },
+    { key: 'cashier_id', label: 'Cashier', render: (r) => r.cashier_id || '-' },
+    { key: 'terminal_id', label: 'Terminal', mono: true, render: (r) => r.terminal_id || '-' },
+    { key: 'customer_name', label: 'Customer', render: (r) => r.customer_name || '(walk-in)' },
+    { key: 'total_cents', label: 'Total', render: (r) => centsToUsd(r.total_cents) },
+    { key: 'payment_method', label: 'Tender', render: (r) => r.payment_method || '-' },
+    { key: 'external_txn_ref', label: 'Windcave Ref', mono: true, render: (r) => r.external_txn_ref || '-' },
+  ];
+
+  const today = summary?.today || {};
+  const terminals = summary?.active_terminals || [];
+
+  return (
+    <div>
+      <PageHeader title="POS Activity">
+        <button className="btn" onClick={refresh}>Refresh</button>
+      </PageHeader>
+
+      {/* KPI Bar */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+        gap: 12,
+        marginBottom: 16,
+      }}>
+        <KpiCard
+          label="Today's Sales"
+          value={today.sales_count ?? '-'}
+          sub={centsToUsd(today.sales_total_cents)}
+        />
+        <KpiCard
+          label="Today's Refunds"
+          value={today.refund_count ?? '-'}
+          sub={centsToUsd(today.refund_total_cents)}
+        />
+        <KpiCard
+          label="Net Revenue Today"
+          value={centsToUsd((today.sales_total_cents || 0) - (today.refund_total_cents || 0))}
+          sub={`${today.sales_count || 0} sales − ${today.refund_count || 0} refunds`}
+        />
+        <KpiCard
+          label="Active Terminals (24h)"
+          value={terminals.length || '-'}
+          sub={terminals.join(', ') || 'none'}
+        />
+      </div>
+
+      {/* Filter bar */}
+      <div className="filter-bar" style={{ marginBottom: 12 }}>
+        <select
+          className="form-select"
+          value={orderType}
+          onChange={(e) => { setOrderType(e.target.value); setPage(1); }}
+          style={{ width: 'auto' }}
+        >
+          {ORDER_TYPE_OPTIONS.map((v) => (
+            <option key={v} value={v}>{v === 'all' ? 'All Types' : (v[0].toUpperCase() + v.slice(1))}</option>
+          ))}
+        </select>
+        <select
+          className="form-select"
+          value={status}
+          onChange={(e) => { setStatus(e.target.value); setPage(1); }}
+          style={{ width: 'auto' }}
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s} value={s}>{s || 'All Statuses'}</option>
+          ))}
+        </select>
+        <input
+          className="form-input"
+          placeholder="Terminal ID (e.g., REG-01)"
+          value={terminalFilter}
+          onChange={(e) => { setTerminalFilter(e.target.value); setPage(1); }}
+          style={{ maxWidth: 200 }}
+        />
+        <input
+          className="form-input"
+          placeholder="Cashier ID"
+          value={cashierFilter}
+          onChange={(e) => { setCashierFilter(e.target.value); setPage(1); }}
+          style={{ maxWidth: 200 }}
+        />
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={salesOrders}
+        pagination={pagination}
+        onPageChange={setPage}
+        emptyMessage={loading ? 'Loading…' : 'No POS orders match the current filters.'}
+      />
+    </div>
+  );
+}
+
+function KpiCard({ label, value, sub }) {
+  return (
+    <div style={{
+      background: 'var(--card-bg, #ffffff)',
+      border: '1px solid var(--border, #e5e7eb)',
+      borderRadius: 8,
+      padding: '12px 16px',
+    }}>
+      <div style={{
+        fontSize: 11,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+        color: 'var(--text-secondary, #6b7280)',
+        marginBottom: 4,
+      }}>{label}</div>
+      <div style={{ fontSize: 24, fontWeight: 600, marginBottom: 2 }}>{value}</div>
+      <div style={{ fontSize: 12, color: 'var(--text-secondary, #6b7280)' }}>{sub}</div>
+    </div>
+  );
+}

--- a/admin/src/pages/PutAway.jsx
+++ b/admin/src/pages/PutAway.jsx
@@ -1,34 +1,195 @@
 import { useState, useEffect } from 'react';
 import { api } from '../api.js';
 import { useWarehouse } from '../warehouse.jsx';
-import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
+
+// Dashboard view of staging bins for the
+// supervisor. Each staging bin shows its SKU count + total qty; the
+// row expands to the per-item breakdown. CSV exports cover both the
+// single-bin view (workpaper for the operator walking that aisle) and
+// the warehouse-wide view (reconciliation / inventory analysis).
+
+function csvEscape(v) {
+  if (v === null || v === undefined) return '';
+  const s = String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function downloadCsv(filename, headerRow, dataRows) {
+  const lines = [headerRow.join(',')];
+  for (const r of dataRows) lines.push(r.map(csvEscape).join(','));
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
 
 export default function PutAway() {
   const { warehouseId } = useWarehouse();
-  const [items, setItems] = useState([]);
+  const [bins, setBins] = useState([]);
+  const [expanded, setExpanded] = useState({});
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!warehouseId) return;
-    api.get(`/putaway/pending/${warehouseId}`).then(async (res) => {
+    setLoading(true);
+    api.get(`/putaway/staging-summary/${warehouseId}`).then(async (res) => {
+      setLoading(false);
       if (!res?.ok) return;
       const data = await res.json();
-      setItems(data.pending_items || []);
-    });
+      setBins(data.bins || []);
+    }).catch(() => setLoading(false));
   }, [warehouseId]);
 
-  const columns = [
-    { key: 'sku', label: 'SKU', mono: true },
-    { key: 'item_name', label: 'Item Name' },
-    { key: 'quantity', label: 'Qty in Staging', render: (r) => r.quantity_on_hand || r.quantity || '-' },
-    { key: 'bin_code', label: 'Bin Code', mono: true },
-    { key: 'suggested_bin', label: 'Suggested Bin', mono: true, render: (r) => r.suggested_bin || r.default_bin_code || '-' },
-  ];
+  function toggle(binId) {
+    setExpanded((e) => ({ ...e, [binId]: !e[binId] }));
+  }
+
+  function exportAll() {
+    const header = ['Bin', 'SKU', 'Item Name', 'UPC', 'Quantity', 'Suggested Bin', 'Lot'];
+    const rows = [];
+    for (const b of bins) {
+      for (const item of b.items) {
+        rows.push([
+          b.bin_code, item.sku, item.item_name, item.upc || '',
+          item.quantity_on_hand, item.suggested_bin || '', item.lot_number || '',
+        ]);
+      }
+    }
+    const stamp = new Date().toISOString().slice(0, 10);
+    downloadCsv(`putaway-staging-wh${warehouseId}-${stamp}.csv`, header, rows);
+  }
+
+  function exportBin(bin) {
+    const header = ['SKU', 'Item Name', 'UPC', 'Quantity', 'Suggested Bin', 'Lot'];
+    const rows = bin.items.map((item) => [
+      item.sku, item.item_name, item.upc || '',
+      item.quantity_on_hand, item.suggested_bin || '', item.lot_number || '',
+    ]);
+    const stamp = new Date().toISOString().slice(0, 10);
+    downloadCsv(`putaway-${bin.bin_code}-${stamp}.csv`, header, rows);
+  }
+
+  const totalSkus = bins.reduce((acc, b) => acc + b.sku_count, 0);
+  const totalQty = bins.reduce((acc, b) => acc + b.total_qty, 0);
+  const binsWithItems = bins.reduce((acc, b) => acc + (b.sku_count > 0 ? 1 : 0), 0);
 
   return (
     <div>
-      <PageHeader title="Put-Away" />
-      <DataTable columns={columns} data={items} emptyMessage="No items awaiting put-away" />
+      <PageHeader title="Put-Away">
+        <button
+          className="btn"
+          onClick={exportAll}
+          disabled={bins.length === 0}
+          title="Export every staging bin and its items to CSV"
+        >
+          Export All (CSV)
+        </button>
+      </PageHeader>
+
+      <div style={{
+        display: 'flex', gap: 16, marginBottom: 16, fontSize: 13,
+        color: 'var(--text-secondary)',
+      }}>
+        <span>
+          <strong style={{ color: 'var(--text)' }}>{binsWithItems}</strong>
+          {' / '}{bins.length} staging bins with items
+        </span>
+        <span><strong style={{ color: 'var(--text)' }}>{totalSkus}</strong> total SKU rows</span>
+        <span><strong style={{ color: 'var(--text)' }}>{totalQty}</strong> total units</span>
+      </div>
+
+      {loading && (
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>Loading…</p>
+      )}
+      {!loading && bins.length === 0 && (
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+          No staging bins exist in this warehouse.
+        </p>
+      )}
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {bins.map((b) => {
+          const isEmpty = b.sku_count === 0;
+          // Empty staging bins still render so the supervisor
+          // sees the full layout, but they are non-expandable and
+          // visually muted so the worklist signal stays clear.
+          const open = !isEmpty && !!expanded[b.bin_id];
+          return (
+            <div
+              key={b.bin_id}
+              className="card"
+              style={{ padding: 0, opacity: isEmpty ? 0.55 : 1 }}
+            >
+              <div
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                  padding: '10px 14px',
+                  cursor: isEmpty ? 'default' : 'pointer',
+                  borderBottom: open ? '1px solid var(--border-dark)' : 'none',
+                }}
+                onClick={isEmpty ? undefined : () => toggle(b.bin_id)}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                  <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                    {isEmpty ? '·' : (open ? '▾' : '▸')}
+                  </span>
+                  <span className="mono" style={{ fontSize: 14, fontWeight: 600 }}>
+                    {b.bin_code}
+                  </span>
+                  <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+                    {isEmpty
+                      ? 'empty'
+                      : `${b.sku_count} ${b.sku_count === 1 ? 'SKU' : 'SKUs'} - ${b.total_qty} units`}
+                  </span>
+                </div>
+                {!isEmpty && (
+                  <button
+                    className="btn btn-sm"
+                    onClick={(e) => { e.stopPropagation(); exportBin(b); }}
+                    title={`Export ${b.bin_code} to CSV`}
+                  >
+                    CSV
+                  </button>
+                )}
+              </div>
+              {open && (
+                <div style={{ padding: '10px 14px' }}>
+                  <table className="lines-table">
+                    <thead>
+                      <tr>
+                        <th>SKU</th>
+                        <th>Item Name</th>
+                        <th>UPC</th>
+                        <th style={{ textAlign: 'right' }}>Qty</th>
+                        <th>Suggested Bin</th>
+                        <th>Lot</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {b.items.map((it) => (
+                        <tr key={it.inventory_id}>
+                          <td className="mono">{it.sku}</td>
+                          <td style={{ color: 'var(--text-secondary)' }}>{it.item_name}</td>
+                          <td className="mono">{it.upc || '-'}</td>
+                          <td className="mono" style={{ textAlign: 'right' }}>{it.quantity_on_hand}</td>
+                          <td className="mono">{it.suggested_bin || '-'}</td>
+                          <td className="mono">{it.lot_number || '-'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -127,6 +127,11 @@ export default function Settings() {
   // lines can accept an SKU (what operators memorize) instead of a
   // raw item_id (a database autoincrement). Loaded lazily when either
   // modal opens so Settings' first paint does not fetch /admin/items.
+  //
+  // The cache holds the first 1000 active items for instant typeahead
+  // and autocomplete; catalogues larger than 1000 fall back to a
+  // per-SKU server lookup in resolveSku so a less-common SKU at line
+  // submit time still resolves correctly instead of silently failing.
   async function ensureItemsLoaded() {
     if (itemsLoaded) return;
     const res = await api.get('/admin/items?per_page=1000&active=true', { silentPermissionDenied: true });
@@ -141,8 +146,20 @@ export default function Settings() {
     }
   }
 
-  function resolveSku(sku) {
-    return itemsBySku.get(String(sku || '').trim().toLowerCase());
+  async function resolveSku(sku) {
+    const key = String(sku || '').trim().toLowerCase();
+    if (!key) return null;
+    if (itemsBySku.has(key)) return itemsBySku.get(key);
+    // Cache miss: catalogue > 1000 items or the SKU is brand new. A
+    // narrow server-side query backs the cache so submit does not
+    // depend on the pre-loaded slice.
+    const res = await api.get(`/admin/items?q=${encodeURIComponent(sku)}&per_page=10&active=true`);
+    if (!res?.ok) return null;
+    const data = await res.json();
+    const match = (data.items || []).find(
+      (i) => String(i.sku || '').trim().toLowerCase() === key,
+    );
+    return match ? match.item_id : null;
   }
 
   function openPoModal() {
@@ -183,14 +200,18 @@ export default function Settings() {
 
   async function createPO() {
     setFormError(''); setFormSuccess('');
+    const entries = poForm.lines.filter((x) => x.sku);
+    // Resolve all SKUs in parallel so a multi-line PO does not pay
+    // a round-trip per line when the cache misses.
+    const ids = await Promise.all(entries.map((l) => resolveSku(l.sku)));
     const resolved = [];
-    for (const l of poForm.lines.filter((x) => x.sku)) {
-      const itemId = resolveSku(l.sku);
+    for (let i = 0; i < entries.length; i++) {
+      const itemId = ids[i];
       if (!itemId) {
-        setFormError(`Unknown SKU: ${l.sku}`);
+        setFormError(`Unknown SKU: ${entries[i].sku}`);
         return;
       }
-      resolved.push({ item_id: itemId, quantity_ordered: Number(l.quantity_ordered) });
+      resolved.push({ item_id: itemId, quantity_ordered: Number(entries[i].quantity_ordered) });
     }
     const body = {
       po_number: poForm.po_number,
@@ -221,14 +242,16 @@ export default function Settings() {
   async function createSO() {
     setFormError(''); setFormSuccess('');
     const shipAddress = [soForm.address_line_1, soForm.address_line_2, soForm.city, soForm.state, soForm.zip].filter(Boolean).join(', ');
+    const entries = soForm.lines.filter((x) => x.sku);
+    const ids = await Promise.all(entries.map((l) => resolveSku(l.sku)));
     const resolved = [];
-    for (const l of soForm.lines.filter((x) => x.sku)) {
-      const itemId = resolveSku(l.sku);
+    for (let i = 0; i < entries.length; i++) {
+      const itemId = ids[i];
       if (!itemId) {
-        setFormError(`Unknown SKU: ${l.sku}`);
+        setFormError(`Unknown SKU: ${entries[i].sku}`);
         return;
       }
-      resolved.push({ item_id: itemId, quantity_ordered: Number(l.quantity_ordered) });
+      resolved.push({ item_id: itemId, quantity_ordered: Number(entries[i].quantity_ordered) });
     }
     const body = {
       so_number: soForm.order_number,

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -56,6 +56,7 @@ export default function Settings() {
       api.get('/admin/settings/picking_ticket_logo_url'),
       api.get('/admin/settings/picking_ticket_returns_text'),
       api.get('/admin/settings/pos_activity_enabled'),
+      api.get('/admin/settings/fraud_review_billing_shipping'),
     ]).then(async (responses) => {
       const initial = {};
       for (const res of responses) {
@@ -80,6 +81,9 @@ export default function Settings() {
       // POS Activity tab is hidden by default; deployments using the POS
       // checkout surface opt in. Sidebar reads the same key to gate the nav.
       if (!('pos_activity_enabled' in initial)) initial.pos_activity_enabled = 'false';
+      // Billing != shipping fraud heuristic is opt-in: off by default so
+      // a fresh install never parks orders in FRAUD_REVIEW automatically.
+      if (!('fraud_review_billing_shipping' in initial)) initial.fraud_review_billing_shipping = 'false';
       setSavedSettings({ ...initial });
       setDraftSettings({ ...initial });
     });
@@ -421,6 +425,21 @@ export default function Settings() {
           </label>
         </div>
         <p className="settings-note">Adds a POS Activity tab to the Outbound nav with point-of-sale order activity and daily KPIs. Off by default; enable it for deployments that use the POS checkout surface.</p>
+      </div>
+
+      <div className="settings-section">
+        <h3>Fraud Review</h3>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 0' }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: 13 }}>
+            <input
+              type="checkbox"
+              checked={toBool(draftSettings.fraud_review_billing_shipping)}
+              onChange={(e) => updateDraft('fraud_review_billing_shipping', String(e.target.checked))}
+            />
+            Auto-flag orders where billing and shipping addresses differ
+          </label>
+        </div>
+        <p className="settings-note">One built-in heuristic for the Outbound &gt; Fraud queue: when on, an inbound order whose billing and shipping addresses diverge (street / city / state / postal, both sides populated) lands in FRAUD_REVIEW and is held out of picking until a CSR clears it. Off by default. A CSR can always flag or clear an order manually regardless of this setting.</p>
       </div>
 
       {/* Picking Ticket branding */}

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -55,6 +55,7 @@ export default function Settings() {
       api.get('/admin/settings/picking_ticket_company_address'),
       api.get('/admin/settings/picking_ticket_logo_url'),
       api.get('/admin/settings/picking_ticket_returns_text'),
+      api.get('/admin/settings/pos_activity_enabled'),
     ]).then(async (responses) => {
       const initial = {};
       for (const res of responses) {
@@ -76,6 +77,9 @@ export default function Settings() {
       if (!('picking_ticket_company_address' in initial)) initial.picking_ticket_company_address = '';
       if (!('picking_ticket_logo_url' in initial)) initial.picking_ticket_logo_url = '';
       if (!('picking_ticket_returns_text' in initial)) initial.picking_ticket_returns_text = '';
+      // POS Activity tab is hidden by default; deployments using the POS
+      // checkout surface opt in. Sidebar reads the same key to gate the nav.
+      if (!('pos_activity_enabled' in initial)) initial.pos_activity_enabled = 'false';
       setSavedSettings({ ...initial });
       setDraftSettings({ ...initial });
     });
@@ -402,6 +406,21 @@ export default function Settings() {
           </label>
         </div>
         <p className="settings-note">When enabled, the admin who performed a cycle count cannot approve the resulting adjustments. A different admin must review and approve.</p>
+      </div>
+
+      <div className="settings-section">
+        <h3>POS</h3>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 0' }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: 13 }}>
+            <input
+              type="checkbox"
+              checked={toBool(draftSettings.pos_activity_enabled)}
+              onChange={(e) => updateDraft('pos_activity_enabled', String(e.target.checked))}
+            />
+            Show the POS Activity dashboard
+          </label>
+        </div>
+        <p className="settings-note">Adds a POS Activity tab to the Outbound nav with point-of-sale order activity and daily KPIs. Off by default; enable it for deployments that use the POS checkout surface.</p>
       </div>
 
       {/* Picking Ticket branding */}

--- a/admin/src/pages/Users.jsx
+++ b/admin/src/pages/Users.jsx
@@ -43,6 +43,7 @@ const PAGE_GROUPS = [
     label: 'Outbound',
     pages: [
       { key: 'sales-orders', label: 'Sales Orders' },
+      { key: 'fraud', label: 'Fraud' },
       // picking/packing/shipping retired in favour of the mobile flow;
       // their page_keys are gone from ALL_PAGE_KEYS so a stale grant
       // cannot persist past the next permissions save.

--- a/api/constants.py
+++ b/api/constants.py
@@ -25,6 +25,10 @@ SO_PICKED = "PICKED"
 SO_PACKED = "PACKED"
 SO_SHIPPED = "SHIPPED"
 SO_CANCELLED = "CANCELLED"
+# SOs held for fraud review (auto-flagged at ingest when the
+# billing/shipping heuristic is enabled, or set manually). Excluded
+# from the picking queue until a CSR clears via the Fraud page.
+SO_FRAUD_REVIEW = "FRAUD_REVIEW"
 # Company-wide timezone for operator-facing calendar dates (e.g. the
 # Shipped Date on the SO modal). Timestamps are stored in UTC; this is
 # the single zone used to convert them to the local calendar date
@@ -146,6 +150,13 @@ ACTION_WEBHOOK_SUBSCRIPTION_AUTO_PAUSE = "WEBHOOK_SUBSCRIPTION_AUTO_PAUSE"
 # not the full address.
 ACTION_SO_ADDRESS_EDITED = "SO_ADDRESS_EDITED"
 
+# Fraud queue. The auto-flag at ingest does NOT get its own audit row
+# -- the existing inbound CREATE row plus the resulting
+# status='FRAUD_REVIEW' already capture it forensically. These two
+# cover the CSR-driven mutations on the Fraud page.
+ACTION_SO_FRAUD_CLEARED = "SO_FRAUD_CLEARED"
+ACTION_SO_MEMO_EDITED = "SO_MEMO_EDITED"
+
 # PO line edit + status surfaces. One audit row per mutation so the
 # historical record of what was ordered survives later edits. Status
 # transitions get their own action so the audit query "when did this
@@ -193,6 +204,10 @@ ALL_PAGE_KEYS = (
     "inventory", "cycle-counts", "count-approvals",
     "purchase-orders", "receiving", "putaway",
     "sales-orders",
+    # Fraud (Outbound): the review queue for SOs held at FRAUD_REVIEW.
+    # Holders see the /fraud page and can edit the CSR memo or push an
+    # order back into the picking queue.
+    "fraud",
     # Picking Tickets (Outbound): the printable packing-slip queue and
     # the per-SO / Print All print views. Holders see the /picking-tickets
     # page and can mark tickets printed.

--- a/api/routes/admin/__init__.py
+++ b/api/routes/admin/__init__.py
@@ -53,6 +53,7 @@ from routes.admin import (  # noqa: E402, F401
     admin_items,
     admin_orders,
     admin_pick_batches,
+    admin_pos,
     admin_search,
     admin_tokens,
     admin_transfer_orders,

--- a/api/routes/admin/admin_items.py
+++ b/api/routes/admin/admin_items.py
@@ -51,7 +51,17 @@ def list_items():
         where_clauses.append("i.is_active = :active")
         params["active"] = active.lower() == "true"
     if search:
-        where_clauses.append("(i.sku ILIKE :search OR i.item_name ILIKE :search OR i.upc ILIKE :search)")
+        # barcode_aliases is a JSONB array of alternate scannable
+        # barcodes (vendor packs, distributor labels, secondary UPCs).
+        # Operators who scan one of these expect the matching item to
+        # surface even though the primary UPC differs; without the
+        # alias match they have to look up the item manually.
+        where_clauses.append(
+            "(i.sku ILIKE :search OR i.item_name ILIKE :search "
+            "OR i.upc ILIKE :search OR EXISTS (SELECT 1 FROM "
+            "jsonb_array_elements_text(COALESCE(i.barcode_aliases, '[]'::jsonb)) "
+            "AS alias(code) WHERE alias.code ILIKE :search))"
+        )
         params["search"] = f"%{search}%"
 
     where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""

--- a/api/routes/admin/admin_items.py
+++ b/api/routes/admin/admin_items.py
@@ -305,6 +305,7 @@ def list_inventory():
     where_clauses, params = [], {}
     warehouse_id = request.args.get("warehouse_id", type=int)
     item_id = request.args.get("item_id", type=int)
+    bin_id = request.args.get("bin_id", type=int)
     search = (request.args.get("q") or "").strip()
     if warehouse_id:
         where_clauses.append("inv.warehouse_id = :wid")
@@ -312,14 +313,30 @@ def list_inventory():
     if item_id:
         where_clauses.append("inv.item_id = :iid")
         params["iid"] = item_id
+    if bin_id:
+        # The Inventory page surfaces a bin-scoped filter dropdown; the
+        # backend has to honor it so operators can drill into a single
+        # bin without scrolling through the full warehouse list.
+        where_clauses.append("inv.bin_id = :binid")
+        params["binid"] = bin_id
     if search:
-        # Join items so the SKU/name search can reach them. The main
-        # SELECT below also joins items and bins for display.
-        where_clauses.append("(i.sku ILIKE :search OR i.item_name ILIKE :search)")
+        # SKU, item name, UPC, and bin code all read like primary
+        # identifiers to a warehouse operator. Searching by any one
+        # of them should return the matching inventory row rather
+        # than forcing the operator to know which field the value
+        # lives in. The main SELECT below already joins items and
+        # bins for display.
+        where_clauses.append(
+            "(i.sku ILIKE :search OR i.item_name ILIKE :search "
+            "OR i.upc ILIKE :search OR b.bin_code ILIKE :search)"
+        )
         params["search"] = f"%{search}%"
 
     where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
-    count_join = "JOIN items i ON i.item_id = inv.item_id" if search else ""
+    count_join = (
+        "JOIN items i ON i.item_id = inv.item_id JOIN bins b ON b.bin_id = inv.bin_id"
+        if search else ""
+    )
     total = g.db.execute(
         text(f"SELECT COUNT(*) FROM inventory inv {count_join} {where_sql}"), params
     ).scalar()

--- a/api/routes/admin/admin_items.py
+++ b/api/routes/admin/admin_items.py
@@ -77,7 +77,20 @@ def list_items():
                    i.default_bin_id, i.is_active, i.created_at,
                    b.bin_code AS default_bin_code
             FROM items i
-            LEFT JOIN preferred_bins pb ON pb.item_id = i.item_id AND pb.priority = 1
+            -- An item can carry more than one priority-1 preferred_bins
+            -- row (the data allows it), and a plain join fans the item
+            -- out into duplicate result rows. Collapse to one
+            -- deterministic bin via LATERAL ... LIMIT 1 so each item
+            -- yields exactly one row. The COUNT(*) above joins nothing,
+            -- so the total was already correct; this aligns the row set
+            -- with it.
+            LEFT JOIN LATERAL (
+                SELECT pb.bin_id
+                FROM preferred_bins pb
+                WHERE pb.item_id = i.item_id AND pb.priority = 1
+                ORDER BY pb.bin_id
+                LIMIT 1
+            ) pb ON TRUE
             LEFT JOIN bins b ON b.bin_id = COALESCE(pb.bin_id, i.default_bin_id)
             {where_sql}
             ORDER BY i.item_id LIMIT :limit OFFSET :offset

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 from constants import (
     PO_OPEN, PO_PARTIAL, PO_RECEIVED, PO_CLOSED, PO_ARCHIVED,
     SO_OPEN, SO_PICKED, SO_PACKED, SO_SHIPPED, SO_CANCELLED,
+    SO_FRAUD_REVIEW,
     TASK_PENDING, ADJ_PENDING,
     COMPANY_TIMEZONE,
     ACTION_PICK,
@@ -19,6 +20,8 @@ from constants import (
     ACTION_PO_LINE_UPDATED,
     ACTION_PO_LINE_REMOVED,
     ACTION_SO_ADDRESS_EDITED,
+    ACTION_SO_FRAUD_CLEARED,
+    ACTION_SO_MEMO_EDITED,
     ACTION_SO_HEADER_EDITED,
     ACTION_SO_LINE_ADDED,
     ACTION_SO_LINE_UPDATED,
@@ -50,6 +53,7 @@ from schemas.sales_orders import (
     RevertSalesOrderStatusRequest,
     UpdateSalesOrderAddressRequest,
     UpdateSalesOrderLineRequest,
+    UpdateSalesOrderMemoRequest,
     UpdateSalesOrderRequest,
 )
 from services.audit_service import write_audit_log
@@ -668,7 +672,13 @@ def list_sales_orders():
                    so.ship_method, so.ship_address, so.order_date, so.ship_by_date, so.created_at, so.created_by,
                    so.carrier, so.tracking_number, so.shipped_at,
                    (so.shipped_at AT TIME ZONE :company_tz)::date AS shipped_date_local,
-                   so.memo, so.printed_at
+                   so.memo, so.printed_at,
+                   so.billing_address_line1, so.billing_address_line2,
+                   so.billing_address_city, so.billing_address_state,
+                   so.billing_address_postal_code,
+                   so.shipping_address_line1, so.shipping_address_line2,
+                   so.shipping_address_city, so.shipping_address_state,
+                   so.shipping_address_postal_code
                    {primary_bin_select}
             FROM sales_orders so {where_sql}
             ORDER BY so.so_id DESC LIMIT :limit OFFSET :offset
@@ -693,6 +703,16 @@ def list_sales_orders():
             "shipped_date_local": r.shipped_date_local.isoformat() if r.shipped_date_local else None,
             "memo": r.memo,
             "printed_at": r.printed_at.isoformat() if r.printed_at else None,
+            "billing_address_line1": r.billing_address_line1,
+            "billing_address_line2": r.billing_address_line2,
+            "billing_address_city": r.billing_address_city,
+            "billing_address_state": r.billing_address_state,
+            "billing_address_postal_code": r.billing_address_postal_code,
+            "shipping_address_line1": r.shipping_address_line1,
+            "shipping_address_line2": r.shipping_address_line2,
+            "shipping_address_city": r.shipping_address_city,
+            "shipping_address_state": r.shipping_address_state,
+            "shipping_address_postal_code": r.shipping_address_postal_code,
         }
         if include_primary_bin:
             out["primary_bin_code"] = r.primary_bin_code
@@ -1278,6 +1298,81 @@ def update_sales_order_address(so_id, validated):
         "so_id": so_id,
         "edited_fields": [e[0] for e in edits],
     })
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/memo", methods=["PATCH"])
+@require_auth
+@require_admin_or_page_permission("fraud")
+@validate_body(UpdateSalesOrderMemoRequest)
+@with_db
+def update_sales_order_memo(so_id, validated):
+    """Edit the free-form CSR memo on an SO (Outbound > Fraud page).
+    Empty string clears to NULL. One audit row per actual change
+    carrying old/new for a forensic diff."""
+    so = g.db.execute(
+        text("SELECT so_id, memo, warehouse_id FROM sales_orders WHERE so_id = :sid FOR UPDATE"),
+        {"sid": so_id},
+    ).fetchone()
+    if not so:
+        return jsonify({"error": "Sales order not found"}), 404
+
+    new_memo = validated.memo if validated.memo != "" else None
+    if so.memo == new_memo:
+        return jsonify({"unchanged": True, "memo": so.memo}), 200
+
+    g.db.execute(
+        text("UPDATE sales_orders SET memo = :memo WHERE so_id = :sid"),
+        {"memo": new_memo, "sid": so_id},
+    )
+    write_audit_log(
+        g.db,
+        action_type=ACTION_SO_MEMO_EDITED,
+        entity_type="SO",
+        entity_id=so_id,
+        user_id=g.current_user["username"],
+        warehouse_id=so.warehouse_id,
+        details={"old_value": so.memo, "new_value": new_memo},
+    )
+    g.db.commit()
+    return jsonify({"so_id": so_id, "memo": new_memo})
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/push-to-queue", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("fraud")
+@with_db
+def push_sales_order_to_queue(so_id):
+    """Clear an auto-flagged fraud SO and return it to the picking
+    queue. Only valid when status=FRAUD_REVIEW; any other current
+    status is a 409 because this path does not know how to transition
+    out of (e.g.) PICKING. Status moves to OPEN."""
+    so = g.db.execute(
+        text("SELECT so_id, status, warehouse_id FROM sales_orders WHERE so_id = :sid FOR UPDATE"),
+        {"sid": so_id},
+    ).fetchone()
+    if not so:
+        return jsonify({"error": "Sales order not found"}), 404
+    if so.status != SO_FRAUD_REVIEW:
+        return jsonify({
+            "error": f"Can only push FRAUD_REVIEW orders to the queue. Current: {so.status}",
+            "current_status": so.status,
+        }), 409
+
+    g.db.execute(
+        text("UPDATE sales_orders SET status = :status WHERE so_id = :sid"),
+        {"status": SO_OPEN, "sid": so_id},
+    )
+    write_audit_log(
+        g.db,
+        action_type=ACTION_SO_FRAUD_CLEARED,
+        entity_type="SO",
+        entity_id=so_id,
+        user_id=g.current_user["username"],
+        warehouse_id=so.warehouse_id,
+        details={"from_status": SO_FRAUD_REVIEW, "to_status": SO_OPEN},
+    )
+    g.db.commit()
+    return jsonify({"so_id": so_id, "status": SO_OPEN})
 
 
 @admin_bp.route("/sales-orders/<int:so_id>/cancel", methods=["POST"])

--- a/api/routes/admin/admin_pos.py
+++ b/api/routes/admin/admin_pos.py
@@ -1,0 +1,253 @@
+"""POS admin endpoints - feeds the new admin/src/pages/POSActivity.jsx
+dashboard with sales-order activity + daily KPI counters.
+
+Data model note: Sentry intentionally does NOT store per-line prices or
+operator metadata in `sales_orders` columns. Per v1.10.0 design (POS
+endpoint surface release), pricing + cashier_id + terminal_id ride into
+the audit_log.details JSONB at POS_CHECKOUT time. So this module's
+queries LEFT JOIN audit_log to surface those fields back to the
+dashboard.
+
+Endpoints:
+    GET /api/admin/pos/sales-orders   - paginated POS SO list w/ filters
+    GET /api/admin/pos/summary        - today's KPI counters (sales /
+                                        revenue / refunds / terminals)
+
+Both gated by ADMIN role (same as the existing /admin/sales-orders).
+"""
+
+import math
+from datetime import date, datetime, timedelta
+from flask import g, jsonify, request
+from sqlalchemy import text
+
+from constants import ACTION_POS_CHECKOUT, ACTION_POS_REFUND
+from middleware.auth_middleware import require_auth, require_role
+from middleware.db import with_db
+from routes.admin import admin_bp
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/pos/sales-orders
+# ---------------------------------------------------------------------------
+
+
+@admin_bp.route("/pos/sales-orders", methods=["GET"])
+@require_auth
+@require_role("ADMIN")
+@with_db
+def list_pos_sales_orders():
+    """Paginated list of POS sales orders with the cashier/terminal/total
+    detail joined from audit_log.
+
+    Query params:
+        page         - 1-based page number, default 1
+        per_page     - page size, default 50, max 200
+        since        - YYYY-MM-DD (orders with order_date >= since at UTC midnight)
+        until        - YYYY-MM-DD (orders with order_date <  until at UTC midnight)
+        terminal_id  - filter on the audit_log JSONB 'terminal_id' field
+        cashier_id   - filter on the audit_log JSONB 'cashier_id' field (= sales_orders.created_by)
+        status       - sales_orders.status filter (OPEN/ALLOCATED/PICKED/PACKED/SHIPPED/CANCELLED)
+        order_type   - 'sale' (default) | 'refund' | 'all'
+    """
+    page = request.args.get("page", 1, type=int)
+    per_page = min(request.args.get("per_page", 50, type=int), 200)
+    since = request.args.get("since")
+    until = request.args.get("until")
+    terminal_id = request.args.get("terminal_id")
+    cashier_id = request.args.get("cashier_id")
+    so_status = request.args.get("status")
+    order_type = request.args.get("order_type", "sale").lower()
+
+    where_clauses = ["so.order_source = :pos_source"]
+    params = {"pos_source": "pos", "checkout_action": ACTION_POS_CHECKOUT}
+
+    if order_type == "sale":
+        where_clauses.append("so.order_type = :order_type")
+        params["order_type"] = "sale"
+    elif order_type == "refund":
+        where_clauses.append("so.order_type = :order_type")
+        params["order_type"] = "refund"
+    elif order_type != "all":
+        # unknown values are treated as 'sale' to fail safe
+        where_clauses.append("so.order_type = :order_type")
+        params["order_type"] = "sale"
+
+    if since:
+        where_clauses.append("so.order_date >= CAST(:since AS DATE)")
+        params["since"] = since
+    if until:
+        where_clauses.append("so.order_date < CAST(:until AS DATE)")
+        params["until"] = until
+    if so_status:
+        where_clauses.append("so.status = :so_status")
+        params["so_status"] = so_status
+    if terminal_id:
+        where_clauses.append("al.details->>'terminal_id' = :terminal_id")
+        params["terminal_id"] = terminal_id
+    if cashier_id:
+        where_clauses.append("al.user_id = :cashier_id")
+        params["cashier_id"] = cashier_id
+
+    where_sql = "WHERE " + " AND ".join(where_clauses)
+
+    # Count (de-duped via DISTINCT so multi-audit-row SOs don't inflate)
+    total = g.db.execute(
+        text(
+            f"""
+            SELECT COUNT(DISTINCT so.so_id)
+              FROM sales_orders so
+              LEFT JOIN audit_log al
+                ON al.entity_type = 'SO'
+               AND al.entity_id   = so.so_id
+               AND al.action_type = :checkout_action
+              {where_sql}
+            """
+        ),
+        params,
+    ).scalar()
+    pages = max(1, math.ceil((total or 0) / per_page))
+
+    params["limit"] = per_page
+    params["offset"] = (page - 1) * per_page
+
+    rows = g.db.execute(
+        text(
+            f"""
+            SELECT DISTINCT ON (so.so_id)
+                   so.so_id,
+                   so.so_number,
+                   so.status,
+                   so.order_type,
+                   so.order_date,
+                   so.customer_name,
+                   so.customer_phone,
+                   so.external_txn_ref,
+                   so.warehouse_id,
+                   al.user_id AS cashier_id,
+                   al.details->>'terminal_id' AS terminal_id,
+                   COALESCE((al.details->>'total_cents')::int, 0) AS total_cents,
+                   al.details->>'payment_method' AS payment_method,
+                   al.created_at AS checkout_at
+              FROM sales_orders so
+              LEFT JOIN audit_log al
+                ON al.entity_type = 'SO'
+               AND al.entity_id   = so.so_id
+               AND al.action_type = :checkout_action
+              {where_sql}
+             ORDER BY so.so_id DESC, al.created_at DESC
+             LIMIT :limit OFFSET :offset
+            """
+        ),
+        params,
+    ).fetchall()
+
+    return jsonify({
+        "sales_orders": [
+            {
+                "so_id": r.so_id,
+                "so_number": r.so_number,
+                "status": r.status,
+                "order_type": r.order_type,
+                "order_date": r.order_date.isoformat() if r.order_date else None,
+                "customer_name": r.customer_name,
+                "customer_phone": r.customer_phone,
+                "external_txn_ref": r.external_txn_ref,
+                "warehouse_id": r.warehouse_id,
+                "cashier_id": r.cashier_id,
+                "terminal_id": r.terminal_id,
+                "total_cents": r.total_cents,
+                "payment_method": r.payment_method,
+                "checkout_at": r.checkout_at.isoformat() if r.checkout_at else None,
+            }
+            for r in rows
+        ],
+        "total": total or 0,
+        "page": page,
+        "per_page": per_page,
+        "pages": pages,
+    })
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/pos/summary
+# ---------------------------------------------------------------------------
+
+
+@admin_bp.route("/pos/summary", methods=["GET"])
+@require_auth
+@require_role("ADMIN")
+@with_db
+def pos_summary():
+    """Today's KPI counters for the dashboard top bar.
+
+    Computed as of `now` in the server's timezone (UTC for ACA deploys -
+    document the offset if cashier-day boundaries become important).
+
+    Returns:
+        today: {sales_count, sales_total_cents, refund_count, refund_total_cents}
+        active_terminals: list of distinct terminal_id seen in the last 24h
+    """
+    # "Today" boundary: midnight UTC. For SLC retail store, that's ~6pm
+    # local the prior day -- if the user wants a Mountain-Time boundary,
+    # we'd switch this to AT TIME ZONE 'America/Denver'. Keeping UTC for
+    # now to match the rest of the admin surface.
+    today_start_utc = "DATE_TRUNC('day', NOW() AT TIME ZONE 'UTC')"
+
+    row = g.db.execute(
+        text(
+            f"""
+            SELECT
+              COUNT(*) FILTER (WHERE so.order_type = 'sale')
+                AS sales_count,
+              COUNT(*) FILTER (WHERE so.order_type = 'refund')
+                AS refund_count,
+              COALESCE(SUM(
+                CASE WHEN so.order_type = 'sale'
+                  THEN COALESCE((al.details->>'total_cents')::int, 0)
+                  ELSE 0
+                END
+              ), 0) AS sales_total_cents,
+              COALESCE(SUM(
+                CASE WHEN so.order_type = 'refund'
+                  THEN COALESCE((al.details->>'total_cents')::int, 0)
+                  ELSE 0
+                END
+              ), 0) AS refund_total_cents
+            FROM sales_orders so
+            LEFT JOIN audit_log al
+              ON al.entity_type = 'SO'
+             AND al.entity_id   = so.so_id
+             AND al.action_type = :checkout_action
+            WHERE so.order_source = 'pos'
+              AND so.order_date >= {today_start_utc}
+            """
+        ),
+        {"checkout_action": ACTION_POS_CHECKOUT},
+    ).fetchone()
+
+    # Active terminals in the last 24h (a "registered today" pulse).
+    twenty_four_hours_ago = "(NOW() - INTERVAL '24 hours')"
+    terminals = g.db.execute(
+        text(
+            f"""
+            SELECT DISTINCT al.details->>'terminal_id' AS terminal_id
+              FROM audit_log al
+             WHERE al.action_type = :checkout_action
+               AND al.created_at >= {twenty_four_hours_ago}
+               AND al.details->>'terminal_id' IS NOT NULL
+             ORDER BY terminal_id
+            """
+        ),
+        {"checkout_action": ACTION_POS_CHECKOUT},
+    ).fetchall()
+
+    return jsonify({
+        "today": {
+            "sales_count": row.sales_count or 0,
+            "sales_total_cents": int(row.sales_total_cents or 0),
+            "refund_count": row.refund_count or 0,
+            "refund_total_cents": int(row.refund_total_cents or 0),
+        },
+        "active_terminals": [t.terminal_id for t in terminals if t.terminal_id],
+    })

--- a/api/routes/putaway.py
+++ b/api/routes/putaway.py
@@ -70,6 +70,119 @@ def pending_putaway(warehouse_id):
     })
 
 
+@putaway_bp.route("/staging-summary/<int:warehouse_id>")
+@require_auth
+@with_db
+def staging_summary(warehouse_id):
+    """Put-Away dashboard backing query.
+
+    Returns every staging-type bin in the warehouse (including empty
+    ones), alphabetised by bin_code, with the distinct-SKU count and
+    the per-item breakdown so the dashboard can expand a bin in-place
+    without a second round trip. Empty bins surface as zero-count
+    cards so the operator sees the full staging-bin map at a glance,
+    not just the worklist.
+
+    Same bin-type filter as /pending/<warehouse_id> so the two
+    surfaces are always in agreement on what counts as "needs
+    putaway".
+    """
+    ok, denied = check_warehouse_access(warehouse_id)
+    if not ok:
+        return denied
+
+    # Two-pass query: first the full set of staging bins so empty
+    # bins still render as cards, then the inventory rows joined to
+    # those bins. Joining inventory + items via LEFT JOIN would also
+    # work but the per-row JSON shape stays simpler with two passes.
+    bin_rows = g.db.execute(
+        text(
+            """
+            SELECT b.bin_id, b.bin_code
+              FROM bins b
+             WHERE b.warehouse_id = :warehouse_id
+               AND b.bin_type IN (:bin_staging, :bin_pickable_staging)
+             ORDER BY b.bin_code
+            """
+        ),
+        {
+            "warehouse_id": warehouse_id,
+            "bin_staging": BIN_STAGING,
+            "bin_pickable_staging": BIN_PICKABLE_STAGING,
+        },
+    ).fetchall()
+
+    inv_rows = g.db.execute(
+        text(
+            """
+            SELECT b.bin_id,
+                   inv.inventory_id, inv.item_id,
+                   i.sku, i.item_name, i.upc,
+                   inv.quantity_on_hand,
+                   inv.lot_number,
+                   COALESCE(
+                       (SELECT pbb.bin_code
+                        FROM preferred_bins pb
+                        JOIN bins pbb ON pbb.bin_id = pb.bin_id
+                        WHERE pb.item_id = inv.item_id
+                          AND pbb.warehouse_id = :warehouse_id
+                        ORDER BY pb.priority ASC
+                        LIMIT 1),
+                       (SELECT db.bin_code
+                        FROM bins db
+                        WHERE db.bin_id = i.default_bin_id
+                          AND db.warehouse_id = :warehouse_id)
+                   ) AS suggested_bin
+              FROM bins b
+              JOIN inventory inv ON inv.bin_id = b.bin_id
+              JOIN items i ON i.item_id = inv.item_id
+             WHERE b.warehouse_id = :warehouse_id
+               AND b.bin_type IN (:bin_staging, :bin_pickable_staging)
+               AND inv.quantity_on_hand > 0
+             ORDER BY b.bin_code, i.sku
+            """
+        ),
+        {
+            "warehouse_id": warehouse_id,
+            "bin_staging": BIN_STAGING,
+            "bin_pickable_staging": BIN_PICKABLE_STAGING,
+        },
+    ).fetchall()
+
+    bins_by_id = {
+        b.bin_id: {
+            "bin_id": b.bin_id,
+            "bin_code": b.bin_code,
+            "sku_count": 0,
+            "total_qty": 0,
+            "items": [],
+        }
+        for b in bin_rows
+    }
+
+    for r in inv_rows:
+        b = bins_by_id.get(r.bin_id)
+        if not b:
+            continue
+        b["sku_count"] += 1
+        b["total_qty"] += int(r.quantity_on_hand or 0)
+        b["items"].append({
+            "inventory_id": r.inventory_id,
+            "item_id": r.item_id,
+            "sku": r.sku,
+            "item_name": r.item_name,
+            "upc": r.upc,
+            "quantity_on_hand": r.quantity_on_hand,
+            "lot_number": r.lot_number,
+            "suggested_bin": r.suggested_bin,
+        })
+
+    return jsonify({
+        "warehouse_id": warehouse_id,
+        "bins": [bins_by_id[b.bin_id] for b in bin_rows],
+    })
+
+
 @putaway_bp.route("/suggest/<int:item_id>")
 @require_auth
 @with_db

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -183,3 +183,12 @@ class MarkSalesOrdersPrintedRequest(BaseModel):
     would silently drop those tickets from the queue."""
 
     so_ids: List[int] = Field(..., min_length=1, max_length=200)
+
+
+class UpdateSalesOrderMemoRequest(BaseModel):
+    """PATCH body for the free-form CSR memo on a sales_order, shown on
+    the Outbound > Fraud page. An empty string is treated as an explicit
+    clear (NULL). The length cap matches the operational reality -- memos
+    are CSR notes, not log dumps."""
+
+    memo: Optional[str] = Field(..., max_length=4000)

--- a/api/services/inbound_service.py
+++ b/api/services/inbound_service.py
@@ -59,6 +59,72 @@ from services.mapping_loader import (
 _LOG = logging.getLogger("services.inbound_service")
 
 
+# Address fields the billing/shipping fraud heuristic compares.
+# Intentionally narrow -- street + city + state + postal, not name
+# (gift orders ship to a different recipient by design), phone (often
+# collected once), or country (operators mix ISO codes and full names,
+# which false-positives). Pairs are in mirror order so the comparison
+# loop stays a simple zip.
+_FRAUD_COMPARE_FIELDS = (
+    ("billing_address_line1",       "shipping_address_line1"),
+    ("billing_address_line2",       "shipping_address_line2"),
+    ("billing_address_city",        "shipping_address_city"),
+    ("billing_address_state",       "shipping_address_state"),
+    ("billing_address_postal_code", "shipping_address_postal_code"),
+)
+
+
+def _normalize_addr(value: Any) -> str:
+    """Lower + strip + collapse whitespace so 'Acme Co' / ' acme co '
+    do not trigger the fraud rule. Returns '' for None / blank input
+    so the caller can use it as a "blank?" check too."""
+    if value is None:
+        return ""
+    return " ".join(str(value).strip().lower().split())
+
+
+def _normalize_postal(value: Any) -> str:
+    """Strip non-alphanumerics so '80112-1234' / ' 80112 ' compare
+    cleanly. Empty for None / blank."""
+    if value is None:
+        return ""
+    return "".join(c for c in str(value).lower() if c.isalnum())
+
+
+def _addresses_diverge(payload: Dict[str, Any]) -> bool:
+    """True if at least one billing/shipping pair has BOTH sides
+    populated AND the populated values differ. Returning False when
+    either side is blank for a given field is intentional: a
+    missing/blank field bypasses the fraud filter so partial-mapping
+    or gift orders without a billing address do not false positive."""
+    for billing_key, shipping_key in _FRAUD_COMPARE_FIELDS:
+        if billing_key.endswith("_postal_code"):
+            b = _normalize_postal(payload.get(billing_key))
+            s = _normalize_postal(payload.get(shipping_key))
+        else:
+            b = _normalize_addr(payload.get(billing_key))
+            s = _normalize_addr(payload.get(shipping_key))
+        if not b or not s:
+            continue
+        if b != s:
+            return True
+    return False
+
+
+def _fraud_heuristic_enabled(db) -> bool:
+    """The billing != shipping fraud heuristic is opt-in. Returns True
+    only when the fraud_review_billing_shipping setting is explicitly
+    'true'; a missing row (fresh install) means disabled, so no order
+    is parked in FRAUD_REVIEW until an operator turns the rule on. It
+    is one built-in heuristic, not the whole surface -- a CSR can still
+    flag/clear manually on the Fraud page regardless of this setting."""
+    row = db.execute(
+        text("SELECT value FROM app_settings "
+             "WHERE key = 'fraud_review_billing_shipping'")
+    ).fetchone()
+    return bool(row) and str(row.value).lower() == "true"
+
+
 # Per-resource configuration. canonical_id_col is the column on the
 # canonical table that the cross_system_mappings.canonical_id and the
 # inbound staging table's canonical_id resolve to. For both existing
@@ -619,6 +685,20 @@ def _upsert_canonical(
     if existing_mapping is None:
         # First-time-receipt: INSERT canonical + INSERT cross_system_mappings.
         canonical_id = uuid.uuid4()
+
+        # Fraud auto-flag at ingest. Sales orders only, INSERT path
+        # only -- updates do NOT re-evaluate, so a CSR's decision to
+        # clear fraud cannot be undone by a later benign update from the
+        # source system. Opt-in: the billing/shipping heuristic only
+        # fires when fraud_review_billing_shipping is enabled, so a
+        # fresh install never parks an order in FRAUD_REVIEW.
+        if (
+            cfg.canonical_table == "sales_orders"
+            and _fraud_heuristic_enabled(db)
+            and _addresses_diverge(write_payload)
+        ):
+            write_payload["status"] = "FRAUD_REVIEW"
+
         # Existing tables (V-216 retrofit): set external_id only.
         # New tables (customers/vendors): set both canonical_id and external_id
         # equal so the cross_system_mappings.canonical_id resolves consistently.

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -1935,6 +1935,50 @@ class TestBinDelete:
         assert resp.status_code == 404
 
 
+class TestItemsSearchQ:
+    """The Items page search must reach the identifiers an operator
+    will type or scan: SKU, item name, primary UPC, and any entry in
+    the barcode_aliases JSONB array."""
+
+    def test_q_matches_sku(self, client, auth_headers):
+        resp = client.get("/api/admin/items?q=TST-005", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 1
+        assert all(i["sku"] == "TST-005" for i in data["items"])
+
+    def test_q_matches_upc(self, client, auth_headers):
+        # TST-005 has UPC 100000000005 in the seed.
+        resp = client.get("/api/admin/items?q=100000000005", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 1
+        assert any(i["sku"] == "TST-005" for i in data["items"])
+
+    def test_q_matches_barcode_alias(self, client, auth_headers):
+        # Attach an alternate barcode to TST-001 and confirm the
+        # search resolves it. Direct SQL because the admin create
+        # / update endpoints do not surface barcode_aliases yet.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE items SET barcode_aliases = %s::jsonb WHERE sku = 'TST-001'",
+            ('["ALT-9999-A", "ALT-9999-B"]',),
+        )
+        cur.close()
+
+        resp = client.get("/api/admin/items?q=ALT-9999-B", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 1
+        assert data["items"][0]["sku"] == "TST-001"
+
+    def test_q_no_match_returns_empty(self, client, auth_headers):
+        resp = client.get("/api/admin/items?q=no-such-thing-zzz", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.get_json()["total"] == 0
+
+
 class TestInventorySearchQ:
     """Issue #82: /admin/inventory must honour the `q` query parameter
     so the admin panel's SKU / item-name search actually filters rows."""

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -2012,6 +2012,63 @@ class TestInventorySearchQ:
         assert resp.status_code == 200
         assert resp.get_json()["total"] == baseline
 
+    def test_q_matches_upc(self, client, auth_headers):
+        # TST-005 has UPC 100000000005 in the seed. Operators scanning a
+        # barcode at the inventory page expect the row to surface even
+        # though the SKU is different.
+        resp = client.get(
+            "/api/admin/inventory?warehouse_id=1&q=100000000005",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 1
+        assert all(r["sku"] == "TST-005" for r in data["inventory"])
+
+    def test_q_matches_bin_code(self, client, auth_headers):
+        # TST-005 lives in bin A-02-02 per seed. Searching by the bin
+        # code returns the rows physically in that bin.
+        resp = client.get(
+            "/api/admin/inventory?warehouse_id=1&q=A-02-02",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 1
+        assert all(r["bin_code"] == "A-02-02" for r in data["inventory"])
+
+
+class TestInventoryBinFilter:
+    """The Inventory page exposes a bin-scoped dropdown that sends
+    bin_id; the backend has to honour it so the dropdown narrows the
+    list instead of being a silent no-op."""
+
+    def test_bin_id_filter_narrows_to_single_bin(self, client, auth_headers):
+        # Bin 11 (B-01-03) holds TST-009 and TST-010 per the shared-bin
+        # seed line; the filter should return exactly those rows.
+        resp = client.get(
+            "/api/admin/inventory?warehouse_id=1&bin_id=11",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] >= 2
+        assert all(r["bin_id"] == 11 for r in data["inventory"])
+        skus = {r["sku"] for r in data["inventory"]}
+        assert {"TST-009", "TST-010"}.issubset(skus)
+
+    def test_bin_id_filter_with_search_intersects(self, client, auth_headers):
+        # bin_id and q must AND together: bin 11 + sku TST-010 returns
+        # only TST-010, not TST-009 which shares the bin.
+        resp = client.get(
+            "/api/admin/inventory?warehouse_id=1&bin_id=11&q=TST-010",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 1
+        assert data["inventory"][0]["sku"] == "TST-010"
+
 
 class TestVendorsCRUD:
     """Admin CRUD over the canonical vendors table: validates

--- a/api/tests/test_admin_pos.py
+++ b/api/tests/test_admin_pos.py
@@ -1,0 +1,31 @@
+"""Smoke coverage for the POS Activity admin endpoints. These are
+read-only reporting surfaces (paginated POS sales-order list + daily
+KPI counters) that LEFT JOIN audit_log for POS_CHECKOUT metadata, so
+the value here is confirming the routes register and the SQL runs and
+returns the expected shape regardless of how much POS data exists."""
+
+
+class TestPosActivityAdmin:
+    def test_pos_sales_orders_list_shape(self, client, auth_headers):
+        resp = client.get("/api/admin/pos/sales-orders", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data["sales_orders"], list)
+        for key in ("total", "page", "per_page", "pages"):
+            assert key in data
+
+    def test_pos_summary_shape(self, client, auth_headers):
+        resp = client.get("/api/admin/pos/summary", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        today = data["today"]
+        for key in (
+            "sales_count", "sales_total_cents",
+            "refund_count", "refund_total_cents",
+        ):
+            assert isinstance(today[key], int)
+        assert isinstance(data["active_terminals"], list)
+
+    def test_pos_summary_requires_auth(self, client):
+        # Unauthenticated requests are rejected before reaching the query.
+        assert client.get("/api/admin/pos/summary").status_code in (401, 403)

--- a/api/tests/test_fraud_review.py
+++ b/api/tests/test_fraud_review.py
@@ -1,0 +1,420 @@
+"""Fraud-flag at ingest + admin push-to-queue + memo PATCH.
+
+Covers the ingest auto-flag scenarios (pure-match, mismatch on city,
+billing entirely blank, only blank-side differs, normalisation) and the
+admin endpoints that back the Outbound > Fraud page. The ingest
+heuristic is opt-in, so TestFraudIngest turns it on for the class.
+"""
+
+import json
+import os
+import sys
+import uuid
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import yaml
+
+import db_test_context
+from services import token_cache
+from services.mapping_loader import (
+    LoadedMappingFile,
+    MappingDocument,
+    MappingRegistry,
+)
+
+
+def _query(sql, params=()):
+    conn = db_test_context.get_raw_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(sql, params)
+        if cur.description is None:
+            return None
+        return cur.fetchall()
+    finally:
+        cur.close()
+
+
+# Mapping doc that exercises every billing/shipping field the fraud
+# rule cares about. Mirrors the v1.8.0 example template shape.
+_FRAUD_MAPPING = """\
+mapping_version: "1.0"
+source_system: "{ss}"
+version_compare: "iso_timestamp"
+resources:
+  sales_orders:
+    canonical_type: "sales_order"
+    fields:
+      - canonical: "so_number"
+        source_path: "$.orderNumber"
+        type: "string"
+        required: true
+      - canonical: "warehouse_id"
+        source_path: "$.warehouseId"
+        type: "integer"
+        required: true
+      - canonical: "customer_name"
+        source_path: "$.customer.name"
+        type: "string"
+      - canonical: "billing_address_line1"
+        source_path: "$.billing.line1"
+        type: "string"
+      - canonical: "billing_address_line2"
+        source_path: "$.billing.line2"
+        type: "string"
+      - canonical: "billing_address_city"
+        source_path: "$.billing.city"
+        type: "string"
+      - canonical: "billing_address_state"
+        source_path: "$.billing.state"
+        type: "string"
+      - canonical: "billing_address_postal_code"
+        source_path: "$.billing.zip"
+        type: "string"
+      - canonical: "shipping_address_line1"
+        source_path: "$.shipping.line1"
+        type: "string"
+      - canonical: "shipping_address_line2"
+        source_path: "$.shipping.line2"
+        type: "string"
+      - canonical: "shipping_address_city"
+        source_path: "$.shipping.city"
+        type: "string"
+      - canonical: "shipping_address_state"
+        source_path: "$.shipping.state"
+        type: "string"
+      - canonical: "shipping_address_postal_code"
+        source_path: "$.shipping.zip"
+        type: "string"
+"""
+
+
+def _build_registry(app, ss, body_yaml):
+    parsed = yaml.safe_load(body_yaml)
+    doc = MappingDocument.model_validate(parsed)
+    registry = MappingRegistry()
+    registry.register(LoadedMappingFile(
+        document=doc, path=f"<test:{ss}>", sha256="0" * 64,
+    ))
+    app.config["MAPPING_REGISTRY"] = registry
+
+
+def _fresh_source(prefix="fraudtest"):
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def _insert_via_test_conn(ss, plaintext, **kw):
+    import hashlib
+    import json as _json
+    from _wms_token_helpers import PEPPER
+
+    conn = db_test_context.get_raw_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "INSERT INTO inbound_source_systems_allowlist (source_system, kind) "
+            "VALUES (%s, 'internal_tool') ON CONFLICT DO NOTHING",
+            (ss,),
+        )
+        token_hash = hashlib.sha256((PEPPER + plaintext).encode()).hexdigest()
+        cur.execute(
+            "INSERT INTO wms_tokens "
+            "(token_name, token_hash, status, warehouse_ids, event_types, "
+            " endpoints, source_system, inbound_resources, mapping_override, "
+            " mapping_overrides) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb) "
+            "RETURNING token_id",
+            (
+                kw.get("name", f"fraud-test-{uuid.uuid4().hex[:6]}"),
+                token_hash, "active",
+                kw.get("warehouse_ids", [1]),
+                [], [],
+                ss,
+                kw.get("inbound_resources", ["sales_orders"]),
+                False,
+                _json.dumps({}),
+            ),
+        )
+        token_id = cur.fetchone()[0]
+    finally:
+        cur.close()
+    return token_id
+
+
+@pytest.fixture
+def scenario(app):
+    ss = _fresh_source()
+    return {"ss": ss}
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    token_cache.clear()
+    yield
+    token_cache.clear()
+
+
+def _setup(app, scenario, plaintext):
+    ss = scenario["ss"]
+    _build_registry(app, ss, _FRAUD_MAPPING.format(ss=ss))
+    _insert_via_test_conn(ss, plaintext)
+    return ss
+
+
+def _post_inbound(client, plaintext, body):
+    return client.post(
+        "/api/v1/inbound/sales_orders",
+        headers={"X-WMS-Token": plaintext, "Content-Type": "application/json"},
+        data=json.dumps(body),
+    )
+
+
+def _payload(order_number, *, billing=None, shipping=None):
+    body = {
+        "external_id": order_number,
+        "external_version": "2026-05-14T10:00:00+00:00",
+        "source_payload": {
+            "orderNumber": order_number,
+            "warehouseId": 1,
+            "customer": {"name": "Acme"},
+        },
+    }
+    if billing is not None:
+        body["source_payload"]["billing"] = billing
+    if shipping is not None:
+        body["source_payload"]["shipping"] = shipping
+    return body
+
+
+def _status_for(canonical_id):
+    rows = _query(
+        "SELECT status FROM sales_orders WHERE external_id = %s",
+        (canonical_id,),
+    )
+    return rows[0][0] if rows else None
+
+
+# ----------------------------------------------------------------------
+# Ingest: fraud auto-flag rule
+# ----------------------------------------------------------------------
+
+
+class TestFraudIngest:
+    @pytest.fixture(autouse=True)
+    def _enable_fraud_heuristic(self):
+        # The billing != shipping heuristic is opt-in (off by default).
+        # These tests exercise both its positive and negative paths, so
+        # enable it for the class.
+        _query(
+            "INSERT INTO app_settings (key, value) "
+            "VALUES ('fraud_review_billing_shipping', 'true') "
+            "ON CONFLICT (key) DO UPDATE SET value = 'true'"
+        )
+        yield
+
+    def test_billing_matches_shipping_stays_open(self, client, app, scenario):
+        _setup(app, scenario, "fraud-match")
+        addr = {"line1": "100 Main St", "city": "Denver",
+                "state": "CO", "zip": "80202"}
+        resp = _post_inbound(client, "fraud-match", _payload(
+            "SO-MATCH", billing=addr, shipping=addr,
+        ))
+        assert resp.status_code == 201
+        assert _status_for(resp.get_json()["canonical_id"]) == "OPEN"
+
+    def test_city_mismatch_flags_fraud(self, client, app, scenario):
+        _setup(app, scenario, "fraud-city")
+        resp = _post_inbound(client, "fraud-city", _payload(
+            "SO-CITYDIFF",
+            billing={"line1": "100 Main St", "city": "Houston",
+                     "state": "TX", "zip": "77002"},
+            shipping={"line1": "100 Main St", "city": "Miami",
+                      "state": "FL", "zip": "33101"},
+        ))
+        assert resp.status_code == 201
+        assert _status_for(resp.get_json()["canonical_id"]) == "FRAUD_REVIEW"
+
+    def test_billing_entirely_blank_stays_open(self, client, app, scenario):
+        # Tenant didn't map billing, or fabric didn't send it. Per the
+        # spec, blank-on-one-side bypasses the rule.
+        _setup(app, scenario, "fraud-blank")
+        resp = _post_inbound(client, "fraud-blank", _payload(
+            "SO-BLANKBILL",
+            shipping={"line1": "100 Main St", "city": "Denver",
+                      "state": "CO", "zip": "80202"},
+        ))
+        assert resp.status_code == 201
+        assert _status_for(resp.get_json()["canonical_id"]) == "OPEN"
+
+    def test_only_blank_side_differs_stays_open(self, client, app, scenario):
+        # billing has line2, shipping doesn't -- that field's
+        # comparison is bypassed; everything else matches; no flag.
+        _setup(app, scenario, "fraud-line2")
+        resp = _post_inbound(client, "fraud-line2", _payload(
+            "SO-LINE2ONLY",
+            billing={"line1": "100 Main St", "line2": "Apt 4B",
+                     "city": "Denver", "state": "CO", "zip": "80202"},
+            shipping={"line1": "100 Main St",
+                      "city": "Denver", "state": "CO", "zip": "80202"},
+        ))
+        assert resp.status_code == 201
+        assert _status_for(resp.get_json()["canonical_id"]) == "OPEN"
+
+    def test_case_and_whitespace_do_not_trigger(self, client, app, scenario):
+        _setup(app, scenario, "fraud-norm")
+        resp = _post_inbound(client, "fraud-norm", _payload(
+            "SO-NORM",
+            billing={"line1": "100 Main St", "city": "Denver",
+                     "state": "CO", "zip": "80202"},
+            shipping={"line1": "  100 main st  ", "city": "DENVER",
+                      "state": "co", "zip": "80202"},
+        ))
+        assert resp.status_code == 201
+        assert _status_for(resp.get_json()["canonical_id"]) == "OPEN"
+
+    def test_postal_dash_stripped_for_compare(self, client, app, scenario):
+        # "80202" and "80202" with one side dashed-formatted are still
+        # the same 5-digit ZIP -> no fraud. Different ZIP+4 extensions
+        # (different physical locations) DO trigger; that's covered by
+        # the city-mismatch test above which would differ on multiple
+        # fields anyway.
+        _setup(app, scenario, "fraud-postal")
+        resp = _post_inbound(client, "fraud-postal", _payload(
+            "SO-POSTAL",
+            billing={"line1": "100 Main St", "city": "Denver",
+                     "state": "CO", "zip": "80202"},
+            shipping={"line1": "100 Main St", "city": "Denver",
+                      "state": "CO", "zip": " 80202 "},
+        ))
+        assert resp.status_code == 201
+        assert _status_for(resp.get_json()["canonical_id"]) == "OPEN"
+
+
+# ----------------------------------------------------------------------
+# Admin: push-to-queue + memo PATCH
+# ----------------------------------------------------------------------
+
+
+def _seed_so(status, *, memo=None):
+    """INSERT a minimal sales_orders row in the test transaction and
+    return so_id. Bypasses the inbound flow so we can isolate the
+    admin endpoints under test."""
+    so_number = f"SO-ADMIN-{uuid.uuid4().hex[:6]}"
+    rows = _query(
+        "INSERT INTO sales_orders (so_number, status, warehouse_id, "
+        "                          external_id, memo) "
+        "VALUES (%s, %s, 1, %s, %s) RETURNING so_id",
+        (so_number, status, str(uuid.uuid4()), memo),
+    )
+    return rows[0][0]
+
+
+class TestPushToQueue:
+    def test_fraud_review_order_moves_to_open(self, client, auth_headers):
+        so_id = _seed_so("FRAUD_REVIEW")
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/push-to-queue",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "OPEN"
+        assert _query("SELECT status FROM sales_orders WHERE so_id = %s",
+                      (so_id,))[0][0] == "OPEN"
+
+    def test_open_order_returns_409(self, client, auth_headers):
+        so_id = _seed_so("OPEN")
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/push-to-queue",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 409
+        assert _query("SELECT status FROM sales_orders WHERE so_id = %s",
+                      (so_id,))[0][0] == "OPEN"
+
+    def test_unknown_so_returns_404(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/sales-orders/99999999/push-to-queue",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404
+
+    def test_audit_log_entry_written(self, client, auth_headers):
+        so_id = _seed_so("FRAUD_REVIEW")
+        resp = client.post(
+            f"/api/admin/sales-orders/{so_id}/push-to-queue",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        rows = _query(
+            "SELECT action_type, details FROM audit_log "
+            " WHERE entity_type = 'SO' AND entity_id = %s "
+            "   AND action_type = 'SO_FRAUD_CLEARED'",
+            (so_id,),
+        )
+        assert rows, "no SO_FRAUD_CLEARED audit row found"
+        action_type, details = rows[0]
+        assert action_type == "SO_FRAUD_CLEARED"
+        assert details["from_status"] == "FRAUD_REVIEW"
+        assert details["to_status"] == "OPEN"
+
+
+class TestMemoPatch:
+    def test_set_memo_persists(self, client, auth_headers):
+        so_id = _seed_so("FRAUD_REVIEW")
+        resp = client.patch(
+            f"/api/admin/sales-orders/{so_id}/memo",
+            headers=auth_headers,
+            json={"memo": "called customer, awaiting confirmation"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["memo"] == "called customer, awaiting confirmation"
+        assert _query("SELECT memo FROM sales_orders WHERE so_id = %s",
+                      (so_id,))[0][0] == "called customer, awaiting confirmation"
+
+    def test_empty_string_clears_to_null(self, client, auth_headers):
+        so_id = _seed_so("FRAUD_REVIEW", memo="prior note")
+        resp = client.patch(
+            f"/api/admin/sales-orders/{so_id}/memo",
+            headers=auth_headers,
+            json={"memo": ""},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["memo"] is None
+        assert _query("SELECT memo FROM sales_orders WHERE so_id = %s",
+                      (so_id,))[0][0] is None
+
+    def test_unchanged_value_returns_unchanged(self, client, auth_headers):
+        so_id = _seed_so("FRAUD_REVIEW", memo="same")
+        resp = client.patch(
+            f"/api/admin/sales-orders/{so_id}/memo",
+            headers=auth_headers,
+            json={"memo": "same"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json().get("unchanged") is True
+
+    def test_audit_log_records_diff(self, client, auth_headers):
+        so_id = _seed_so("FRAUD_REVIEW", memo="old note")
+        client.patch(
+            f"/api/admin/sales-orders/{so_id}/memo",
+            headers=auth_headers,
+            json={"memo": "new note"},
+        )
+        rows = _query(
+            "SELECT action_type, details FROM audit_log "
+            " WHERE entity_type = 'SO' AND entity_id = %s "
+            "   AND action_type = 'SO_MEMO_EDITED'",
+            (so_id,),
+        )
+        assert rows, "no SO_MEMO_EDITED audit row found"
+        _, details = rows[0]
+        assert details["old_value"] == "old note"
+        assert details["new_value"] == "new note"

--- a/api/tests/test_putaway.py
+++ b/api/tests/test_putaway.py
@@ -38,6 +38,29 @@ class TestPendingPutaway:
         assert len(data["pending_items"]) == 0
 
 
+class TestStagingSummary:
+    def test_empty_staging_bins_still_render(self, client, auth_headers):
+        # Fresh seed: nothing received. The dashboard still lists every
+        # staging bin so the supervisor sees the full map, each as a
+        # zero-count card rather than an empty worklist.
+        resp = client.get("/api/putaway/staging-summary/1", headers=auth_headers)
+        assert resp.status_code == 200
+        bins = resp.get_json()["bins"]
+        assert len(bins) >= 1
+        assert all(b["sku_count"] == 0 and b["items"] == [] for b in bins)
+
+    def test_staging_summary_counts_received_inventory(self, client, auth_headers):
+        _receive_to_staging(client, auth_headers, item_id=1, quantity=10, bin_id=1)
+        resp = client.get("/api/putaway/staging-summary/1", headers=auth_headers)
+        assert resp.status_code == 200
+        bins = resp.get_json()["bins"]
+        filled = [b for b in bins if b["sku_count"] > 0]
+        assert len(filled) == 1
+        assert filled[0]["bin_id"] == 1
+        assert filled[0]["total_qty"] == 10
+        assert "TST-001" in [it["sku"] for it in filled[0]["items"]]
+
+
 class TestBinSuggestion:
     def test_suggest_returns_default_bin(self, client, auth_headers):
         # Item 1 (TST-001) has default_bin_id = 3 (A-01-01)

--- a/db/migrations/066_sales_orders_fraud_review_status.sql
+++ b/db/migrations/066_sales_orders_fraud_review_status.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- Migration 066: sales_orders FRAUD_REVIEW status
+-- ============================================================
+-- Backs the new Outbound > Fraud queue. A sales order can carry
+-- status='FRAUD_REVIEW' to hold it out of the picking queue until a
+-- CSR clears it (auto-flagged at ingest when the billing/shipping
+-- heuristic is enabled, or set manually).
+--
+-- No DDL is required:
+--   * status is plain VARCHAR(20) with no DB CHECK, so the new value
+--     needs no column change; api/constants.py is the source of truth
+--     for the allowed set (SO_FRAUD_REVIEW).
+--   * the CSR memo field (sales_orders.memo) already shipped in
+--     migration 055.
+--
+-- This migration only refreshes the inline column comment so schema
+-- readers see the full status enum. Forward-only: it does not scan or
+-- re-evaluate existing orders.
+--
+-- Migration discipline (V-213): SET lock_timeout / statement_timeout,
+-- BEGIN/COMMIT-wrapped.
+-- ============================================================
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+COMMENT ON COLUMN sales_orders.status IS
+    'Lifecycle: OPEN, PICKED, PACKED, SHIPPED, CANCELLED, FRAUD_REVIEW. PICKING/PACKING retired in mig 060. Enforced by api/constants.py, not by a DB CHECK.';
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -185,7 +185,7 @@ CREATE TABLE sales_orders (
     customer_id VARCHAR(50),
     customer_phone VARCHAR(50),
     customer_address TEXT,
-    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED'. PICKING/PACKING retired in mig 060; "in picking" is derived from pick_batches.
+    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED', 'FRAUD_REVIEW'. PICKING/PACKING retired in mig 060; "in picking" is derived from pick_batches.
     priority INT DEFAULT 0,                -- higher = pick first
     warehouse_id INT NOT NULL REFERENCES warehouses(warehouse_id),
     ship_method VARCHAR(50),


### PR DESCRIPTION
Adds an Outbound > Fraud queue. A sales order can be held at
status=FRAUD_REVIEW (out of the picking queue) until a CSR clears it.

The billing != shipping heuristic that auto-flags at ingest is opt-in:
it only fires when the fraud_review_billing_shipping setting is enabled
(off by default, in Settings > Fraud Review), so a fresh install never
parks orders in FRAUD_REVIEW on its own. It is one built-in heuristic,
not the whole surface; a CSR can flag or clear manually regardless.

- Backend: SO_FRAUD_REVIEW status (no DB CHECK; migration 066 is a
  comment-only refresh, no DDL); ingest flags on first receipt when
  enabled and addresses diverge (line1/line2/city/state/postal,
  normalised, both sides populated); PATCH .../memo and POST
  .../push-to-queue gated by a new `fraud` page permission, each writing
  an audit row; the SO list returns the structured address columns.
- Admin UI: a /fraud page (billing/shipping side by side, inline memo,
  push-to-queue), the `fraud` page key in the sidebar + Users grid, and
  the heuristic toggle in Settings.

Note: stacked on #379 and #380; its commits show here until those merge,
after which this reduces to the single fraud commit.