### PR TITLE
feat: partial-fulfillment + backorders

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -3440,9 +3440,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -16,6 +16,7 @@ import PickingTickets from './pages/PickingTickets.jsx';
 import PickingTicketPrint from './pages/PickingTicketPrint.jsx';
 import PickingTicketPrintAll from './pages/PickingTicketPrintAll.jsx';
 import PickingBatches from './pages/PickingBatches.jsx';
+import Backorders from './pages/Backorders.jsx';
 import Bins from './pages/Bins.jsx';
 import Zones from './pages/Zones.jsx';
 import Items from './pages/Items.jsx';
@@ -97,6 +98,7 @@ export default function App() {
         <Route path="/sales-orders" element={<ErrorBoundary fallbackMessage="Could not load sales orders."><SalesOrders /></ErrorBoundary>} />
         <Route path="/pos-activity" element={<ErrorBoundary fallbackMessage="Could not load POS activity."><POSActivity /></ErrorBoundary>} />
         <Route path="/fraud" element={<ErrorBoundary fallbackMessage="Could not load fraud queue."><Fraud /></ErrorBoundary>} />
+        <Route path="/backorders" element={<ErrorBoundary fallbackMessage="Could not load backorders."><Backorders /></ErrorBoundary>} />
         <Route path="/picking-tickets" element={<ErrorBoundary fallbackMessage="Could not load picking tickets."><PickingTickets /></ErrorBoundary>} />
         {/* The /picking, /packing, /shipping admin pages were retired:
             the workflow lives on the handheld scanners, and the

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -34,6 +34,8 @@ const NAV = [
       { to: '/sales-orders', label: 'Sales Orders', pageKey: 'sales-orders' },
       { to: '/pos-activity', label: 'POS Activity' },
       { to: '/fraud', label: 'Fraud', pageKey: 'fraud' },
+      // Partial-fulfill / backorders dashboard.
+      { to: '/backorders', label: 'Backorders', pageKey: 'backorders' },
       { to: '/picking-tickets', label: 'Picking Tickets', pageKey: 'picking-tickets' },
       // Picking/Packing/Shipping are mobile-only: the admin-side
       // mirrors were retired. Supervisors use Sales Orders + Picking

--- a/admin/src/pages/Backorders.jsx
+++ b/admin/src/pages/Backorders.jsx
@@ -1,0 +1,266 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '../api.js';
+import { useWarehouse } from '../warehouse.jsx';
+import DataTable from '../components/DataTable.jsx';
+import PageHeader from '../components/PageHeader.jsx';
+import Modal from '../components/Modal.jsx';
+
+// Partial-fulfill / backorders dashboard. Two tabs:
+//   Waiting       - status=WAITING_STOCK, oldest backorder_opened_at
+//                   surfaces first so a long-tail backorder is not
+//                   buried under a fresh one.
+//   Ready to ship - status IN (OPEN, PICKED, PACKED) with
+//                   backorder_opened_at IS NOT NULL. These have been
+//                   flipped to OPEN by the receipt-hook matcher and
+//                   are eligible for the next pick batch.
+// Click row opens the existing SO edit modal via
+// /sales-orders?focus=<so_number>; the SO page reads the focus query
+// param and pops the modal in-place.
+
+const TABS = [
+  { key: 'waiting', label: 'Waiting' },
+  { key: 'ready-to-ship', label: 'Ready to Ship' },
+];
+
+const CANCEL_REASONS = [
+  { value: 'found', label: 'Found in warehouse' },
+  { value: 'customer_asked', label: 'Customer asked to cancel' },
+  { value: 'refunded', label: 'Refunded' },
+  { value: 'other', label: 'Other' },
+];
+
+
+function ItemsCell({ items }) {
+  if (!items || items.length === 0) {
+    return <span style={{ color: 'var(--text-secondary)' }}>(none)</span>;
+  }
+  return (
+    <div style={{ fontSize: 12, lineHeight: 1.4 }}>
+      {items.map((it, i) => (
+        <div key={i}>
+          <span className="mono">{it.sku}</span>
+          {' × '}
+          {it.qty}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+
+export default function Backorders() {
+  const navigate = useNavigate();
+  const { warehouseId } = useWarehouse();
+  const [tab, setTab] = useState('waiting');
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [actionError, setActionError] = useState('');
+  const [successBanner, setSuccessBanner] = useState('');
+
+  // Cancel-BO confirm modal state. cancelTarget holds the BO row
+  // being cancelled; cancelReason is a dropdown enum mirroring the
+  // backend's CANCEL_REASONS.
+  const [cancelTarget, setCancelTarget] = useState(null);
+  const [cancelReason, setCancelReason] = useState('other');
+  const [cancelSubmitting, setCancelSubmitting] = useState(false);
+  const [cancelError, setCancelError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setActionError('');
+    const qs = new URLSearchParams({ tab });
+    if (warehouseId) qs.set('warehouse_id', String(warehouseId));
+    const res = await api.get(`/admin/backorders?${qs.toString()}`);
+    if (res?.ok) {
+      const data = await res.json();
+      setRows(data.backorders || []);
+    } else {
+      setRows([]);
+      setActionError('Failed to load backorders.');
+    }
+    setLoading(false);
+  }, [tab, warehouseId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  function openCancel(row) {
+    setCancelTarget(row);
+    setCancelReason('other');
+    setCancelError('');
+  }
+
+  function closeCancel() {
+    setCancelTarget(null);
+    setCancelReason('other');
+    setCancelError('');
+    setCancelSubmitting(false);
+  }
+
+  async function submitCancel() {
+    if (!cancelTarget) return;
+    setCancelSubmitting(true);
+    setCancelError('');
+    const res = await api.post(
+      `/admin/sales-orders/${cancelTarget.so_id}/cancel-backorder`,
+      { cancellation_reason: cancelReason },
+    );
+    setCancelSubmitting(false);
+    if (!res?.ok) {
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON */ }
+      setCancelError(data?.error || 'Failed to cancel backorder.');
+      return;
+    }
+    const soNumber = cancelTarget.so_number;
+    closeCancel();
+    setSuccessBanner(`Backorder ${soNumber} cancelled (${cancelReason}).`);
+    setTimeout(() => setSuccessBanner(''), 6000);
+    load();
+  }
+
+  // Both tabs share a base column set; ready-to-ship adds
+  // "Fulfillable since" so the operator can prioritise the longest-
+  // waiting ready batch first.
+  const baseColumns = [
+    { key: 'so_number', label: 'Backorder #', mono: true },
+    { key: 'parent_so_number', label: 'Parent SO', mono: true,
+      render: (r) => r.parent_so_number || <span style={{ color: 'var(--text-secondary)' }}>-</span> },
+    { key: 'customer_name', label: 'Customer',
+      render: (r) => r.customer_name || <span style={{ color: 'var(--text-secondary)' }}>-</span> },
+    { key: 'items', label: 'Items', render: (r) => <ItemsCell items={r.items} /> },
+    { key: 'days_waiting', label: 'Days waiting',
+      render: (r) => (
+        <span className="mono">
+          {r.days_waiting}
+        </span>
+      ),
+    },
+  ];
+
+  const readyColumn = {
+    key: 'fulfillable_since',
+    label: 'Fulfillable since',
+    render: (r) => r.fulfillable_since
+      ? new Date(r.fulfillable_since).toLocaleDateString()
+      : <span style={{ color: 'var(--text-secondary)' }}>-</span>,
+  };
+
+  const actionsColumn = {
+    key: 'actions',
+    label: '',
+    render: (r) => (
+      <button
+        className="btn btn-sm btn-danger"
+        onClick={(e) => { e.stopPropagation(); openCancel(r); }}
+        title="Cancel this backorder"
+      >
+        Cancel
+      </button>
+    ),
+  };
+
+  const columns = tab === 'ready-to-ship'
+    ? [...baseColumns, readyColumn, actionsColumn]
+    : [...baseColumns, actionsColumn];
+
+  function openRowInSalesOrders(row) {
+    // The SO list page reads ?focus=<so_number> to auto-open the
+    // edit modal for that row. Mirrors the deep-link pattern the
+    // Teams adaptive card uses so /backorders -> click -> SO modal
+    // is the same path as Teams ping -> Open in Sentry -> SO modal.
+    navigate(`/sales-orders?focus=${encodeURIComponent(row.so_number)}`);
+  }
+
+  return (
+    <div>
+      <PageHeader title="Backorders" />
+      {successBanner && (
+        <div
+          role="status"
+          style={{
+            margin: '0 0 12px 0',
+            padding: '8px 12px',
+            background: 'var(--success-bg, #e8f5e9)',
+            color: 'var(--success, #2e7d32)',
+            border: '1px solid var(--success, #2e7d32)',
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {successBanner}
+        </div>
+      )}
+      {actionError && (
+        <div className="form-error" style={{ marginBottom: 12 }}>{actionError}</div>
+      )}
+      <div className="section">
+        <div role="tablist" style={{ display: 'flex', gap: 4, marginBottom: 12 }}>
+          {TABS.map((t) => (
+            <button
+              key={t.key}
+              role="tab"
+              aria-selected={tab === t.key}
+              className={`btn ${tab === t.key ? 'btn-primary' : ''}`}
+              onClick={() => setTab(t.key)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <DataTable
+          columns={columns}
+          data={rows}
+          loading={loading}
+          emptyMessage={tab === 'waiting'
+            ? 'No backorders waiting for stock.'
+            : 'No backorders are ready to ship right now.'}
+          onRowClick={openRowInSalesOrders}
+        />
+      </div>
+
+      {cancelTarget && (
+        <Modal
+          title={`Cancel backorder ${cancelTarget.so_number}?`}
+          onClose={closeCancel}
+          footer={
+            <>
+              <button className="btn" onClick={closeCancel} disabled={cancelSubmitting}>
+                Keep Backorder
+              </button>
+              <button
+                className="btn btn-danger"
+                onClick={submitCancel}
+                disabled={cancelSubmitting}
+              >
+                {cancelSubmitting ? 'Cancelling...' : 'Cancel Backorder'}
+              </button>
+            </>
+          }
+        >
+          {cancelError && (
+            <div className="form-error" style={{ marginBottom: 12 }}>{cancelError}</div>
+          )}
+          <p style={{ fontSize: 13, marginBottom: 12 }}>
+            Cancelling will mark <strong>{cancelTarget.so_number}</strong> as
+            CANCELLED. The parent SO (<span className="mono">{cancelTarget.parent_so_number}</span>)
+            is unaffected. A backorder.cancelled event fires on the
+            integration outbox + Teams channel.
+          </p>
+          <div className="form-group">
+            <label>Reason</label>
+            <select
+              className="form-select"
+              value={cancelReason}
+              onChange={(e) => setCancelReason(e.target.value)}
+            >
+              {CANCEL_REASONS.map((r) => (
+                <option key={r.value} value={r.value}>{r.label}</option>
+              ))}
+            </select>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -143,6 +143,29 @@ export default function SalesOrders() {
 
   useEffect(() => { loadOrders(); }, [page, statusFilter, search]);  // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ?focus=<so_number> deep-link. /backorders click-through
+  // and the Teams adaptive card both land here with focus set so the
+  // operator goes straight to the edit modal instead of hunting for
+  // the row in the list. Effect runs once per focus param change;
+  // looks up the SO by number via the list endpoint, opens the
+  // modal on the first match.
+  useEffect(() => {
+    const target = searchParams.get('focus');
+    if (!target) return;
+    let cancelled = false;
+    (async () => {
+      const qs = new URLSearchParams({ q: target, per_page: '1' });
+      const res = await api.get(`/admin/sales-orders?${qs.toString()}`);
+      if (!res?.ok || cancelled) return;
+      const data = await res.json();
+      const row = (data.sales_orders || []).find(
+        (r) => String(r.so_number).toLowerCase() === String(target).toLowerCase(),
+      );
+      if (row && !cancelled) openEdit(row);
+    })();
+    return () => { cancelled = true; };
+  }, [searchParams]);  // eslint-disable-line react-hooks/exhaustive-deps
+
   useEffect(() => {
     api.get('/admin/source-systems', { silentPermissionDenied: true }).then(async (res) => {
       if (!res?.ok) return;

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -111,6 +111,16 @@ export default function SalesOrders() {
   // Address fields moved inline into editForm; the separate
   // address modal is retired.
   const [revertConfirm, setRevertConfirm] = useState(null);
+  // Partial-fulfill sub-modal. partialFulfilling holds the SO
+  // being shorted; partialForm carries the per-line short_qty inputs
+  // (keyed by so_line_id) plus a free-text reason. Banner message
+  // appears on the SO list after a successful partial-fulfill so the
+  // operator sees "Backorder SO-12345-BO created" without a toast lib.
+  const [partialFulfilling, setPartialFulfilling] = useState(null);
+  const [partialForm, setPartialForm] = useState({ shorts: {}, reason: '' });
+  const [partialError, setPartialError] = useState('');
+  const [partialSubmitting, setPartialSubmitting] = useState(false);
+  const [successBanner, setSuccessBanner] = useState('');
   // SO line CRUD inside the edit modal (mig 062). State
   // mirrors PurchaseOrders.jsx: editLines is the working copy, optimistic
   // PATCH/POST/DELETE update it without refetching; lineErrors keep
@@ -692,6 +702,68 @@ export default function SalesOrders() {
     }
   }
 
+  // ── Partial-fulfill ──────────────────────────────────────────────────────
+
+  function openPartialFulfill() {
+    // Seed the form with empty short_qty per pickable line so the
+    // operator only needs to fill rows they actually want to short.
+    // Pickable lines = quantity_ordered > quantity_picked (the spec's
+    // PICKED-shorting validation; OPEN lines have quantity_picked=0).
+    const shorts = {};
+    for (const line of editLines || []) {
+      const unshipped = (line.quantity_ordered || 0) - (line.quantity_picked || 0);
+      if (unshipped > 0) shorts[line.so_line_id] = '';
+    }
+    setPartialForm({ shorts, reason: '' });
+    setPartialError('');
+    setPartialFulfilling(editing);
+  }
+
+  function closePartialFulfill() {
+    setPartialFulfilling(null);
+    setPartialForm({ shorts: {}, reason: '' });
+    setPartialError('');
+    setPartialSubmitting(false);
+  }
+
+  async function submitPartialFulfill() {
+    setPartialError('');
+    const lines = [];
+    for (const [solId, raw] of Object.entries(partialForm.shorts)) {
+      const qty = parseInt(raw, 10);
+      if (!raw || isNaN(qty) || qty <= 0) continue;
+      lines.push({ so_line_id: Number(solId), short_qty: qty });
+    }
+    if (lines.length === 0) {
+      setPartialError('Enter a short qty on at least one line.');
+      return;
+    }
+    setPartialSubmitting(true);
+    try {
+      const res = await api.post(
+        `/admin/sales-orders/${partialFulfilling.so_id}/partial-fulfill`,
+        { lines, reason_detail: partialForm.reason || undefined },
+      );
+      if (!res?.ok) {
+        let data = null;
+        try { data = await res?.json(); } catch (_) { /* non-JSON */ }
+        setPartialError(formatApiError(data, 'Failed to partial-fulfill'));
+        return;
+      }
+      const data = await res.json();
+      const boNumber = data.backorder_so?.so_number || '(unknown BO)';
+      closePartialFulfill();
+      closeEdit();
+      setSuccessBanner(`Backorder ${boNumber} created.`);
+      // Auto-clear the banner after a few seconds so it does not
+      // shadow later actions on the list.
+      setTimeout(() => setSuccessBanner(''), 6000);
+      loadOrders();
+    } finally {
+      setPartialSubmitting(false);
+    }
+  }
+
   async function cancelSO() {
     setEditError('');
     const res = await api.post(`/admin/sales-orders/${editing.so_id}/cancel`, {});
@@ -720,6 +792,22 @@ export default function SalesOrders() {
   return (
     <div>
       <PageHeader title="Sales Orders" />
+      {successBanner && (
+        <div
+          role="status"
+          style={{
+            margin: '0 0 12px 0',
+            padding: '8px 12px',
+            background: 'var(--success-bg, #e8f5e9)',
+            color: 'var(--success, #2e7d32)',
+            border: '1px solid var(--success, #2e7d32)',
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {successBanner}
+        </div>
+      )}
 
       <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
         <label style={{ fontSize: 13, color: 'var(--text-secondary)' }}>Status:</label>
@@ -908,6 +996,23 @@ export default function SalesOrders() {
                     onClick={() => openReleaseOnly(editing._pick_tasks || [])}
                     title="Release picked inventory back to source bins without changing status"
                   >Release Picked Quantities</button>
+                )}
+                {/* Partial-fulfill. Status gate {OPEN, PICKED};
+                    PICKED requires admin/so-full-edit so the button
+                    hides for a base sales-orders USER on a PICKED SO
+                    (the backend would 403 anyway). Hidden on
+                    backorders to enforce the one-level chaining cap
+                    (the backend rejects too; UI hides for clarity). */}
+                {['OPEN', 'PICKED'].includes(status)
+                  && !editing.parent_so_id
+                  && editing.order_type !== 'refund'
+                  && (isAdmin || hasSOFullEdit || status === 'OPEN') && (
+                  <button
+                    className="btn btn-warning"
+                    onClick={openPartialFulfill}
+                  >
+                    Partially Fulfill
+                  </button>
                 )}
                 <button className="btn" onClick={closeEdit}>Cancel</button>
                 <button className="btn btn-primary" onClick={saveEdit} disabled={!headerEditable}>Save</button>
@@ -1520,6 +1625,102 @@ export default function SalesOrders() {
           </Modal>
         );
       })()}
+
+      {/* Partial-fulfill sub-modal. Renders on top of the SO edit
+          modal; submit closes both. Per-line short_qty inputs gated
+          by max = quantity_ordered - quantity_picked so the UI mirrors
+          the server validation. */}
+      {partialFulfilling && (
+        <Modal
+          title={`Partially fulfill ${partialFulfilling.so_number}`}
+          onClose={closePartialFulfill}
+          size="wide"
+          footer={
+            <>
+              <button className="btn" onClick={closePartialFulfill} disabled={partialSubmitting}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-warning"
+                onClick={submitPartialFulfill}
+                disabled={partialSubmitting}
+              >
+                {partialSubmitting ? 'Creating BO...' : 'Ship Available + Create Backorder'}
+              </button>
+            </>
+          }
+        >
+          {partialError && (
+            <div className="form-error" style={{ marginBottom: 12 }}>{partialError}</div>
+          )}
+          <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 12 }}>
+            Enter the number of units you cannot ship per line. Shorted
+            quantities move to a new backorder ({partialFulfilling.so_number}-BO,
+            status WAITING_STOCK) and the original SO continues with the
+            remainder. Lines shrunk to zero are removed; rows below
+            already-picked qty are not editable.
+          </p>
+          {(editLines || []).length === 0 ? (
+            <p style={{ fontSize: 13 }}>No lines on this order.</p>
+          ) : (
+            <table className="data-table" style={{ marginBottom: 12 }}>
+              <thead>
+                <tr>
+                  <th>Line</th>
+                  <th>SKU</th>
+                  <th>Item</th>
+                  <th style={{ textAlign: 'right' }}>Ordered</th>
+                  <th style={{ textAlign: 'right' }}>Picked</th>
+                  <th style={{ textAlign: 'right' }}>Unshipped</th>
+                  <th style={{ width: 100 }}>Short</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(editLines || []).map((line) => {
+                  const unshipped = (line.quantity_ordered || 0) - (line.quantity_picked || 0);
+                  const disabled = unshipped <= 0;
+                  return (
+                    <tr key={line.so_line_id}>
+                      <td>{line.line_number}</td>
+                      <td className="mono">{line.sku}</td>
+                      <td>{line.item_name}</td>
+                      <td style={{ textAlign: 'right' }}>{line.quantity_ordered}</td>
+                      <td style={{ textAlign: 'right' }}>{line.quantity_picked}</td>
+                      <td style={{ textAlign: 'right' }}>{unshipped}</td>
+                      <td>
+                        <input
+                          type="number"
+                          className="form-input"
+                          min={0}
+                          max={unshipped}
+                          step={1}
+                          disabled={disabled}
+                          value={partialForm.shorts[line.so_line_id] ?? ''}
+                          onChange={(e) => setPartialForm((prev) => ({
+                            ...prev,
+                            shorts: { ...prev.shorts, [line.so_line_id]: e.target.value },
+                          }))}
+                          placeholder={disabled ? '-' : '0'}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+          <div className="form-group">
+            <label>Reason (free text, audit-logged)</label>
+            <input
+              className="form-input"
+              value={partialForm.reason}
+              onChange={(e) => setPartialForm((prev) => ({ ...prev, reason: e.target.value }))}
+              placeholder="e.g. physical count came up short"
+              maxLength={500}
+            />
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/api/constants.py
+++ b/api/constants.py
@@ -250,6 +250,12 @@ ALL_PAGE_KEYS = (
     "inventory", "cycle-counts", "count-approvals",
     "purchase-orders", "receiving", "putaway",
     "sales-orders",
+    # Partial-fulfill / backorders (Outbound). Holders see the
+    # /backorders dashboard plus the cancel-backorder action. The
+    # partial-fulfill action itself is gated by 'sales-orders' since it
+    # lives on the SO edit modal; this key only gates the dedicated
+    # dashboard.
+    "backorders",
     # Fraud (Outbound): the review queue for SOs held at FRAUD_REVIEW.
     # Holders see the /fraud page and can edit the CSR memo or push an
     # order back into the picking queue.

--- a/api/constants.py
+++ b/api/constants.py
@@ -29,6 +29,34 @@ SO_CANCELLED = "CANCELLED"
 # billing/shipping heuristic is enabled, or set manually). Excluded
 # from the picking queue until a CSR clears via the Fraud page.
 SO_FRAUD_REVIEW = "FRAUD_REVIEW"
+
+# mig 067: backorder-only off-ramp. A BO SO created via
+# /partial-fulfill starts here and flips to OPEN when receipt.completed
+# makes all its lines satisfiable. Hidden from picker queues by the
+# existing status != OPEN gate in create_pick_batch / wave_create.
+SO_WAITING_STOCK = "WAITING_STOCK"
+
+# Sales Order order_type (mig 056 + mig 067 CHECK expansion)
+ORDER_TYPE_SALE      = "sale"
+ORDER_TYPE_REFUND    = "refund"
+ORDER_TYPE_BACKORDER = "backorder"
+
+# mig 067: sales_orders.cancellation_reason allowed values.
+# App-enforced enum (no DB CHECK). Set by /cancel-backorder
+# (operator-supplied) or by the parent-cancel cascade in
+# sales_order_service.cancel_sales_order.
+CANCEL_REASON_FOUND            = "found"
+CANCEL_REASON_CUSTOMER_ASKED   = "customer_asked"
+CANCEL_REASON_REFUNDED         = "refunded"
+CANCEL_REASON_PARENT_CANCELLED = "parent_cancelled"
+CANCEL_REASON_OTHER            = "other"
+CANCEL_REASONS = (
+    CANCEL_REASON_FOUND,
+    CANCEL_REASON_CUSTOMER_ASKED,
+    CANCEL_REASON_REFUNDED,
+    CANCEL_REASON_PARENT_CANCELLED,
+    CANCEL_REASON_OTHER,
+)
 # Company-wide timezone for operator-facing calendar dates (e.g. the
 # Shipped Date on the SO modal). Timestamps are stored in UTC; this is
 # the single zone used to convert them to the local calendar date
@@ -65,6 +93,16 @@ ADJ_PENDING = "PENDING"
 ADJ_APPROVED = "APPROVED"
 ADJ_REJECTED = "REJECTED"
 
+# Inventory Adjustment reason codes (mig 067 added SHORT). App-enforced
+# enum (no DB CHECK). SHORT is written by /partial-fulfill when on-hand
+# stock exists for a shorted line; reason_detail carries the BO SO #.
+ADJ_REASON_CYCLE_COUNT = "CYCLE_COUNT"
+ADJ_REASON_DAMAGE      = "DAMAGE"
+ADJ_REASON_FOUND       = "FOUND"
+ADJ_REASON_LOST        = "LOST"
+ADJ_REASON_CORRECTION  = "CORRECTION"
+ADJ_REASON_SHORT       = "SHORT"
+
 # Audit Log action types
 ACTION_RECEIVE = "RECEIVE"
 ACTION_RECEIVE_CANCEL = "RECEIVE_CANCEL"
@@ -84,6 +122,14 @@ ACTION_POS_REFUND = "POS_REFUND"
 # operator. Pre-PICKED states release allocation; PICKED/PACKED states
 # revert inventory to the default receiving bin.
 ACTION_CANCEL = "CANCEL"
+# Partial-fulfill / backorders. Two rows per partial-fulfill
+# call: one on the original SO (shrink summary), one on the new BO SO
+# (creation). BACKORDER_CANCELLED is emitted by /cancel-backorder
+# alongside the existing CANCEL row that cancel_sales_order writes;
+# kept distinct so dashboards can split BO-only cancels from regular
+# CANCEL volume.
+ACTION_PARTIAL_FULFILL     = "PARTIAL_FULFILL"
+ACTION_BACKORDER_CANCELLED = "BACKORDER_CANCELLED"
 ACTION_TRANSFER = "TRANSFER"
 ACTION_ADJUST = "ADJUST"
 ACTION_COUNT = "COUNT"

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -11,8 +11,10 @@ from sqlalchemy import text
 from constants import (
     PO_OPEN, PO_PARTIAL, PO_RECEIVED, PO_CLOSED, PO_ARCHIVED,
     SO_OPEN, SO_PICKED, SO_PACKED, SO_SHIPPED, SO_CANCELLED,
-    SO_FRAUD_REVIEW,
-    TASK_PENDING, ADJ_PENDING,
+    SO_FRAUD_REVIEW, SO_WAITING_STOCK,
+    TASK_PENDING, ADJ_PENDING, ADJ_APPROVED, ADJ_REASON_SHORT,
+    ORDER_TYPE_BACKORDER,
+    CANCEL_REASONS, CANCEL_REASON_OTHER,
     COMPANY_TIMEZONE,
     ACTION_PICK,
     ACTION_PO_STATUS_CHANGED,
@@ -28,6 +30,8 @@ from constants import (
     ACTION_SO_LINE_REMOVED,
     ACTION_SO_SOURCE_SYSTEM_REASSIGNED,
     ACTION_SO_ALLOCATION_RELEASED,
+    ACTION_PARTIAL_FULFILL,
+    ACTION_BACKORDER_CANCELLED,
     OVERRIDE_SO_FULL_EDIT,
     ROLE_ADMIN,
 )
@@ -48,8 +52,10 @@ from schemas.sales_orders import (
     ADDRESS_FIELD_NAMES,
     AddSalesOrderLineRequest,
     AdminPickRequest,
+    CancelBackorderRequest,
     CreateSalesOrderRequest,
     MarkSalesOrdersPrintedRequest,
+    PartialFulfillRequest,
     RevertSalesOrderStatusRequest,
     UpdateSalesOrderAddressRequest,
     UpdateSalesOrderLineRequest,
@@ -57,6 +63,7 @@ from schemas.sales_orders import (
     UpdateSalesOrderRequest,
 )
 from services.audit_service import write_audit_log
+from services.events_service import emit_event, get_user_external_id
 from services.sales_order_service import (
     AdminPickError,
     CancelNotAllowed,
@@ -1575,6 +1582,476 @@ def admin_pick_sales_order(so_id, validated):
         "promoted_to_picked": bool(promoted),
         **result,
     })
+
+
+# ── Partial Fulfill / Backorders ─────────────────────────────────────────────
+#
+# Partial-fulfill shrinks one or more lines on an existing SO and
+# creates a new backorder SO (status=WAITING_STOCK) carrying the
+# shorted qty. The original SO continues through pack -> ship with
+# what was actually picked; the BO waits for the receiving hook in
+# receiving.py to flip it to OPEN when matching stock arrives.
+#
+# Status gate: {OPEN, PICKED}. OPEN is allowed for any sales-orders
+# user; PICKED requires ADMIN or the so-full-edit override (same
+# escalation as the post-OPEN line edit gate at _so_line_edit_gate).
+# Validation rule `short_qty <= quantity_ordered - quantity_picked`
+# keeps PICKED-shorting safe: it is only valid when the SO has
+# unpicked qty (short-picks happened during the batch). The
+# defective-tote case (PICKED-with-everything-picked) requires the
+# operator to cancel and recreate; out of scope for v1.
+#
+# BO chaining is capped at one level: a SO with parent_so_id IS NOT
+# NULL rejects partial-fulfill (the UI hides the button too, but the
+# server is authoritative).
+
+ADDRESS_COPY_FIELDS = (
+    "billing_address_name", "billing_address_line1", "billing_address_line2",
+    "billing_address_city", "billing_address_state",
+    "billing_address_postal_code", "billing_address_country",
+    "billing_address_phone",
+    "shipping_address_name", "shipping_address_line1", "shipping_address_line2",
+    "shipping_address_city", "shipping_address_state",
+    "shipping_address_postal_code", "shipping_address_country",
+    "shipping_address_phone",
+)
+
+
+def _select_so_for_partial_fulfill(db, so_id):
+    """Returns the SO row with every column the BO clone needs.
+
+    Locked FOR UPDATE so a concurrent /cancel or /update cannot
+    transition past us mid-shrink. Centralised so the partial-fulfill
+    handler does not carry a 30-column SELECT inline."""
+    cols = (
+        "so_id, so_number, external_id, status, warehouse_id, parent_so_id, "
+        "order_type, customer_name, customer_id, customer_phone, "
+        "customer_address, ship_method, ship_address, source_system, memo, "
+        "created_by, "
+        + ", ".join(ADDRESS_COPY_FIELDS)
+    )
+    return db.execute(
+        text(f"SELECT {cols} FROM sales_orders WHERE so_id = :sid FOR UPDATE"),
+        {"sid": so_id},
+    ).fetchone()
+
+
+def _write_short_adjustment(db, *, item_id, warehouse_id, short_qty, reason_detail, bo_so_number, username):
+    """If there is on-hand stock for this item in this warehouse, write
+    a SHORT inventory_adjustments row and decrement on-hand from the bin
+    with the most available units.
+
+    Returns the adjusted qty (0 if no on-hand stock existed). The bin
+    pick is deterministic (most-available, then lowest bin_id) so
+    tests can assert against it."""
+    bin_row = db.execute(
+        text(
+            "SELECT bin_id, quantity_on_hand, quantity_allocated "
+            "  FROM inventory "
+            " WHERE item_id = :iid AND warehouse_id = :wid "
+            "   AND (quantity_on_hand - quantity_allocated) > 0 "
+            " ORDER BY (quantity_on_hand - quantity_allocated) DESC, bin_id ASC "
+            " LIMIT 1"
+        ),
+        {"iid": item_id, "wid": warehouse_id},
+    ).fetchone()
+    if not bin_row:
+        return 0
+    available = bin_row.quantity_on_hand - bin_row.quantity_allocated
+    adj_qty = min(available, short_qty)
+    if adj_qty <= 0:
+        return 0
+    db.execute(
+        text(
+            "UPDATE inventory "
+            "   SET quantity_on_hand = GREATEST(0, quantity_on_hand - :qty), "
+            "       updated_at = NOW() "
+            " WHERE item_id = :iid AND bin_id = :bid"
+        ),
+        {"qty": adj_qty, "iid": item_id, "bid": bin_row.bin_id},
+    )
+    db.execute(
+        text(
+            "INSERT INTO inventory_adjustments ("
+            "  item_id, bin_id, warehouse_id, quantity_change, reason_code, "
+            "  reason_detail, status, adjusted_by, adjusted_at, external_id"
+            ") VALUES ("
+            "  :iid, :bid, :wid, :qty_change, :reason_code, :reason_detail, "
+            "  :status, :user, NOW(), :ext_id"
+            ")"
+        ),
+        {
+            "iid": item_id,
+            "bid": bin_row.bin_id,
+            "wid": warehouse_id,
+            "qty_change": -adj_qty,
+            "reason_code": ADJ_REASON_SHORT,
+            "reason_detail": f"{reason_detail} (BO: {bo_so_number})",
+            "status": ADJ_APPROVED,
+            "user": username,
+            "ext_id": str(uuid.uuid4()),
+        },
+    )
+    return adj_qty
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/partial-fulfill", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@validate_body(PartialFulfillRequest)
+@with_db
+def partial_fulfill_sales_order(so_id, validated):
+    """Ship what's pickable, create a backorder SO for the rest."""
+    so = _select_so_for_partial_fulfill(g.db, so_id)
+    if not so:
+        return jsonify({"error": "Sales order not found"}), 404
+
+    if so.status not in (SO_OPEN, SO_PICKED):
+        return jsonify({
+            "error": f"Can only partial-fulfill OPEN or PICKED orders. Current: {so.status}",
+            "current_status": so.status,
+        }), 400
+
+    # BO chaining cap: a backorder cannot itself spawn a backorder.
+    if so.parent_so_id is not None:
+        return jsonify({
+            "error": "This SO is a backorder; cancel it and create a fresh standalone SO instead of chaining backorders.",
+            "parent_so_id": so.parent_so_id,
+        }), 400
+
+    if so.order_type == "refund":
+        return jsonify({"error": "Cannot partial-fulfill a refund SO."}), 400
+
+    # PICKED requires ADMIN or so-full-edit override (mirrors
+    # _so_line_edit_gate). OPEN is allowed for any sales-orders user.
+    role = g.current_user.get("role")
+    if so.status == SO_PICKED and role != ROLE_ADMIN and not has_override(OVERRIDE_SO_FULL_EDIT):
+        return jsonify({
+            "error": "Partial-fulfill on a PICKED order requires ADMIN or so-full-edit override.",
+            "current_status": so.status,
+        }), 403
+
+    bo_so_number = f"{so.so_number}-BO"
+    reason_detail_base = (validated.reason_detail or "partial-fulfill").strip() or "partial-fulfill"
+    username = g.current_user["username"]
+
+    # 1. Validate every input line up-front (item exists, qty bounds).
+    #    Validating first lets us reject 400 cleanly without partial
+    #    inventory writes lingering in the transaction.
+    line_inputs = []
+    for entry in validated.lines:
+        line = g.db.execute(
+            text(
+                "SELECT sol.so_line_id, sol.item_id, sol.quantity_ordered, "
+                "       sol.quantity_picked, sol.line_number, "
+                "       i.sku, i.external_id AS item_external_id "
+                "  FROM sales_order_lines sol "
+                "  JOIN items i ON i.item_id = sol.item_id "
+                " WHERE sol.so_line_id = :sol_id AND sol.so_id = :sid "
+                " FOR UPDATE OF sol"
+            ),
+            {"sol_id": entry.so_line_id, "sid": so_id},
+        ).fetchone()
+        if not line:
+            return jsonify({
+                "error": f"so_line_id {entry.so_line_id} not on SO {so.so_number}",
+            }), 400
+        unshipped = line.quantity_ordered - line.quantity_picked
+        if entry.short_qty > unshipped:
+            return jsonify({
+                "error": (
+                    f"short_qty {entry.short_qty} on line {line.line_number} "
+                    f"exceeds unshipped qty ({line.quantity_ordered} ordered - "
+                    f"{line.quantity_picked} picked = {unshipped})"
+                ),
+                "so_line_id": entry.so_line_id,
+            }), 400
+        line_inputs.append((entry, line))
+
+    # 2. Apply per-line shrink + adjustment.
+    short_summary = []
+    for entry, line in line_inputs:
+        new_qty = line.quantity_ordered - entry.short_qty
+        if new_qty == 0:
+            # Hard-delete shrunk-to-zero lines. Zero-qty rows break the
+            # dockd payload + picker assumptions.
+            g.db.execute(
+                text("DELETE FROM sales_order_lines WHERE so_line_id = :sol_id"),
+                {"sol_id": line.so_line_id},
+            )
+        else:
+            g.db.execute(
+                text(
+                    "UPDATE sales_order_lines SET quantity_ordered = :qty "
+                    " WHERE so_line_id = :sol_id"
+                ),
+                {"qty": new_qty, "sol_id": line.so_line_id},
+            )
+
+        adj_qty = _write_short_adjustment(
+            g.db,
+            item_id=line.item_id,
+            warehouse_id=so.warehouse_id,
+            short_qty=entry.short_qty,
+            reason_detail=reason_detail_base,
+            bo_so_number=bo_so_number,
+            username=username,
+        )
+
+        short_summary.append({
+            "so_line_id": line.so_line_id,
+            "item_id": line.item_id,
+            "sku": line.sku,
+            "item_external_id": str(line.item_external_id),
+            "line_number": line.line_number,
+            "ordered_before": line.quantity_ordered,
+            "short_qty": entry.short_qty,
+            "ordered_after": new_qty,
+            "line_deleted": new_qty == 0,
+            "adjustment_qty": adj_qty,
+        })
+
+    # 3. Create the BO SO. Address fields + customer + ship_method
+    #    copied from the parent; order_total / customer_shipping_paid
+    #    are NULL on the BO because they were already paid on the
+    #    parent (downstream revenue reports must filter via
+    #    parent_so_id IS NULL or COALESCE).
+    bo_memo = f"[BACKORDER from {so.so_number}]\n" + (so.memo or "")
+    bo_external_id = str(uuid.uuid4())
+    address_cols = ", ".join(ADDRESS_COPY_FIELDS)
+    address_binds = ", ".join(f":{f}" for f in ADDRESS_COPY_FIELDS)
+    address_params = {f: getattr(so, f) for f in ADDRESS_COPY_FIELDS}
+
+    bo_row = g.db.execute(
+        text(f"""
+            INSERT INTO sales_orders (
+                so_number, customer_name, customer_id, customer_phone,
+                customer_address, status, warehouse_id, ship_method,
+                ship_address, {address_cols},
+                memo, order_total, customer_shipping_paid,
+                order_type, parent_so_id, backorder_opened_at,
+                created_by, external_id, source_system
+            ) VALUES (
+                :so_number, :customer_name, :customer_id, :customer_phone,
+                :customer_address, :status, :warehouse_id, :ship_method,
+                :ship_address, {address_binds},
+                :memo, NULL, NULL,
+                :order_type, :parent_so_id, NOW(),
+                :created_by, :external_id, :source_system
+            ) RETURNING so_id
+        """),
+        {
+            "so_number": bo_so_number,
+            "customer_name": so.customer_name,
+            "customer_id": so.customer_id,
+            "customer_phone": so.customer_phone,
+            "customer_address": so.customer_address,
+            "status": SO_WAITING_STOCK,
+            "warehouse_id": so.warehouse_id,
+            "ship_method": so.ship_method,
+            "ship_address": so.ship_address,
+            "memo": bo_memo,
+            "order_type": ORDER_TYPE_BACKORDER,
+            "parent_so_id": so.so_id,
+            "created_by": username,
+            "external_id": bo_external_id,
+            "source_system": so.source_system,
+            **address_params,
+        },
+    ).fetchone()
+    bo_so_id = bo_row.so_id
+
+    # 4. BO lines: one per shorted entry, line_number sequential.
+    for idx, shrink in enumerate(short_summary, 1):
+        g.db.execute(
+            text(
+                "INSERT INTO sales_order_lines "
+                "  (so_id, item_id, quantity_ordered, line_number, status) "
+                "VALUES (:sid, :iid, :qty, :ln, 'PENDING')"
+            ),
+            {
+                "sid": bo_so_id,
+                "iid": shrink["item_id"],
+                "qty": shrink["short_qty"],
+                "ln": idx,
+            },
+        )
+
+    # 5. Audit log. Two rows in the same transaction:
+    #    - Original SO: shrink summary + BO pointer.
+    #    - BO SO: creation hook + parent pointer.
+    write_audit_log(
+        g.db,
+        action_type=ACTION_PARTIAL_FULFILL,
+        entity_type="SO",
+        entity_id=so.so_id,
+        user_id=username,
+        warehouse_id=so.warehouse_id,
+        details={
+            "kind": "shrink",
+            "bo_so_id": bo_so_id,
+            "bo_so_number": bo_so_number,
+            "reason_detail": reason_detail_base,
+            "pre_status": so.status,
+            "lines": [
+                {
+                    k: v for k, v in s.items()
+                    if k in (
+                        "so_line_id", "sku", "line_number", "ordered_before",
+                        "short_qty", "ordered_after", "line_deleted",
+                        "adjustment_qty",
+                    )
+                }
+                for s in short_summary
+            ],
+        },
+    )
+    write_audit_log(
+        g.db,
+        action_type=ACTION_PARTIAL_FULFILL,
+        entity_type="SO",
+        entity_id=bo_so_id,
+        user_id=username,
+        warehouse_id=so.warehouse_id,
+        details={
+            "kind": "created_from_partial_fulfill",
+            "parent_so_id": so.so_id,
+            "parent_so_number": so.so_number,
+            "lines": [
+                {"sku": s["sku"], "qty": s["short_qty"]} for s in short_summary
+            ],
+        },
+    )
+
+    # 6. Emit backorder.opened on the integration_events outbox. No
+    #    consumer wires this yet (the Teams adapter does; marketplace
+    #    adapter is deferred to a follow-up branch), but emitting now
+    #    means "wire later" does not require an event-history
+    #    backfill.
+    user_external_id = get_user_external_id(g.db, username)
+    opened_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    emit_event(
+        g.db,
+        event_type="backorder.opened",
+        event_version=1,
+        aggregate_type="sales_order",
+        aggregate_id=bo_so_id,
+        aggregate_external_id=bo_external_id,
+        warehouse_id=so.warehouse_id,
+        source_txn_id=g.source_txn_id,
+        payload={
+            "backorder_so_external_id": bo_external_id,
+            "backorder_so_number": bo_so_number,
+            "parent_so_external_id": str(so.external_id),
+            "parent_so_number": so.so_number,
+            "warehouse_id": so.warehouse_id,
+            "customer_name": so.customer_name,
+            "items": [
+                {
+                    "item_external_id": s["item_external_id"],
+                    "sku": s["sku"],
+                    "qty": s["short_qty"],
+                }
+                for s in short_summary
+            ],
+            "opened_by_user_external_id": user_external_id,
+            "opened_at": opened_at,
+        },
+    )
+
+    g.db.commit()
+
+    return jsonify({
+        "original_so": {
+            "so_id": so.so_id,
+            "so_number": so.so_number,
+            "status": so.status,
+        },
+        "backorder_so": {
+            "so_id": bo_so_id,
+            "so_number": bo_so_number,
+            "status": SO_WAITING_STOCK,
+            "external_id": bo_external_id,
+        },
+        "shrink_summary": short_summary,
+    })
+
+
+@admin_bp.route("/sales-orders/<int:bo_so_id>/cancel-backorder", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@validate_body(CancelBackorderRequest)
+@with_db
+def cancel_backorder(bo_so_id, validated):
+    """Cancel a backorder SO. Thin wrapper that stamps
+    cancellation_reason then delegates to the shared cancel service.
+
+    The backorder.cancelled event is emitted inside
+    sales_order_service.cancel_sales_order (so the parent-cancel
+    cascade emits too); this endpoint only sets the reason and
+    handles the BO-specific validation."""
+    reason = (validated.cancellation_reason or CANCEL_REASON_OTHER).strip()
+    if reason not in CANCEL_REASONS:
+        return jsonify({
+            "error": (
+                f"Invalid cancellation_reason. Allowed: "
+                f"{', '.join(CANCEL_REASONS)}"
+            ),
+        }), 400
+
+    bo = g.db.execute(
+        text(
+            "SELECT so_id, status, parent_so_id, order_type "
+            "  FROM sales_orders WHERE so_id = :sid"
+        ),
+        {"sid": bo_so_id},
+    ).fetchone()
+    if not bo:
+        return jsonify({"error": "Sales order not found"}), 404
+    if bo.parent_so_id is None or bo.order_type != ORDER_TYPE_BACKORDER:
+        return jsonify({
+            "error": (
+                "Not a backorder SO. Use /cancel for non-backorder orders."
+            ),
+        }), 400
+    if bo.status == SO_CANCELLED:
+        return jsonify({
+            "error": "Backorder already cancelled.",
+            "current_status": bo.status,
+        }), 400
+
+    # Stamp the reason BEFORE cancel_sales_order so the service-side
+    # backorder.cancelled emit sees it on the row.
+    g.db.execute(
+        text(
+            "UPDATE sales_orders SET cancellation_reason = :reason "
+            " WHERE so_id = :sid"
+        ),
+        {"reason": reason, "sid": bo_so_id},
+    )
+
+    try:
+        result = _cancel_so(
+            g.db, so_id=bo_so_id, source="admin",
+            username=g.current_user["username"],
+        )
+    except CancelNotAllowed as exc:
+        if exc.current_status == "UNKNOWN":
+            return jsonify({"error": "Sales order not found"}), 404
+        return jsonify({
+            "error": str(exc),
+            "current_status": exc.current_status,
+        }), 400
+
+    g.db.commit()
+    return jsonify({
+        "message": "Backorder cancelled",
+        "bo_so_id": bo_so_id,
+        "cancellation_reason": reason,
+        "audit_log_id": result["audit_log_id"],
+    })
+
+
 # ── Sales Order Lines (add / update / remove) ────────────────────────────────
 #
 # Mirrors the PO line surface shape but layers an

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -2052,6 +2052,109 @@ def cancel_backorder(bo_so_id, validated):
     })
 
 
+@admin_bp.route("/backorders", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission("backorders")
+@with_db
+def list_backorders():
+    """List backorder SOs grouped by tab.
+
+    Query params:
+      - warehouse_id (optional): scope to one warehouse
+      - tab: 'waiting' (status=WAITING_STOCK) or 'ready-to-ship'
+        (status IN OPEN/PICKED/PACKED AND backorder_opened_at is set)
+        Defaults to 'waiting'.
+
+    Response carries per-BO items[] + days_waiting; the
+    ready-to-ship tab also carries fulfillable_since
+    (backorder_fulfillable_at). Latest open-PO ETA per item is
+    omitted because purchase_order_lines does not carry an
+    expected_arrival_date column yet; revisit once that's wired."""
+    tab = (request.args.get("tab") or "waiting").lower()
+    warehouse_id = request.args.get("warehouse_id", type=int)
+
+    if tab == "waiting":
+        status_clause = "bo.status = :waiting"
+        params = {"waiting": SO_WAITING_STOCK}
+    elif tab in ("ready-to-ship", "ready_to_ship", "ready"):
+        status_clause = (
+            "bo.status IN (:s_open, :s_picked, :s_packed) "
+            "  AND bo.backorder_opened_at IS NOT NULL"
+        )
+        params = {"s_open": SO_OPEN, "s_picked": SO_PICKED, "s_packed": SO_PACKED}
+    else:
+        return jsonify({
+            "error": "tab must be 'waiting' or 'ready-to-ship'",
+            "got": tab,
+        }), 400
+
+    if warehouse_id:
+        status_clause += " AND bo.warehouse_id = :wid"
+        params["wid"] = warehouse_id
+
+    rows = g.db.execute(
+        text(
+            f"""
+            SELECT bo.so_id, bo.so_number, bo.warehouse_id, bo.status,
+                   bo.customer_name, bo.backorder_opened_at,
+                   bo.backorder_fulfillable_at,
+                   parent.so_number AS parent_so_number,
+                   EXTRACT(EPOCH FROM (NOW() - bo.backorder_opened_at))::bigint AS waiting_seconds
+              FROM sales_orders bo
+              LEFT JOIN sales_orders parent ON parent.so_id = bo.parent_so_id
+             WHERE {status_clause}
+               AND bo.order_type = :backorder
+             ORDER BY bo.backorder_opened_at ASC
+            """
+        ),
+        {**params, "backorder": ORDER_TYPE_BACKORDER},
+    ).fetchall()
+
+    so_ids = [r.so_id for r in rows]
+    items_by_so = {}
+    if so_ids:
+        line_rows = g.db.execute(
+            text(
+                "SELECT sol.so_id, i.sku, sol.quantity_ordered "
+                "  FROM sales_order_lines sol "
+                "  JOIN items i ON i.item_id = sol.item_id "
+                " WHERE sol.so_id = ANY(:so_ids) "
+                " ORDER BY sol.line_number"
+            ),
+            {"so_ids": so_ids},
+        ).fetchall()
+        for lr in line_rows:
+            items_by_so.setdefault(lr.so_id, []).append({
+                "sku": lr.sku,
+                "qty": lr.quantity_ordered,
+            })
+
+    return jsonify({
+        "tab": tab,
+        "backorders": [
+            {
+                "so_id":           r.so_id,
+                "so_number":       r.so_number,
+                "parent_so_number": r.parent_so_number,
+                "warehouse_id":    r.warehouse_id,
+                "status":          r.status,
+                "customer_name":   r.customer_name,
+                "items":           items_by_so.get(r.so_id, []),
+                "days_waiting":    (int(r.waiting_seconds) // 86400) if r.waiting_seconds else 0,
+                "backorder_opened_at": (
+                    r.backorder_opened_at.isoformat()
+                    if r.backorder_opened_at else None
+                ),
+                "fulfillable_since": (
+                    r.backorder_fulfillable_at.isoformat()
+                    if r.backorder_fulfillable_at else None
+                ),
+            }
+            for r in rows
+        ],
+    })
+
+
 # ── Sales Order Lines (add / update / remove) ────────────────────────────────
 #
 # Mirrors the PO line surface shape but layers an

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -750,6 +750,9 @@ def get_sales_order(so_id):
                    source_system,
                    order_origin,
                    carrier, tracking_number,
+                   order_type, parent_so_id,
+                   backorder_opened_at, backorder_fulfillable_at,
+                   cancellation_reason,
                    billing_address_name, billing_address_line1, billing_address_line2,
                    billing_address_city, billing_address_state,
                    billing_address_postal_code, billing_address_country,
@@ -840,6 +843,16 @@ def get_sales_order(so_id):
             # current tracking number and the view modal can display it.
             "carrier": so.carrier,
             "tracking_number": so.tracking_number,
+            # Backorder lifecycle (mig 067). The admin Edit modal uses
+            # order_type + parent_so_id to gate the "Partially Fulfill"
+            # button (rejects backorders to enforce the one-level
+            # chaining cap). backorder_*_at + cancellation_reason are
+            # read-only context for the Backorders page detail view.
+            "order_type":                so.order_type,
+            "parent_so_id":              so.parent_so_id,
+            "backorder_opened_at":       so.backorder_opened_at.isoformat() if so.backorder_opened_at else None,
+            "backorder_fulfillable_at":  so.backorder_fulfillable_at.isoformat() if so.backorder_fulfillable_at else None,
+            "cancellation_reason":       so.cancellation_reason,
             # v1.8.0 (#288): structured billing/shipping address fields.
             **{name: getattr(so, name) for name in ADDRESS_FIELD_NAMES},
         },

--- a/api/routes/receiving.py
+++ b/api/routes/receiving.py
@@ -12,6 +12,8 @@ from constants import (
     PO_OPEN, PO_PARTIAL, PO_RECEIVED, PO_CLOSED,
     POL_PENDING, POL_PARTIAL, POL_RECEIVED,
     ACTION_RECEIVE, ACTION_RECEIVE_CANCEL,
+    SO_OPEN, SO_WAITING_STOCK,
+    BIN_PICKABLE, BIN_PICKABLE_STAGING,
 )
 from middleware.auth_middleware import require_auth, warehouse_scope_clause
 from middleware.db import with_db
@@ -22,6 +24,143 @@ from services.inventory_service import add_inventory
 from utils.validation import validate_body
 
 receiving_bp = Blueprint("receiving", __name__)
+
+
+def _check_waiting_backorders_for_item(db, *, warehouse_id, item_id, source_txn_id):
+    """After a receipt lands inventory for (warehouse_id, item_id),
+    look at WAITING_STOCK backorders in that warehouse that carry a line
+    on this item. For each, check whether ALL its lines are now satisfiable
+    against current pickable on-hand. Flip the satisfiable ones to OPEN,
+    stamp backorder_fulfillable_at, and emit backorder.fulfillable.
+
+    Partial-satisfaction stays in WAITING_STOCK with no event (matches the
+    spec's "notify only when fully available" decision so a Teams ping
+    doesn't fire until the warehouse can actually pull the BO).
+
+    Inventory is NOT consumed here; the BO becomes pickable for the
+    next batch builder.
+    """
+    candidates = db.execute(
+        text(
+            """
+            SELECT bo.so_id, bo.so_number, bo.external_id, bo.warehouse_id,
+                   bo.backorder_opened_at, bo.parent_so_id, bo.customer_name
+              FROM sales_orders bo
+             WHERE bo.status = :waiting
+               AND bo.warehouse_id = :wid
+               AND EXISTS (
+                 SELECT 1 FROM sales_order_lines bol
+                  WHERE bol.so_id = bo.so_id
+                    AND bol.item_id = :iid
+               )
+             ORDER BY bo.backorder_opened_at ASC
+            """
+        ),
+        {"waiting": SO_WAITING_STOCK, "wid": warehouse_id, "iid": item_id},
+    ).fetchall()
+
+    for bo in candidates:
+        bo_lines = db.execute(
+            text(
+                """
+                SELECT sol.so_line_id, sol.item_id, sol.quantity_ordered,
+                       i.sku, i.external_id AS item_external_id
+                  FROM sales_order_lines sol
+                  JOIN items i ON i.item_id = sol.item_id
+                 WHERE sol.so_id = :bid
+                """
+            ),
+            {"bid": bo.so_id},
+        ).fetchall()
+        if not bo_lines:
+            continue
+
+        all_satisfiable = True
+        for line in bo_lines:
+            available = db.execute(
+                text(
+                    """
+                    SELECT COALESCE(
+                             SUM(GREATEST(inv.quantity_on_hand - inv.quantity_allocated, 0)),
+                             0
+                           )
+                      FROM inventory inv
+                      JOIN bins b ON b.bin_id = inv.bin_id
+                     WHERE inv.item_id = :iid
+                       AND inv.warehouse_id = :wid
+                       AND b.bin_type IN (:bp, :bps)
+                    """
+                ),
+                {
+                    "iid": line.item_id,
+                    "wid": warehouse_id,
+                    "bp": BIN_PICKABLE,
+                    "bps": BIN_PICKABLE_STAGING,
+                },
+            ).scalar() or 0
+            if available < line.quantity_ordered:
+                all_satisfiable = False
+                break
+        if not all_satisfiable:
+            continue
+
+        db.execute(
+            text(
+                "UPDATE sales_orders "
+                "   SET status = :open, backorder_fulfillable_at = NOW() "
+                " WHERE so_id = :bid"
+            ),
+            {"open": SO_OPEN, "bid": bo.so_id},
+        )
+
+        days_waiting = 0
+        if bo.backorder_opened_at:
+            row = db.execute(
+                text(
+                    "SELECT EXTRACT(EPOCH FROM (NOW() - :opened))::bigint AS s"
+                ),
+                {"opened": bo.backorder_opened_at},
+            ).fetchone()
+            if row and row.s:
+                days_waiting = int(row.s) // 86400
+
+        parent_so_number = ""
+        if bo.parent_so_id is not None:
+            parent_so_number = db.execute(
+                text("SELECT so_number FROM sales_orders WHERE so_id = :sid"),
+                {"sid": bo.parent_so_id},
+            ).scalar() or ""
+
+        fulfillable_at = (
+            datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        )
+        emit_event(
+            db,
+            event_type="backorder.fulfillable",
+            event_version=1,
+            aggregate_type="sales_order",
+            aggregate_id=bo.so_id,
+            aggregate_external_id=bo.external_id,
+            warehouse_id=warehouse_id,
+            source_txn_id=source_txn_id,
+            payload={
+                "backorder_so_external_id": str(bo.external_id),
+                "backorder_so_number": bo.so_number,
+                "parent_so_number": parent_so_number,
+                "warehouse_id": warehouse_id,
+                "customer_name": bo.customer_name,
+                "items": [
+                    {
+                        "item_external_id": str(line.item_external_id),
+                        "sku": line.sku,
+                        "qty": line.quantity_ordered,
+                    }
+                    for line in bo_lines
+                ],
+                "days_waiting": days_waiting,
+                "fulfillable_at": fulfillable_at,
+            },
+        )
 
 
 @receiving_bp.route("/po/<barcode>")
@@ -301,6 +440,16 @@ def receive_items(validated):
                 "completed_by_user_external_id": get_user_external_id(g.db, username),
                 "completed_at": receipt_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
             },
+        )
+
+        # Flip any WAITING_STOCK backorders in this warehouse
+        # that this receipt makes fully satisfiable. Same transaction;
+        # the partial index from mig 067 covers the candidate lookup.
+        _check_waiting_backorders_for_item(
+            g.db,
+            warehouse_id=warehouse_id,
+            item_id=item_id,
+            source_txn_id=g.source_txn_id,
         )
 
     # Update PO status based on all lines

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -174,6 +174,46 @@ class UpdateSalesOrderAddressRequest(BaseModel):
         return self
 
 
+class PartialFulfillLineEntry(BaseModel):
+    """Partial-fulfill: per-line short input.
+
+    short_qty is the number of units the operator is declaring as
+    unshippable for this line; it shifts onto the new BO SO. The
+    handler enforces ``short_qty <= quantity_ordered - quantity_picked``
+    at request time (server-side; the UI's max= attribute is hinting,
+    not authoritative)."""
+
+    so_line_id: int = Field(..., gt=0)
+    short_qty:  int = Field(..., gt=0, le=1000000)
+
+
+class PartialFulfillRequest(BaseModel):
+    """Partial-fulfill: POST body for
+    /admin/sales-orders/<so_id>/partial-fulfill.
+
+    lines carries one entry per shorted line; lines that are NOT
+    shorted are simply omitted (no zero-qty entries needed). At
+    least one entry is required.
+
+    reason_detail is free-text operator-supplied context that lands
+    in the audit row and in the inventory_adjustments.reason_detail
+    column on any SHORT adjustments written. Optional; the handler
+    falls back to a generated stub when omitted."""
+
+    lines: List[PartialFulfillLineEntry] = Field(..., min_length=1, max_length=200)
+    reason_detail: Optional[str] = Field(None, max_length=500)
+
+
+class CancelBackorderRequest(BaseModel):
+    """Partial-fulfill: POST body for
+    /admin/sales-orders/<bo_so_id>/cancel-backorder.
+
+    cancellation_reason is an app-enforced enum; valid values live
+    in constants.CANCEL_REASONS. Defaults to 'other' if omitted."""
+
+    cancellation_reason: Optional[str] = Field("other", max_length=50)
+
+
 class MarkSalesOrdersPrintedRequest(BaseModel):
     """mig 064: POST body to stamp printed_at on a batch of SOs. Sent by
     the picking-ticket print page after the client-side render confirms

--- a/api/schemas_v1/events/backorder.cancelled/1.json
+++ b/api/schemas_v1/events/backorder.cancelled/1.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sentry-wms.example/events/backorder.cancelled/1.json",
+  "title": "backorder.cancelled v1",
+  "description": "A backorder SO has been cancelled. Emitted by api/routes/admin/admin_orders.py::cancel_backorder (operator path) and by services/sales_order_service.cancel_sales_order when the parent-cancel cascade walks a child BO. Aggregate: sales_order (the BO so_id).",
+  "type": "object",
+  "required": [
+    "backorder_so_external_id",
+    "backorder_so_number",
+    "parent_so_number",
+    "warehouse_id",
+    "cancellation_reason",
+    "cancelled_by_user_external_id",
+    "cancelled_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "backorder_so_external_id":   { "type": "string", "format": "uuid" },
+    "backorder_so_number":        { "type": "string" },
+    "parent_so_number":           { "type": "string" },
+    "warehouse_id":               { "type": "integer", "minimum": 1 },
+    "cancellation_reason": {
+      "type": "string",
+      "enum": ["found", "customer_asked", "refunded", "parent_cancelled", "other"]
+    },
+    "cancelled_by_user_external_id": { "type": "string", "format": "uuid" },
+    "cancelled_at":               { "type": "string", "format": "date-time" }
+  }
+}

--- a/api/schemas_v1/events/backorder.fulfillable/1.json
+++ b/api/schemas_v1/events/backorder.fulfillable/1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sentry-wms.example/events/backorder.fulfillable/1.json",
+  "title": "backorder.fulfillable v1",
+  "description": "All lines on a WAITING_STOCK backorder are now satisfiable; Sentry flipped it to OPEN. Emitted by api/routes/receiving.py inside the receipt.completed transaction. Aggregate: sales_order (the BO so_id).",
+  "type": "object",
+  "required": [
+    "backorder_so_external_id",
+    "backorder_so_number",
+    "parent_so_number",
+    "warehouse_id",
+    "items",
+    "days_waiting",
+    "fulfillable_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "backorder_so_external_id":   { "type": "string", "format": "uuid" },
+    "backorder_so_number":        { "type": "string" },
+    "parent_so_number":           { "type": "string" },
+    "warehouse_id":               { "type": "integer", "minimum": 1 },
+    "customer_name":              { "type": ["string", "null"] },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["item_external_id", "sku", "qty"],
+        "additionalProperties": false,
+        "properties": {
+          "item_external_id":     { "type": "string", "format": "uuid" },
+          "sku":                  { "type": "string" },
+          "qty":                  { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "days_waiting":               { "type": "integer", "minimum": 0 },
+    "fulfillable_at":             { "type": "string", "format": "date-time" }
+  }
+}

--- a/api/schemas_v1/events/backorder.opened/1.json
+++ b/api/schemas_v1/events/backorder.opened/1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sentry-wms.example/events/backorder.opened/1.json",
+  "title": "backorder.opened v1",
+  "description": "A backorder SO has been created via /partial-fulfill. Emitted by api/routes/admin/admin_orders.py::partial_fulfill_sales_order. Aggregate: sales_order (the BO so_id).",
+  "type": "object",
+  "required": [
+    "backorder_so_external_id",
+    "backorder_so_number",
+    "parent_so_external_id",
+    "parent_so_number",
+    "warehouse_id",
+    "items",
+    "opened_by_user_external_id",
+    "opened_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "backorder_so_external_id":   { "type": "string", "format": "uuid" },
+    "backorder_so_number":        { "type": "string" },
+    "parent_so_external_id":      { "type": "string", "format": "uuid" },
+    "parent_so_number":           { "type": "string" },
+    "warehouse_id":               { "type": "integer", "minimum": 1 },
+    "customer_name":              { "type": ["string", "null"] },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["item_external_id", "sku", "qty"],
+        "additionalProperties": false,
+        "properties": {
+          "item_external_id":     { "type": "string", "format": "uuid" },
+          "sku":                  { "type": "string" },
+          "qty":                  { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "opened_by_user_external_id": { "type": "string", "format": "uuid" },
+    "opened_at":                  { "type": "string", "format": "date-time" }
+  }
+}

--- a/api/services/events_schema_registry.py
+++ b/api/services/events_schema_registry.py
@@ -39,6 +39,16 @@ V150_CATALOG: Tuple[Tuple[str, int, str], ...] = (
     # v1.9.0 dockd: emitted when a previously-shipped sales order is
     # voided through the /api/v1/dockd/orders/{so}/void-ship route.
     ("ship.voided",          1, "sales_order"),
+    # Partial-fulfill / backorders. opened: a BO SO has been
+    # created via /partial-fulfill (status WAITING_STOCK). fulfillable:
+    # the receipt hook found that all of a waiting BO's lines are
+    # satisfiable and flipped it to OPEN. cancelled: the BO has been
+    # cancelled, either operator-initiated via /cancel-backorder or
+    # cascaded from the parent SO's cancel. All three carry the
+    # sales_order aggregate (the BO so_id).
+    ("backorder.opened",      1, "sales_order"),
+    ("backorder.fulfillable", 1, "sales_order"),
+    ("backorder.cancelled",   1, "sales_order"),
 )
 
 # Resolved once at module import from api/schemas_v1/events. The

--- a/api/services/sales_order_service.py
+++ b/api/services/sales_order_service.py
@@ -2,16 +2,33 @@
 
 v1.9.0 introduces one shared cancel handler. Two callers converge here:
 
-- Admin operator path: POST /api/admin/sales-orders/<id>/cancel.
+- Admin operator path: POST /api/admin/sales-orders/<id>/cancel
+  (and /cancel-backorder, which delegates here after stamping
+  cancellation_reason).
 - Inbound path: an ERP-pushed update on an existing SO whose
   canonical status field has flipped to CANCELLED.
 
 The cancel transition is the only state-changing SO operation that
 historically did NOT write audit_log; routing both paths through this
 service closes that hole and gives the inventory unwind one source of
-truth. Cancellation does not emit an outbox event (Sentry follows the
-ERP for cancel; downstream consumers learn through their own ERP
-integration).
+truth.
+
+Backorders add two things on top:
+
+- Parent-cancel cascade: after the per-status unwind, any non-terminal
+  child backorder (order_type='backorder') is recursively cancelled
+  with cancellation_reason='parent_cancelled'. Keeps Sentry from
+  stranding a BO when the parent is cancelled.
+- backorder.cancelled emit: when the SO being cancelled is itself a
+  BO (order_type='backorder'), emit on the integration_events outbox
+  so the Teams adapter / future marketplace adapter see the event.
+  The operator-initiated path and the cascade both emit; no consumer
+  needs to know which.
+
+The emit relies on the Flask request context for source_txn_id /
+user_external_id, mirroring complete_batch's pattern. Outside a
+request (unit tests that call cancel_sales_order directly) the emit
+is skipped.
 """
 
 from datetime import datetime, timezone
@@ -28,6 +45,8 @@ from constants import (
     ACTION_SO_UNPACKED,
     ACTION_SO_UNSHIPPED,
     BATCH_COMPLETED,
+    CANCEL_REASON_PARENT_CANCELLED,
+    ORDER_TYPE_BACKORDER,
     SO_CANCELLED,
     SO_OPEN,
     SO_PACKED,
@@ -121,7 +140,8 @@ def cancel_sales_order(
 
     so = db.execute(
         text(
-            "SELECT so_id, so_number, status, warehouse_id "
+            "SELECT so_id, so_number, external_id, status, warehouse_id, "
+            "       parent_so_id, order_type, cancellation_reason "
             "  FROM sales_orders "
             " WHERE so_id = :sid "
             " FOR UPDATE"
@@ -157,6 +177,8 @@ def cancel_sales_order(
         _unwind_allocated(db, so_id)
     elif pre_status in (SO_PICKED, SO_PACKED):
         _unwind_picked_or_packed(db, so_id, warehouse_id)
+    # WAITING_STOCK (mig 067) is BO-only and inventory-free; no
+    # per-status unwind beyond the status flip below.
 
     db.execute(
         text(
@@ -178,6 +200,87 @@ def cancel_sales_order(
             "source": source,
         },
     )
+
+    # If this SO is a backorder, emit backorder.cancelled on
+    # the integration_events outbox. Both the operator path
+    # (/cancel-backorder) and the parent-cancel cascade reach this
+    # branch, so the consumer always sees the event regardless of
+    # initiator. Emit is skipped outside a Flask request context
+    # (unit tests that call cancel_sales_order directly).
+    if so.order_type == ORDER_TYPE_BACKORDER and has_request_context():
+        parent_so_number = db.execute(
+            text("SELECT so_number FROM sales_orders WHERE so_id = :sid"),
+            {"sid": so.parent_so_id},
+        ).scalar() if so.parent_so_id is not None else None
+
+        # cancellation_reason may have been stamped by the caller
+        # (/cancel-backorder) or by the cascade below. Re-read so the
+        # emit reflects the latest value.
+        reason_row = db.execute(
+            text(
+                "SELECT cancellation_reason FROM sales_orders "
+                " WHERE so_id = :sid"
+            ),
+            {"sid": so_id},
+        ).fetchone()
+        reason = (reason_row.cancellation_reason if reason_row else None) or "other"
+
+        cancelled_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        user_external_id = get_user_external_id(db, username)
+        emit_event(
+            db,
+            event_type="backorder.cancelled",
+            event_version=1,
+            aggregate_type="sales_order",
+            aggregate_id=so_id,
+            aggregate_external_id=so.external_id,
+            warehouse_id=warehouse_id,
+            source_txn_id=g.source_txn_id,
+            payload={
+                "backorder_so_external_id": str(so.external_id),
+                "backorder_so_number": so.so_number,
+                "parent_so_number": parent_so_number or "",
+                "warehouse_id": warehouse_id,
+                "cancellation_reason": reason,
+                "cancelled_by_user_external_id": user_external_id,
+                "cancelled_at": cancelled_at,
+            },
+        )
+
+    # Parent-cancel cascade. Walk any non-terminal child
+    # backorder, stamp 'parent_cancelled' as its reason, and
+    # recursively cancel. The recursive call re-enters this function
+    # on the child's so_id (a different row, so FOR UPDATE does not
+    # deadlock); the child path's own emit handles backorder.cancelled.
+    # cancel_sales_order is idempotent on already-CANCELLED so a child
+    # that is already CANCELLED is a no-op.
+    if so.order_type != ORDER_TYPE_BACKORDER:
+        children = db.execute(
+            text(
+                "SELECT so_id FROM sales_orders "
+                " WHERE parent_so_id = :sid "
+                "   AND order_type = :backorder "
+                "   AND status NOT IN (:cancelled, :shipped)"
+            ),
+            {
+                "sid": so_id,
+                "backorder": ORDER_TYPE_BACKORDER,
+                "cancelled": SO_CANCELLED,
+                "shipped": SO_SHIPPED,
+            },
+        ).fetchall()
+        for child in children:
+            db.execute(
+                text(
+                    "UPDATE sales_orders "
+                    "   SET cancellation_reason = :reason "
+                    " WHERE so_id = :cid"
+                ),
+                {"reason": CANCEL_REASON_PARENT_CANCELLED, "cid": child.so_id},
+            )
+            cancel_sales_order(
+                db, so_id=child.so_id, source=source, username=username,
+            )
 
     return {
         "pre_status": pre_status,

--- a/api/tests/test_admin_backorders_list.py
+++ b/api/tests/test_admin_backorders_list.py
@@ -1,0 +1,115 @@
+"""GET /api/admin/backorders.
+
+Tabs: 'waiting' (status=WAITING_STOCK) and 'ready-to-ship'
+(status IN OPEN/PICKED/PACKED AND backorder_opened_at IS NOT NULL).
+Returns per-BO items[] + days_waiting; ready-to-ship adds
+fulfillable_since.
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_val(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row[0] if row else None
+
+
+def _create_bo_via_partial_fulfill(client, auth_headers, so_id=1, short_qty=1):
+    sol_id = _query_val(
+        "SELECT so_line_id FROM sales_order_lines WHERE so_id = %s LIMIT 1",
+        (so_id,),
+    )
+    resp = client.post(
+        f"/api/admin/sales-orders/{so_id}/partial-fulfill",
+        json={"lines": [{"so_line_id": sol_id, "short_qty": short_qty}]},
+        headers=auth_headers,
+    )
+    return resp.get_json()["backorder_so"]["so_id"]
+
+
+class TestListBackorders:
+    def test_waiting_tab_lists_waiting_bo(self, client, auth_headers):
+        bo_so_id = _create_bo_via_partial_fulfill(client, auth_headers)
+
+        resp = client.get("/api/admin/backorders?tab=waiting", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["tab"] == "waiting"
+
+        bo_ids = [b["so_id"] for b in data["backorders"]]
+        assert bo_so_id in bo_ids
+
+        # Card payload shape.
+        target = next(b for b in data["backorders"] if b["so_id"] == bo_so_id)
+        assert target["status"] == "WAITING_STOCK"
+        assert target["parent_so_number"] == "SO-2026-001"
+        assert target["so_number"] == "SO-2026-001-BO"
+        assert target["customer_name"] == "Test Customer 1"
+        assert len(target["items"]) == 1
+        assert target["items"][0]["sku"] == "TST-001"
+        assert target["items"][0]["qty"] == 1
+        assert target["days_waiting"] == 0  # just created
+        assert target["fulfillable_since"] is None
+
+    def test_default_tab_is_waiting(self, client, auth_headers):
+        _create_bo_via_partial_fulfill(client, auth_headers)
+        resp = client.get("/api/admin/backorders", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.get_json()["tab"] == "waiting"
+
+    def test_invalid_tab_rejected(self, client, auth_headers):
+        resp = client.get("/api/admin/backorders?tab=bogus", headers=auth_headers)
+        assert resp.status_code == 400
+
+    def test_ready_to_ship_tab_shows_flipped_bo(self, client, auth_headers):
+        # Force the BO to OPEN with a fulfillable_at stamp (simulating
+        # the receipt-hook flip without running a full receipt cycle).
+        bo_so_id = _create_bo_via_partial_fulfill(client, auth_headers)
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_orders SET status = 'OPEN', "
+            "                        backorder_fulfillable_at = NOW() "
+            " WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        cur.close()
+
+        # Waiting tab should NOT include it.
+        waiting = client.get(
+            "/api/admin/backorders?tab=waiting", headers=auth_headers
+        ).get_json()
+        assert bo_so_id not in [b["so_id"] for b in waiting["backorders"]]
+
+        # Ready-to-ship tab should.
+        ready = client.get(
+            "/api/admin/backorders?tab=ready-to-ship", headers=auth_headers
+        ).get_json()
+        assert bo_so_id in [b["so_id"] for b in ready["backorders"]]
+        target = next(b for b in ready["backorders"] if b["so_id"] == bo_so_id)
+        assert target["fulfillable_since"] is not None
+
+    def test_warehouse_id_filter(self, client, auth_headers):
+        _create_bo_via_partial_fulfill(client, auth_headers)
+        # Warehouse 1 returns the BO; warehouse 9999 returns empty.
+        wh1 = client.get(
+            "/api/admin/backorders?tab=waiting&warehouse_id=1",
+            headers=auth_headers,
+        ).get_json()
+        wh_none = client.get(
+            "/api/admin/backorders?tab=waiting&warehouse_id=9999",
+            headers=auth_headers,
+        ).get_json()
+        assert len(wh1["backorders"]) >= 1
+        assert wh_none["backorders"] == []
+
+    def test_non_backorder_so_not_listed(self, client, auth_headers):
+        # SO-2026-002 is a regular sale, not a BO. Listing should
+        # NOT include it.
+        resp = client.get("/api/admin/backorders?tab=waiting", headers=auth_headers)
+        bo_ids = [b["so_id"] for b in resp.get_json()["backorders"]]
+        assert 2 not in bo_ids

--- a/api/tests/test_cancel_backorder.py
+++ b/api/tests/test_cancel_backorder.py
@@ -1,0 +1,211 @@
+"""Cancel-backorder endpoint.
+
+Thin wrapper over sales_order_service.cancel_sales_order; this file
+covers the wrapper-specific validation (must be a BO; valid reason;
+not already cancelled) and confirms the event + audit emission via
+the underlying service.
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_one(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row
+
+
+def _query_val(sql, params=None):
+    row = _query_one(sql, params)
+    return row[0] if row else None
+
+
+def _partial_fulfill_seed_so(client, auth_headers, so_id=1, short_qty=1):
+    """Run /partial-fulfill against a seeded OPEN SO to create a BO
+    we can then cancel. Returns the BO's so_id."""
+    sol_id = _query_val(
+        "SELECT so_line_id FROM sales_order_lines WHERE so_id = %s LIMIT 1",
+        (so_id,),
+    )
+    resp = client.post(
+        f"/api/admin/sales-orders/{so_id}/partial-fulfill",
+        json={"lines": [{"so_line_id": sol_id, "short_qty": short_qty}]},
+        headers=auth_headers,
+    )
+    return resp.get_json()["backorder_so"]["so_id"]
+
+
+class TestHappyPath:
+    def test_cancel_waiting_stock_bo(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["bo_so_id"] == bo_so_id
+        assert body["cancellation_reason"] == "found"
+
+        row = _query_one(
+            "SELECT status, cancellation_reason FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert row == ("CANCELLED", "found")
+
+        # CANCEL audit row + backorder.cancelled event on the outbox.
+        cancel_audit_count = _query_val(
+            "SELECT COUNT(*) FROM audit_log "
+            " WHERE entity_type = 'SO' AND entity_id = %s "
+            "   AND action_type = 'CANCEL'",
+            (bo_so_id,),
+        )
+        assert cancel_audit_count == 1
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.cancelled' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 1
+
+    def test_cancel_with_default_reason_is_other(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers)
+        # Omitting cancellation_reason should default to 'other'.
+        resp = client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["cancellation_reason"] == "other"
+
+
+class TestValidation:
+    def test_non_bo_so_rejected(self, client, auth_headers):
+        # SO-2026-002 has no parent_so_id and order_type='sale'.
+        resp = client.post(
+            "/api/admin/sales-orders/2/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "Not a backorder" in resp.get_json()["error"]
+
+    def test_already_cancelled_bo_rejected(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers)
+        # Cancel once.
+        client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        # Second cancel: 400 at the wrapper layer (service is
+        # idempotent but the UI wants the explicit error).
+        resp = client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "already cancelled" in resp.get_json()["error"].lower()
+
+    def test_invalid_reason_rejected(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers)
+        resp = client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "made_up_value"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "Allowed:" in resp.get_json()["error"]
+
+
+class TestParentCancelCascade:
+    """Cascade lives in sales_order_service.cancel_sales_order. These
+    tests confirm the cascade fires when the parent is cancelled via
+    the regular /cancel endpoint."""
+
+    def test_cancelling_parent_cascades_to_bo(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers, so_id=1)
+
+        # Cancel the parent (SO-2026-001, so_id=1) via the regular
+        # /cancel endpoint.
+        resp = client.post(
+            "/api/admin/sales-orders/1/cancel",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+
+        # Both parent and BO are CANCELLED.
+        parent_status = _query_val(
+            "SELECT status FROM sales_orders WHERE so_id = 1"
+        )
+        assert parent_status == "CANCELLED"
+
+        bo_row = _query_one(
+            "SELECT status, cancellation_reason FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert bo_row == ("CANCELLED", "parent_cancelled")
+
+        # backorder.cancelled was emitted for the BO (cascade path).
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.cancelled' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 1
+
+    def test_parent_with_already_cancelled_bo_is_idempotent(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers, so_id=1)
+
+        # Cancel BO first.
+        client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        # Now cancel parent.
+        resp = client.post(
+            "/api/admin/sales-orders/1/cancel",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # BO keeps its original reason (the cascade does not overwrite
+        # a CANCELLED child).
+        bo_reason = _query_val(
+            "SELECT cancellation_reason FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        # Either the original "found" (cascade skipped) or
+        # "parent_cancelled" (cascade overwrote then idempotent
+        # cancel returned no-op). Either is acceptable behavior; the
+        # invariant is exactly one backorder.cancelled event.
+        assert bo_reason in ("found", "parent_cancelled")
+
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.cancelled' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 1
+
+    def test_parent_with_no_bo_does_not_cascade(self, client, auth_headers):
+        # SO-2026-002 has no children; cancel should behave normally.
+        resp = client.post(
+            "/api/admin/sales-orders/2/cancel",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.cancelled'",
+        )
+        assert emit_count == 0

--- a/api/tests/test_partial_fulfill.py
+++ b/api/tests/test_partial_fulfill.py
@@ -1,0 +1,374 @@
+"""Partial-fulfill endpoint.
+
+Covers the happy path against an OPEN seeded SO, the PICKED-with-
+short-picks variant, the gates that protect the surface (status,
+chaining, permission, validation), and the BO SO shape (address copy,
+memo prefix, NULL totals, order_type, audit + event emission).
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_one(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row
+
+
+def _query_val(sql, params=None):
+    row = _query_one(sql, params)
+    return row[0] if row else None
+
+
+def _query_all(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    rows = cur.fetchall()
+    cur.close()
+    return rows
+
+
+def _set_so_status(so_id, status):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE sales_orders SET status = %s WHERE so_id = %s",
+        (status, so_id),
+    )
+    cur.close()
+
+
+def _set_line_picked(so_line_id, picked):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE sales_order_lines SET quantity_picked = %s WHERE so_line_id = %s",
+        (picked, so_line_id),
+    )
+    cur.close()
+
+
+def _so_line_id_for(so_id):
+    return _query_val(
+        "SELECT so_line_id FROM sales_order_lines WHERE so_id = %s ORDER BY line_number LIMIT 1",
+        (so_id,),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestOpenHappyPath:
+    def test_open_so_shrinks_and_creates_backorder(self, client, auth_headers):
+        # SO-2026-001 is seeded OPEN with item 1, qty 2.
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}], "reason_detail": "test short"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        data = resp.get_json()
+        assert data["original_so"]["so_id"] == 1
+        assert data["backorder_so"]["so_number"] == "SO-2026-001-BO"
+        assert data["backorder_so"]["status"] == "WAITING_STOCK"
+
+        # Original line shrunk from 2 -> 1.
+        ordered_after = _query_val(
+            "SELECT quantity_ordered FROM sales_order_lines WHERE so_line_id = %s",
+            (sol_id,),
+        )
+        assert ordered_after == 1
+
+        # BO has one line for item 1, qty 1.
+        bo_so_id = data["backorder_so"]["so_id"]
+        bo_lines = _query_all(
+            "SELECT item_id, quantity_ordered, status FROM sales_order_lines WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert bo_lines == [(1, 1, "PENDING")]
+
+
+class TestPickedHappyPath:
+    def test_picked_so_with_short_picks_can_be_partial_fulfilled(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        # Simulate the post-batch state: SO is PICKED with one of the
+        # two units actually picked (the other short-confirmed during
+        # picking).
+        _set_so_status(1, "PICKED")
+        _set_line_picked(sol_id, 1)
+
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        # Original now has qty_ordered=1, qty_picked=1.
+        row = _query_one(
+            "SELECT quantity_ordered, quantity_picked FROM sales_order_lines WHERE so_line_id = %s",
+            (sol_id,),
+        )
+        assert row == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Gates
+# ---------------------------------------------------------------------------
+
+
+class TestStatusGate:
+    def test_packed_rejected(self, client, auth_headers):
+        _set_so_status(1, "PACKED")
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "Can only partial-fulfill" in resp.get_json()["error"]
+
+    def test_shipped_rejected(self, client, auth_headers):
+        _set_so_status(1, "SHIPPED")
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_waiting_stock_rejected(self, client, auth_headers):
+        _set_so_status(1, "WAITING_STOCK")
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+
+class TestBoChainingCap:
+    def test_so_with_parent_id_rejected(self, client, auth_headers):
+        # Promote SO-2026-002 to a "backorder" by stamping parent_so_id.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_orders SET parent_so_id = 1, order_type = 'backorder' WHERE so_id = 2"
+        )
+        cur.close()
+        sol_id = _so_line_id_for(2)
+
+        resp = client.post(
+            "/api/admin/sales-orders/2/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "backorder" in resp.get_json()["error"].lower()
+
+
+class TestValidation:
+    def test_short_qty_exceeds_unshipped_rejected(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        # SO-2026-001 has item 1 qty 2. Short 5 -> rejected.
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 5}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "exceeds unshipped qty" in resp.get_json()["error"]
+
+    def test_invalid_so_line_id_rejected(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": 999999, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "not on SO" in resp.get_json()["error"]
+
+    def test_zero_short_qty_rejected_at_schema_layer(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 0}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Shrink semantics
+# ---------------------------------------------------------------------------
+
+
+class TestShrinkSemantics:
+    def test_shrink_to_zero_hard_deletes_line(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 2}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        # Line is gone.
+        remaining = _query_val(
+            "SELECT COUNT(*) FROM sales_order_lines WHERE so_line_id = %s",
+            (sol_id,),
+        )
+        assert remaining == 0
+
+
+# ---------------------------------------------------------------------------
+# BO SO shape
+# ---------------------------------------------------------------------------
+
+
+class TestBoSoShape:
+    def test_bo_has_order_type_backorder_and_parent_link(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        bo_so_id = resp.get_json()["backorder_so"]["so_id"]
+
+        row = _query_one(
+            "SELECT order_type, parent_so_id, status, "
+            "       order_total, customer_shipping_paid, "
+            "       customer_name, ship_method "
+            "  FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert row[0] == "backorder"
+        assert row[1] == 1
+        assert row[2] == "WAITING_STOCK"
+        assert row[3] is None  # order_total NULL on BO
+        assert row[4] is None  # customer_shipping_paid NULL on BO
+        assert row[5] == "Test Customer 1"  # customer copied
+        assert row[6] == "GROUND"  # ship_method copied
+
+    def test_bo_memo_prepended(self, client, auth_headers):
+        # Set a memo on the parent first.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_orders SET memo = 'original note' WHERE so_id = 1"
+        )
+        cur.close()
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        bo_so_id = resp.get_json()["backorder_so"]["so_id"]
+        memo = _query_val(
+            "SELECT memo FROM sales_orders WHERE so_id = %s", (bo_so_id,)
+        )
+        assert memo.startswith("[BACKORDER from SO-2026-001]")
+        assert "original note" in memo
+
+    def test_bo_backorder_opened_at_stamped(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        bo_so_id = resp.get_json()["backorder_so"]["so_id"]
+        opened_at = _query_val(
+            "SELECT backorder_opened_at FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert opened_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Inventory adjustment
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryAdjustment:
+    def test_on_hand_nonzero_writes_short_adjustment(self, client, auth_headers):
+        # Item 1 in the seed has inventory. Verify a SHORT row lands.
+        sol_id = _so_line_id_for(1)
+        before = _query_val(
+            "SELECT COUNT(*) FROM inventory_adjustments WHERE reason_code = 'SHORT'"
+        )
+        client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        after = _query_val(
+            "SELECT COUNT(*) FROM inventory_adjustments WHERE reason_code = 'SHORT'"
+        )
+        assert after == before + 1
+
+    def test_on_hand_zero_no_adjustment_row(self, client, auth_headers):
+        # Drop on-hand for item 1 to zero across all bins.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute("UPDATE inventory SET quantity_on_hand = 0 WHERE item_id = 1")
+        cur.close()
+        sol_id = _so_line_id_for(1)
+        before = _query_val(
+            "SELECT COUNT(*) FROM inventory_adjustments WHERE reason_code = 'SHORT'"
+        )
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        after = _query_val(
+            "SELECT COUNT(*) FROM inventory_adjustments WHERE reason_code = 'SHORT'"
+        )
+        assert after == before  # no new SHORT row
+
+
+# ---------------------------------------------------------------------------
+# Audit + event emission
+# ---------------------------------------------------------------------------
+
+
+class TestAuditAndEvents:
+    def test_two_audit_rows_one_event_emitted(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        bo_so_id = resp.get_json()["backorder_so"]["so_id"]
+
+        audit_rows = _query_all(
+            "SELECT entity_id, action_type, details "
+            "  FROM audit_log "
+            " WHERE action_type = 'PARTIAL_FULFILL' "
+            " ORDER BY log_id",
+        )
+        # One row on original, one on BO.
+        entity_ids = [r[0] for r in audit_rows]
+        assert 1 in entity_ids
+        assert bo_so_id in entity_ids
+
+        # backorder.opened event landed on integration_events.
+        event_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.opened' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert event_count == 1

--- a/api/tests/test_receiving_backorder_match.py
+++ b/api/tests/test_receiving_backorder_match.py
@@ -1,0 +1,128 @@
+"""Receipt -> backorder.fulfillable matcher.
+
+When receipt.completed lands inventory in a warehouse, the matcher in
+receiving.py looks at WAITING_STOCK backorders in that warehouse and
+flips any whose lines are now fully satisfiable to OPEN. Emits
+backorder.fulfillable per flipped BO.
+
+Partial satisfaction stays WAITING_STOCK with no event (the operator
+explicitly chose "notify only when fully available").
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_one(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row
+
+
+def _query_val(sql, params=None):
+    row = _query_one(sql, params)
+    return row[0] if row else None
+
+
+def _zero_inventory_for_item(item_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE inventory SET quantity_on_hand = 0, quantity_allocated = 0 "
+        " WHERE item_id = %s",
+        (item_id,),
+    )
+    cur.close()
+
+
+def _create_bo_from_so1(client, auth_headers, short_qty):
+    """Drop inventory for item 1 to zero, then partial-fulfill SO-2026-001
+    so the resulting BO is WAITING_STOCK with on-hand=0."""
+    _zero_inventory_for_item(1)
+    sol_id = _query_val(
+        "SELECT so_line_id FROM sales_order_lines WHERE so_id = 1 LIMIT 1"
+    )
+    resp = client.post(
+        "/api/admin/sales-orders/1/partial-fulfill",
+        json={"lines": [{"so_line_id": sol_id, "short_qty": short_qty}]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.get_json()
+    return resp.get_json()["backorder_so"]["so_id"]
+
+
+def _receive(client, auth_headers, *, po_id=1, item_id=1, qty=5, bin_id=3):
+    return client.post(
+        "/api/receiving/receive",
+        json={
+            "po_id": po_id,
+            "items": [{"item_id": item_id, "quantity": qty, "bin_id": bin_id}],
+        },
+        headers=auth_headers,
+    )
+
+
+class TestFulfillable:
+    def test_receipt_satisfies_bo_flips_to_open_and_emits(self, client, auth_headers):
+        bo_so_id = _create_bo_from_so1(client, auth_headers, short_qty=2)
+
+        # Sanity: BO is WAITING_STOCK with no fulfillable timestamp.
+        before = _query_one(
+            "SELECT status, backorder_fulfillable_at FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert before[0] == "WAITING_STOCK"
+        assert before[1] is None
+
+        # Receive 5 of item 1 (more than the 2 the BO needs).
+        resp = _receive(client, auth_headers, qty=5)
+        assert resp.status_code == 200, resp.get_json()
+
+        # BO flipped.
+        after = _query_one(
+            "SELECT status, backorder_fulfillable_at FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert after[0] == "OPEN"
+        assert after[1] is not None
+
+        # backorder.fulfillable on the outbox.
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.fulfillable' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 1
+
+    def test_partial_receipt_stays_waiting_no_event(self, client, auth_headers):
+        # SO-2026-001 only has qty 2, so we can only short up to 2.
+        # Force on-hand to 0, partial-fulfill 2, then receive only 1
+        # (BO needs 2; receipt of 1 is partial; BO stays WAITING).
+        bo_so_id = _create_bo_from_so1(client, auth_headers, short_qty=2)
+
+        resp = _receive(client, auth_headers, qty=1)
+        assert resp.status_code == 200, resp.get_json()
+
+        status = _query_val(
+            "SELECT status FROM sales_orders WHERE so_id = %s", (bo_so_id,)
+        )
+        assert status == "WAITING_STOCK"
+
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.fulfillable' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 0
+
+    def test_receipt_for_unrelated_item_does_not_flip_bo(self, client, auth_headers):
+        bo_so_id = _create_bo_from_so1(client, auth_headers, short_qty=2)
+        # Receive item 2 (not the BO's item). BO stays WAITING.
+        resp = _receive(client, auth_headers, item_id=2, qty=5, bin_id=4)
+        assert resp.status_code == 200, resp.get_json()
+        status = _query_val(
+            "SELECT status FROM sales_orders WHERE so_id = %s", (bo_so_id,)
+        )
+        assert status == "WAITING_STOCK"

--- a/db/migrations/067_partial_fulfill_backorders.sql
+++ b/db/migrations/067_partial_fulfill_backorders.sql
@@ -1,0 +1,87 @@
+-- ============================================================
+-- Migration 067: partial-fulfill + backorders
+-- ============================================================
+-- Backs the new "Partially Fulfill" admin workflow plus the
+-- /backorders Outbound surface.
+--
+-- Additive shape:
+--
+--   backorder_opened_at        -- set on a BO SO when it is created
+--                                 via /partial-fulfill. NULL on every
+--                                 non-BO SO.
+--   backorder_fulfillable_at   -- set on a BO SO when receipt.completed
+--                                 makes all its lines satisfiable and
+--                                 the BO flips WAITING_STOCK -> OPEN.
+--   cancellation_reason        -- on a CANCELLED SO, free-form-ish
+--                                 enum (app-enforced, see
+--                                 api/constants.py). Used by
+--                                 /cancel-backorder and the parent
+--                                 cancellation cascade.
+--
+--   order_type CHECK gains 'backorder'. The column was added in
+--   mig 056 for POS refunds; backorder SOs reuse the existing
+--   parent_so_id FK and disambiguate via order_type='backorder'.
+--
+--   sales_orders.status comment gains 'WAITING_STOCK'. The status
+--   column is plain VARCHAR (no DB CHECK; matches mig 054 + mig 058
+--   pattern). The new lifecycle slot is a backorder-only off-ramp:
+--   a BO flips to OPEN when receipt.completed makes its lines
+--   satisfiable, picker-side workflow then runs unchanged.
+--
+--   inventory_adjustments.reason_code comment gains 'SHORT'. Same
+--   app-enforced enum pattern as the SO status; no DB CHECK.
+--
+--   ix_sales_orders_waiting_stock partial index covers the receipt
+--   hook's "find WAITING_STOCK BOs in this warehouse, oldest first"
+--   query.
+--
+-- v1.8.0 migration discipline (#213): SET lock_timeout /
+-- statement_timeout, BEGIN/COMMIT-wrapped. Constraint adds wrapped
+-- in DO $$ blocks so partial-apply re-runs do not abort.
+-- ============================================================
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+ALTER TABLE sales_orders
+    ADD COLUMN IF NOT EXISTS backorder_opened_at      TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS backorder_fulfillable_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS cancellation_reason      VARCHAR(50);
+
+-- order_type CHECK expansion. Drop-then-add inside a DO block so a
+-- partially-applied state (e.g. constraint already dropped from a
+-- prior aborted run) does not abort the migration. The replacement
+-- constraint keeps the existing ('sale','refund') values and adds
+-- ('backorder') for SOs created via the partial-fulfill endpoint.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'sales_orders_order_type_check'
+    ) THEN
+        ALTER TABLE sales_orders DROP CONSTRAINT sales_orders_order_type_check;
+    END IF;
+
+    ALTER TABLE sales_orders
+        ADD CONSTRAINT sales_orders_order_type_check
+        CHECK (order_type IN ('sale','refund','backorder'));
+END $$;
+
+COMMENT ON COLUMN sales_orders.status IS
+    'Lifecycle: OPEN, PICKED, PACKED, SHIPPED, CANCELLED, FRAUD_REVIEW, WAITING_STOCK. Enforced by api/constants.py, not by a DB CHECK. WAITING_STOCK (mig 067) is a backorder-only off-ramp; a BO flips to OPEN when receipt.completed makes all its lines satisfiable.';
+
+COMMENT ON COLUMN sales_order_lines.status IS
+    'Lifecycle: PENDING, PICKED, PACKED, SHIPPED. ALLOCATED retired in mig 058 (never written by app code).';
+
+COMMENT ON COLUMN inventory_adjustments.reason_code IS
+    'Reason for the adjustment. App-enforced enum (no DB CHECK): CYCLE_COUNT, DAMAGE, FOUND, LOST, CORRECTION, SHORT. SHORT (mig 067) is written by /partial-fulfill when on-hand stock exists for a shorted line.';
+
+COMMENT ON COLUMN sales_orders.cancellation_reason IS
+    'On a CANCELLED SO, the reason the cancel was issued. App-enforced enum (no DB CHECK): found, customer_asked, refunded, parent_cancelled, other. Set by /cancel-backorder (operator-supplied) or by the parent-cancel cascade in sales_order_service.cancel_sales_order (value: parent_cancelled). NULL on non-cancelled SOs and on cancels that predate mig 067.';
+
+CREATE INDEX IF NOT EXISTS ix_sales_orders_waiting_stock
+    ON sales_orders (warehouse_id, backorder_opened_at)
+    WHERE status = 'WAITING_STOCK';
+
+COMMIT;

--- a/db/migrations/068_notification_webhooks.sql
+++ b/db/migrations/068_notification_webhooks.sql
@@ -1,0 +1,61 @@
+-- ============================================================
+-- Migration 068: notification_webhooks table
+-- ============================================================
+-- Backs the per-warehouse Teams notification surface introduced
+-- alongside the partial-fulfill / backorder workflow.
+--
+-- Distinct from webhook_subscriptions: that table carries
+-- signed-envelope HTTP subscribers with a different
+-- payload shape, audit surface, and rate-limit ceiling. This table
+-- carries chat-channel destinations (Teams adaptive cards in v1).
+-- Both are routed through services/webhook_dispatcher; the
+-- dispatcher selects an adapter by channel_kind.
+--
+-- url is Fernet-encrypted at rest via the existing
+-- SENTRY_ENCRYPTION_KEY wrapper that token storage uses today
+-- (services/credential_vault.py). Plaintext URL never appears in
+-- the DB.
+--
+-- v1.8.0 mig discipline (#213): SET lock_timeout /
+-- statement_timeout, BEGIN/COMMIT-wrapped.
+-- ============================================================
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS notification_webhooks (
+    webhook_id    SERIAL PRIMARY KEY,
+    warehouse_id  INT NOT NULL REFERENCES warehouses(warehouse_id),
+    channel_kind  VARCHAR(20) NOT NULL,
+    url           TEXT NOT NULL,
+    event_filter  TEXT[] NOT NULL DEFAULT
+                  ARRAY['backorder.opened','backorder.fulfillable'],
+    enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+    secret        VARCHAR(128),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by    VARCHAR(100) NOT NULL,
+    external_id   UUID UNIQUE NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_notification_webhooks_active
+    ON notification_webhooks (warehouse_id, channel_kind)
+    WHERE enabled = TRUE;
+
+COMMENT ON TABLE notification_webhooks IS
+    'Chat-channel notification destinations (Teams adaptive cards in v1). Distinct from webhook_subscriptions, which carries signed-envelope HTTP subscribers with a different payload shape and audit surface. Folded into services/webhook_dispatcher via a channel_kind adapter; routing reads this table for events in the backorder.* family.';
+
+COMMENT ON COLUMN notification_webhooks.url IS
+    'Fernet-encrypted at rest via SENTRY_ENCRYPTION_KEY. Plaintext URL never appears in the DB; the admin-facing CRUD surface accepts the URL on create and exposes a "rotate URL" flow that swaps the ciphertext.';
+
+COMMENT ON COLUMN notification_webhooks.channel_kind IS
+    'Adapter selector. v1 only ships ''teams''; the column is sized for future ''slack'', ''pagerduty'', etc.';
+
+COMMENT ON COLUMN notification_webhooks.event_filter IS
+    'Allowlist of event_type values this webhook receives. Default carries the partial-fulfill events. An empty array means "receive nothing" (explicit opt-out without disabling the row).';
+
+COMMENT ON COLUMN notification_webhooks.secret IS
+    'Optional HMAC key for sign-verify on the receiving end. Teams adaptive cards do not require this; Slack and self-hosted webhooks may. NULL on rows that do not need it.';
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -185,7 +185,7 @@ CREATE TABLE sales_orders (
     customer_id VARCHAR(50),
     customer_phone VARCHAR(50),
     customer_address TEXT,
-    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED', 'FRAUD_REVIEW'. PICKING/PACKING retired in mig 060; "in picking" is derived from pick_batches.
+    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED', 'FRAUD_REVIEW', 'WAITING_STOCK'. PICKING/PACKING retired in mig 060; "in picking" is derived from pick_batches. WAITING_STOCK added in mig 067 (backorder-only off-ramp).
     priority INT DEFAULT 0,                -- higher = pick first
     warehouse_id INT NOT NULL REFERENCES warehouses(warehouse_id),
     ship_method VARCHAR(50),
@@ -267,10 +267,20 @@ CREATE TABLE sales_orders (
     idempotency_body_hash   CHAR(64),
     cached_response_body    JSONB,
     order_type              VARCHAR(20) NOT NULL DEFAULT 'sale'
-                            CHECK (order_type IN ('sale','refund')),
+                            CHECK (order_type IN ('sale','refund','backorder')),
     parent_so_id            INT REFERENCES sales_orders(so_id),
     refunded_at             TIMESTAMPTZ,
     refund_so_id            INT REFERENCES sales_orders(so_id),
+    -- mig 067: partial-fulfill / backorder lifecycle stamps.
+    -- backorder_opened_at is set on a BO SO when it is created via
+    -- /partial-fulfill; backorder_fulfillable_at is set when the
+    -- receipt hook flips a WAITING_STOCK BO to OPEN. cancellation_reason
+    -- is set on a CANCELLED SO (by /cancel-backorder or by the
+    -- parent-cancel cascade). All three are NULL on non-BO / non-cancel
+    -- SOs.
+    backorder_opened_at      TIMESTAMPTZ,
+    backorder_fulfillable_at TIMESTAMPTZ,
+    cancellation_reason      VARCHAR(50),
     -- mig 064: timestamp set when a picking ticket has been
     -- confirmed-rendered for this SO. POST /sales-orders/mark-printed
     -- writes it once the client-side ticket render succeeds. NULL
@@ -281,6 +291,13 @@ CREATE TABLE sales_orders (
 CREATE INDEX IF NOT EXISTS ix_sales_orders_unprinted
     ON sales_orders (status, ship_by_date)
     WHERE printed_at IS NULL;
+
+-- mig 067: covers the receipt hook's "find WAITING_STOCK BOs
+-- in this warehouse, oldest first" lookup; also drives the
+-- /backorders Waiting tab.
+CREATE INDEX IF NOT EXISTS ix_sales_orders_waiting_stock
+    ON sales_orders (warehouse_id, backorder_opened_at)
+    WHERE status = 'WAITING_STOCK';
 
 CREATE TABLE sales_order_lines (
     so_line_id SERIAL PRIMARY KEY,
@@ -466,7 +483,7 @@ CREATE TABLE inventory_adjustments (
     bin_id INT NOT NULL REFERENCES bins(bin_id),
     warehouse_id INT NOT NULL REFERENCES warehouses(warehouse_id),
     quantity_change INT NOT NULL,           -- positive = add, negative = remove
-    reason_code VARCHAR(50) NOT NULL,      -- 'CYCLE_COUNT', 'DAMAGE', 'FOUND', 'LOST', 'CORRECTION'
+    reason_code VARCHAR(50) NOT NULL,      -- 'CYCLE_COUNT', 'DAMAGE', 'FOUND', 'LOST', 'CORRECTION', 'SHORT'. SHORT (mig 063) is written by /partial-fulfill when on-hand exists for a shorted line.
     reason_detail VARCHAR(500),
     status VARCHAR(20) NOT NULL DEFAULT 'PENDING',  -- 'PENDING', 'APPROVED', 'REJECTED'
     adjusted_by VARCHAR(100) NOT NULL,
@@ -1854,6 +1871,39 @@ CREATE TABLE webhook_subscriptions_tombstones (
 CREATE INDEX webhook_subscriptions_tombstones_canonical_unack
     ON webhook_subscriptions_tombstones (delivery_url_canonical)
     WHERE acknowledged_at IS NULL;
+
+-- ============================================================
+-- NOTIFICATION WEBHOOKS (mig 068)
+-- ============================================================
+-- Chat-channel notification destinations (Teams adaptive cards in
+-- v1). Distinct from webhook_subscriptions, which carries
+-- signed-envelope HTTP subscribers with a different payload shape
+-- and audit surface. Folded into services/webhook_dispatcher via a
+-- channel_kind adapter; routing reads this table for events in the
+-- backorder.* family.
+
+CREATE TABLE notification_webhooks (
+    webhook_id    SERIAL PRIMARY KEY,
+    warehouse_id  INT NOT NULL REFERENCES warehouses(warehouse_id),
+    channel_kind  VARCHAR(20) NOT NULL,
+    -- Fernet-encrypted at rest via SENTRY_ENCRYPTION_KEY. Plaintext
+    -- URL never appears in the DB.
+    url           TEXT NOT NULL,
+    event_filter  TEXT[] NOT NULL DEFAULT
+                  ARRAY['backorder.opened','backorder.fulfillable'],
+    enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+    -- Optional HMAC key for sign-verify on the receiving end. Teams
+    -- adaptive cards do not require this; Slack and self-hosted
+    -- webhooks may.
+    secret        VARCHAR(128),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by    VARCHAR(100) NOT NULL,
+    external_id   UUID UNIQUE NOT NULL
+);
+
+CREATE INDEX ix_notification_webhooks_active
+    ON notification_webhooks (warehouse_id, channel_kind)
+    WHERE enabled = TRUE;
 
 -- ============================================================
 -- TRANSFER ORDERS (v1.8.0 #281)


### PR DESCRIPTION
## Partial-fulfillment + backorders

Adds a partial-fulfill workflow: when a sales order can only ship some of its lines, the operator shorts the unshippable quantity and the system spins off a backorder SO that waits for stock and rejoins the picking queue automatically when a receipt makes it whole.

### Backend
- `POST /admin/sales-orders/<id>/partial-fulfill` shrinks the shorted lines on the original SO (it continues through pack/ship with what was picked) and creates a backorder SO with `order_type='backorder'`, `status=WAITING_STOCK`, a `parent_so_id` back-pointer, a full address copy, and NULL totals (already paid on the parent). Writes a SHORT inventory adjustment when on-hand stock exists for a shorted line. BO chaining is capped at one level; refund SOs are rejected.
- `POST /admin/sales-orders/<id>/cancel-backorder` cancels a BO with a `cancellation_reason`; the shared `cancel_sales_order` service gained a parent-cancel cascade (cancelling a parent recursively cancels its non-terminal backorders) and emits `backorder.cancelled`.
- The receiving loop matches `WAITING_STOCK` backorders on every receipt: a BO whose lines are all satisfiable against pickable on-hand flips to OPEN, stamps `backorder_fulfillable_at`, and emits `backorder.fulfillable`. Partial satisfaction stays waiting (no event).
- `GET /admin/backorders` backs the new dashboard (Waiting / Ready-to-ship tabs), gated by a new `backorders` page key.
- Event registry: `backorder.opened` / `backorder.fulfillable` / `backorder.cancelled` at v1, with JSON schemas.

### Admin UI
- A "Partially Fulfill" button + sub-modal on the SO edit screen (gated to OPEN/PICKED, non-refund, non-backorder).
- A `/backorders` page under Outbound with per-row items, days-waiting, parent SO, and a cancel action; clicking a row deep-links into the SO modal.

### Migrations
- **067** -- `sales_orders` gains `backorder_opened_at`, `backorder_fulfillable_at`, `cancellation_reason`; `order_type` CHECK adds `'backorder'`; `WAITING_STOCK` status + `SHORT` adjustment reason documented (app-enforced, no DB CHECK); partial index `ix_sales_orders_waiting_stock` for the receipt-hook lookup.
- **068** -- `notification_webhooks` table (used by the notifications thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
