### PR TITLE
feat: notification webhooks (Teams)

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -3440,9 +3440,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -28,6 +28,7 @@ import Tokens from './pages/Tokens.jsx';
 import InboundActivity from './pages/InboundActivity.jsx';
 import ConsumerGroups from './pages/ConsumerGroups.jsx';
 import Webhooks from './pages/Webhooks.jsx';
+import Notifications from './pages/Notifications.jsx';
 import AuditLog from './pages/AuditLog.jsx';
 import PreferredBins from './pages/PreferredBins.jsx';
 import Settings from './pages/Settings.jsx';
@@ -126,6 +127,7 @@ export default function App() {
         <Route path="/inbound" element={<ErrorBoundary fallbackMessage="Could not load Inbound activity."><InboundActivity /></ErrorBoundary>} />
         <Route path="/consumer-groups" element={<ErrorBoundary fallbackMessage="Could not load consumer groups."><ConsumerGroups /></ErrorBoundary>} />
         <Route path="/webhooks" element={<ErrorBoundary fallbackMessage="Could not load webhooks."><Webhooks /></ErrorBoundary>} />
+        <Route path="/notifications" element={<ErrorBoundary fallbackMessage="Could not load notifications."><Notifications /></ErrorBoundary>} />
         <Route path="/audit-log" element={<ErrorBoundary fallbackMessage="Could not load audit log."><AuditLog /></ErrorBoundary>} />
         <Route path="/settings" element={<ErrorBoundary fallbackMessage="Could not load settings."><Settings /></ErrorBoundary>} />
         <Route path="/imports" element={<ErrorBoundary fallbackMessage="Could not load imports."><Imports /></ErrorBoundary>} />

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -16,6 +16,7 @@ import PickingTickets from './pages/PickingTickets.jsx';
 import PickingTicketPrint from './pages/PickingTicketPrint.jsx';
 import PickingTicketPrintAll from './pages/PickingTicketPrintAll.jsx';
 import PickingBatches from './pages/PickingBatches.jsx';
+import Backorders from './pages/Backorders.jsx';
 import Bins from './pages/Bins.jsx';
 import Zones from './pages/Zones.jsx';
 import Items from './pages/Items.jsx';
@@ -97,6 +98,7 @@ export default function App() {
         <Route path="/sales-orders" element={<ErrorBoundary fallbackMessage="Could not load sales orders."><SalesOrders /></ErrorBoundary>} />
         <Route path="/pos-activity" element={<ErrorBoundary fallbackMessage="Could not load POS activity."><POSActivity /></ErrorBoundary>} />
         <Route path="/fraud" element={<ErrorBoundary fallbackMessage="Could not load fraud queue."><Fraud /></ErrorBoundary>} />
+        <Route path="/backorders" element={<ErrorBoundary fallbackMessage="Could not load backorders."><Backorders /></ErrorBoundary>} />
         <Route path="/picking-tickets" element={<ErrorBoundary fallbackMessage="Could not load picking tickets."><PickingTickets /></ErrorBoundary>} />
         {/* The /picking, /packing, /shipping admin pages were retired:
             the workflow lives on the handheld scanners, and the

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -34,6 +34,8 @@ const NAV = [
       { to: '/sales-orders', label: 'Sales Orders', pageKey: 'sales-orders' },
       { to: '/pos-activity', label: 'POS Activity' },
       { to: '/fraud', label: 'Fraud', pageKey: 'fraud' },
+      // Partial-fulfill / backorders dashboard.
+      { to: '/backorders', label: 'Backorders', pageKey: 'backorders' },
       { to: '/picking-tickets', label: 'Picking Tickets', pageKey: 'picking-tickets' },
       // Picking/Packing/Shipping are mobile-only: the admin-side
       // mirrors were retired. Supervisors use Sales Orders + Picking

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -65,6 +65,11 @@ const NAV = [
       { to: '/inbound', label: 'Inbound activity', pageKey: 'inbound' },
       { to: '/consumer-groups', label: 'Consumer groups', pageKey: 'consumer-groups' },
       { to: '/webhooks', label: 'Webhooks', pageKey: 'webhooks' },
+      // v1.13.0 mig 064 notification_webhooks. Sibling to /webhooks
+      // because both are outbound-delivery surfaces; this one carries
+      // chat-channel destinations (Teams adaptive cards), the other
+      // signed-envelope HTTP subscribers.
+      { to: '/notifications', label: 'Notifications', pageKey: 'notifications' },
       { to: '/audit-log', label: 'Audit log', pageKey: 'audit-log' },
       { to: '/imports', label: 'Import', pageKey: 'imports' },
       { to: '/integrations', label: 'Integrations', pageKey: 'integrations' },

--- a/admin/src/pages/Backorders.jsx
+++ b/admin/src/pages/Backorders.jsx
@@ -1,0 +1,266 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '../api.js';
+import { useWarehouse } from '../warehouse.jsx';
+import DataTable from '../components/DataTable.jsx';
+import PageHeader from '../components/PageHeader.jsx';
+import Modal from '../components/Modal.jsx';
+
+// Partial-fulfill / backorders dashboard. Two tabs:
+//   Waiting       - status=WAITING_STOCK, oldest backorder_opened_at
+//                   surfaces first so a long-tail backorder is not
+//                   buried under a fresh one.
+//   Ready to ship - status IN (OPEN, PICKED, PACKED) with
+//                   backorder_opened_at IS NOT NULL. These have been
+//                   flipped to OPEN by the receipt-hook matcher and
+//                   are eligible for the next pick batch.
+// Click row opens the existing SO edit modal via
+// /sales-orders?focus=<so_number>; the SO page reads the focus query
+// param and pops the modal in-place.
+
+const TABS = [
+  { key: 'waiting', label: 'Waiting' },
+  { key: 'ready-to-ship', label: 'Ready to Ship' },
+];
+
+const CANCEL_REASONS = [
+  { value: 'found', label: 'Found in warehouse' },
+  { value: 'customer_asked', label: 'Customer asked to cancel' },
+  { value: 'refunded', label: 'Refunded' },
+  { value: 'other', label: 'Other' },
+];
+
+
+function ItemsCell({ items }) {
+  if (!items || items.length === 0) {
+    return <span style={{ color: 'var(--text-secondary)' }}>(none)</span>;
+  }
+  return (
+    <div style={{ fontSize: 12, lineHeight: 1.4 }}>
+      {items.map((it, i) => (
+        <div key={i}>
+          <span className="mono">{it.sku}</span>
+          {' × '}
+          {it.qty}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+
+export default function Backorders() {
+  const navigate = useNavigate();
+  const { warehouseId } = useWarehouse();
+  const [tab, setTab] = useState('waiting');
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [actionError, setActionError] = useState('');
+  const [successBanner, setSuccessBanner] = useState('');
+
+  // Cancel-BO confirm modal state. cancelTarget holds the BO row
+  // being cancelled; cancelReason is a dropdown enum mirroring the
+  // backend's CANCEL_REASONS.
+  const [cancelTarget, setCancelTarget] = useState(null);
+  const [cancelReason, setCancelReason] = useState('other');
+  const [cancelSubmitting, setCancelSubmitting] = useState(false);
+  const [cancelError, setCancelError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setActionError('');
+    const qs = new URLSearchParams({ tab });
+    if (warehouseId) qs.set('warehouse_id', String(warehouseId));
+    const res = await api.get(`/admin/backorders?${qs.toString()}`);
+    if (res?.ok) {
+      const data = await res.json();
+      setRows(data.backorders || []);
+    } else {
+      setRows([]);
+      setActionError('Failed to load backorders.');
+    }
+    setLoading(false);
+  }, [tab, warehouseId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  function openCancel(row) {
+    setCancelTarget(row);
+    setCancelReason('other');
+    setCancelError('');
+  }
+
+  function closeCancel() {
+    setCancelTarget(null);
+    setCancelReason('other');
+    setCancelError('');
+    setCancelSubmitting(false);
+  }
+
+  async function submitCancel() {
+    if (!cancelTarget) return;
+    setCancelSubmitting(true);
+    setCancelError('');
+    const res = await api.post(
+      `/admin/sales-orders/${cancelTarget.so_id}/cancel-backorder`,
+      { cancellation_reason: cancelReason },
+    );
+    setCancelSubmitting(false);
+    if (!res?.ok) {
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON */ }
+      setCancelError(data?.error || 'Failed to cancel backorder.');
+      return;
+    }
+    const soNumber = cancelTarget.so_number;
+    closeCancel();
+    setSuccessBanner(`Backorder ${soNumber} cancelled (${cancelReason}).`);
+    setTimeout(() => setSuccessBanner(''), 6000);
+    load();
+  }
+
+  // Both tabs share a base column set; ready-to-ship adds
+  // "Fulfillable since" so the operator can prioritise the longest-
+  // waiting ready batch first.
+  const baseColumns = [
+    { key: 'so_number', label: 'Backorder #', mono: true },
+    { key: 'parent_so_number', label: 'Parent SO', mono: true,
+      render: (r) => r.parent_so_number || <span style={{ color: 'var(--text-secondary)' }}>-</span> },
+    { key: 'customer_name', label: 'Customer',
+      render: (r) => r.customer_name || <span style={{ color: 'var(--text-secondary)' }}>-</span> },
+    { key: 'items', label: 'Items', render: (r) => <ItemsCell items={r.items} /> },
+    { key: 'days_waiting', label: 'Days waiting',
+      render: (r) => (
+        <span className="mono">
+          {r.days_waiting}
+        </span>
+      ),
+    },
+  ];
+
+  const readyColumn = {
+    key: 'fulfillable_since',
+    label: 'Fulfillable since',
+    render: (r) => r.fulfillable_since
+      ? new Date(r.fulfillable_since).toLocaleDateString()
+      : <span style={{ color: 'var(--text-secondary)' }}>-</span>,
+  };
+
+  const actionsColumn = {
+    key: 'actions',
+    label: '',
+    render: (r) => (
+      <button
+        className="btn btn-sm btn-danger"
+        onClick={(e) => { e.stopPropagation(); openCancel(r); }}
+        title="Cancel this backorder"
+      >
+        Cancel
+      </button>
+    ),
+  };
+
+  const columns = tab === 'ready-to-ship'
+    ? [...baseColumns, readyColumn, actionsColumn]
+    : [...baseColumns, actionsColumn];
+
+  function openRowInSalesOrders(row) {
+    // The SO list page reads ?focus=<so_number> to auto-open the
+    // edit modal for that row. Mirrors the deep-link pattern the
+    // Teams adaptive card uses so /backorders -> click -> SO modal
+    // is the same path as Teams ping -> Open in Sentry -> SO modal.
+    navigate(`/sales-orders?focus=${encodeURIComponent(row.so_number)}`);
+  }
+
+  return (
+    <div>
+      <PageHeader title="Backorders" />
+      {successBanner && (
+        <div
+          role="status"
+          style={{
+            margin: '0 0 12px 0',
+            padding: '8px 12px',
+            background: 'var(--success-bg, #e8f5e9)',
+            color: 'var(--success, #2e7d32)',
+            border: '1px solid var(--success, #2e7d32)',
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {successBanner}
+        </div>
+      )}
+      {actionError && (
+        <div className="form-error" style={{ marginBottom: 12 }}>{actionError}</div>
+      )}
+      <div className="section">
+        <div role="tablist" style={{ display: 'flex', gap: 4, marginBottom: 12 }}>
+          {TABS.map((t) => (
+            <button
+              key={t.key}
+              role="tab"
+              aria-selected={tab === t.key}
+              className={`btn ${tab === t.key ? 'btn-primary' : ''}`}
+              onClick={() => setTab(t.key)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <DataTable
+          columns={columns}
+          data={rows}
+          loading={loading}
+          emptyMessage={tab === 'waiting'
+            ? 'No backorders waiting for stock.'
+            : 'No backorders are ready to ship right now.'}
+          onRowClick={openRowInSalesOrders}
+        />
+      </div>
+
+      {cancelTarget && (
+        <Modal
+          title={`Cancel backorder ${cancelTarget.so_number}?`}
+          onClose={closeCancel}
+          footer={
+            <>
+              <button className="btn" onClick={closeCancel} disabled={cancelSubmitting}>
+                Keep Backorder
+              </button>
+              <button
+                className="btn btn-danger"
+                onClick={submitCancel}
+                disabled={cancelSubmitting}
+              >
+                {cancelSubmitting ? 'Cancelling...' : 'Cancel Backorder'}
+              </button>
+            </>
+          }
+        >
+          {cancelError && (
+            <div className="form-error" style={{ marginBottom: 12 }}>{cancelError}</div>
+          )}
+          <p style={{ fontSize: 13, marginBottom: 12 }}>
+            Cancelling will mark <strong>{cancelTarget.so_number}</strong> as
+            CANCELLED. The parent SO (<span className="mono">{cancelTarget.parent_so_number}</span>)
+            is unaffected. A backorder.cancelled event fires on the
+            integration outbox + Teams channel.
+          </p>
+          <div className="form-group">
+            <label>Reason</label>
+            <select
+              className="form-select"
+              value={cancelReason}
+              onChange={(e) => setCancelReason(e.target.value)}
+            >
+              {CANCEL_REASONS.map((r) => (
+                <option key={r.value} value={r.value}>{r.label}</option>
+              ))}
+            </select>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/admin/src/pages/Notifications.jsx
+++ b/admin/src/pages/Notifications.jsx
@@ -1,0 +1,535 @@
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '../api.js';
+import { useWarehouse } from '../warehouse.jsx';
+import DataTable from '../components/DataTable.jsx';
+import PageHeader from '../components/PageHeader.jsx';
+import Modal from '../components/Modal.jsx';
+
+// notification_webhooks admin surface. Operators
+// configure per-warehouse Teams destinations that receive the
+// backorder.* event family (opened / fulfillable / cancelled). The
+// URL is Fernet-encrypted at rest and never returned in plaintext;
+// the list shows a masked host preview. A "rotate URL" action lets
+// operators swap the destination without round-tripping the
+// secret back to the browser. "Test send" fires a sample
+// backorder.opened adaptive card so the operator can verify the
+// Teams channel renders before real events flow.
+
+const SUPPORTED_CHANNELS = [
+  { value: 'teams', label: 'Microsoft Teams' },
+];
+
+const ALLOWED_EVENT_TYPES = [
+  { value: 'backorder.opened',      label: 'backorder.opened' },
+  { value: 'backorder.fulfillable', label: 'backorder.fulfillable' },
+  { value: 'backorder.cancelled',   label: 'backorder.cancelled' },
+];
+
+const DEFAULT_EVENT_FILTER = ['backorder.opened', 'backorder.fulfillable'];
+
+
+function EventFilterCheckboxes({ value, onChange, disabled = false }) {
+  const set = new Set(value || []);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {ALLOWED_EVENT_TYPES.map((opt) => (
+        <label key={opt.value} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13 }}>
+          <input
+            type="checkbox"
+            checked={set.has(opt.value)}
+            disabled={disabled}
+            onChange={(e) => {
+              const next = new Set(set);
+              if (e.target.checked) next.add(opt.value); else next.delete(opt.value);
+              onChange([...next]);
+            }}
+          />
+          <span className="mono">{opt.label}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+
+function TestSendOutcome({ outcome }) {
+  if (!outcome) return null;
+  const ok = outcome.delivered;
+  return (
+    <div
+      role="status"
+      style={{
+        marginTop: 8,
+        padding: '6px 10px',
+        background: ok ? 'var(--success-bg, #e8f5e9)' : 'var(--danger-bg, #fdecea)',
+        color: ok ? 'var(--success, #2e7d32)' : 'var(--danger, #c62828)',
+        border: `1px solid ${ok ? 'var(--success, #2e7d32)' : 'var(--danger, #c62828)'}`,
+        borderRadius: 4,
+        fontSize: 12,
+        whiteSpace: 'pre-wrap',
+      }}
+    >
+      {ok
+        ? `Delivered (status ${outcome.status_code || 200}).`
+        : `Send failed: ${outcome.error_kind || 'unknown'}${outcome.status_code ? ` (status ${outcome.status_code})` : ''}${outcome.error_detail ? `\n${outcome.error_detail}` : ''}`}
+    </div>
+  );
+}
+
+
+export default function Notifications() {
+  const { warehouseId } = useWarehouse();
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [pageError, setPageError] = useState('');
+  const [successBanner, setSuccessBanner] = useState('');
+
+  const [creating, setCreating] = useState(false);
+  const [createForm, setCreateForm] = useState({
+    channel_kind: 'teams',
+    url: '',
+    event_filter: DEFAULT_EVENT_FILTER,
+    enabled: true,
+    secret: '',
+  });
+  const [createError, setCreateError] = useState('');
+  const [createSubmitting, setCreateSubmitting] = useState(false);
+
+  const [rotating, setRotating] = useState(null);
+  const [rotateUrl, setRotateUrl] = useState('');
+  const [rotateError, setRotateError] = useState('');
+  const [rotateSubmitting, setRotateSubmitting] = useState(false);
+
+  // Per-row test-send outcomes keyed by webhook_id so multiple
+  // tests in flight do not blow away each other's status.
+  const [testOutcomes, setTestOutcomes] = useState({});
+  const [testInFlight, setTestInFlight] = useState({});
+
+  const [deleting, setDeleting] = useState(null);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setPageError('');
+    const qs = new URLSearchParams();
+    if (warehouseId) qs.set('warehouse_id', String(warehouseId));
+    const res = await api.get(`/admin/notification-webhooks?${qs.toString()}`);
+    if (res?.ok) {
+      const data = await res.json();
+      setRows(data.notification_webhooks || []);
+    } else {
+      setRows([]);
+      setPageError('Failed to load notification webhooks.');
+    }
+    setLoading(false);
+  }, [warehouseId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  function flashSuccess(msg) {
+    setSuccessBanner(msg);
+    setTimeout(() => setSuccessBanner(''), 6000);
+  }
+
+  function openCreate() {
+    setCreateForm({
+      channel_kind: 'teams',
+      url: '',
+      event_filter: DEFAULT_EVENT_FILTER,
+      enabled: true,
+      secret: '',
+    });
+    setCreateError('');
+    setCreating(true);
+  }
+
+  function closeCreate() {
+    setCreating(false);
+    setCreateError('');
+    setCreateSubmitting(false);
+  }
+
+  async function submitCreate() {
+    if (!warehouseId) {
+      setCreateError('Pick a warehouse from the top bar first.');
+      return;
+    }
+    if (!createForm.url) {
+      setCreateError('URL is required.');
+      return;
+    }
+    if (!createForm.event_filter || createForm.event_filter.length === 0) {
+      setCreateError('Select at least one event type.');
+      return;
+    }
+    setCreateSubmitting(true);
+    setCreateError('');
+    const body = {
+      warehouse_id: warehouseId,
+      channel_kind: createForm.channel_kind,
+      url: createForm.url,
+      event_filter: createForm.event_filter,
+      enabled: createForm.enabled,
+    };
+    if (createForm.secret) body.secret = createForm.secret;
+    const res = await api.post('/admin/notification-webhooks', body);
+    setCreateSubmitting(false);
+    if (!res?.ok) {
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON */ }
+      setCreateError(data?.error || 'Failed to create webhook.');
+      return;
+    }
+    closeCreate();
+    flashSuccess('Notification webhook created.');
+    load();
+  }
+
+  async function togglEnabled(row) {
+    const res = await api.patch(
+      `/admin/notification-webhooks/${row.webhook_id}`,
+      { enabled: !row.enabled },
+    );
+    if (!res?.ok) {
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON */ }
+      setPageError(data?.error || 'Failed to toggle webhook.');
+      return;
+    }
+    load();
+  }
+
+  function openRotate(row) {
+    setRotating(row);
+    setRotateUrl('');
+    setRotateError('');
+  }
+
+  function closeRotate() {
+    setRotating(null);
+    setRotateUrl('');
+    setRotateError('');
+    setRotateSubmitting(false);
+  }
+
+  async function submitRotate() {
+    if (!rotateUrl) {
+      setRotateError('New URL is required.');
+      return;
+    }
+    setRotateSubmitting(true);
+    setRotateError('');
+    const res = await api.post(
+      `/admin/notification-webhooks/${rotating.webhook_id}/rotate-url`,
+      { url: rotateUrl },
+    );
+    setRotateSubmitting(false);
+    if (!res?.ok) {
+      let data = null;
+      try { data = await res?.json(); } catch (_) { /* non-JSON */ }
+      setRotateError(data?.error || 'Failed to rotate URL.');
+      return;
+    }
+    closeRotate();
+    flashSuccess('Webhook URL rotated.');
+    load();
+  }
+
+  async function testSend(row) {
+    setTestInFlight((prev) => ({ ...prev, [row.webhook_id]: true }));
+    setTestOutcomes((prev) => ({ ...prev, [row.webhook_id]: null }));
+    const res = await api.post(
+      `/admin/notification-webhooks/${row.webhook_id}/test-send`,
+      {},
+    );
+    let outcome = null;
+    try { outcome = await res?.json(); } catch (_) { /* non-JSON */ }
+    setTestInFlight((prev) => ({ ...prev, [row.webhook_id]: false }));
+    if (!res?.ok) {
+      setTestOutcomes((prev) => ({
+        ...prev,
+        [row.webhook_id]: {
+          delivered: false,
+          error_kind: 'request_failed',
+          error_detail: outcome?.error || 'request failed',
+        },
+      }));
+      return;
+    }
+    setTestOutcomes((prev) => ({ ...prev, [row.webhook_id]: outcome }));
+  }
+
+  function openDelete(row) {
+    setDeleting(row);
+  }
+
+  function closeDelete() {
+    setDeleting(null);
+    setDeleteSubmitting(false);
+  }
+
+  async function submitDelete() {
+    setDeleteSubmitting(true);
+    const res = await api.delete(
+      `/admin/notification-webhooks/${deleting.webhook_id}`,
+    );
+    setDeleteSubmitting(false);
+    if (!res?.ok) {
+      setPageError('Failed to delete webhook.');
+      closeDelete();
+      return;
+    }
+    closeDelete();
+    flashSuccess('Webhook deleted.');
+    load();
+  }
+
+  const columns = [
+    { key: 'webhook_id', label: 'ID', mono: true },
+    { key: 'channel_kind', label: 'Channel' },
+    { key: 'host_preview', label: 'Host',
+      render: (r) => r.host_preview
+        ? <span className="mono" style={{ fontSize: 12 }}>{r.host_preview}</span>
+        : <span style={{ color: 'var(--text-secondary)', fontSize: 12 }}>(decrypt failed)</span>,
+    },
+    { key: 'event_filter', label: 'Events',
+      render: (r) => (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {(r.event_filter || []).map((e) => (
+            <span key={e} className="mono" style={{ fontSize: 11 }}>{e}</span>
+          ))}
+        </div>
+      ),
+    },
+    { key: 'enabled', label: 'Enabled',
+      render: (r) => (
+        <label style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          <input
+            type="checkbox"
+            checked={r.enabled}
+            onChange={(e) => { e.stopPropagation(); togglEnabled(r); }}
+          />
+          <span style={{ fontSize: 12 }}>{r.enabled ? 'On' : 'Off'}</span>
+        </label>
+      ),
+    },
+    { key: 'created_at', label: 'Created',
+      render: (r) => r.created_at ? new Date(r.created_at).toLocaleString() : '-',
+    },
+    { key: 'actions', label: 'Actions',
+      render: (r) => (
+        <div onClick={(e) => e.stopPropagation()}>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            <button
+              className="btn btn-sm"
+              onClick={() => testSend(r)}
+              disabled={!!testInFlight[r.webhook_id]}
+              title="Send a sample backorder.opened card to verify the channel"
+            >
+              {testInFlight[r.webhook_id] ? 'Sending...' : 'Test'}
+            </button>
+            <button className="btn btn-sm" onClick={() => openRotate(r)}>
+              Rotate URL
+            </button>
+            <button className="btn btn-sm btn-danger" onClick={() => openDelete(r)}>
+              Delete
+            </button>
+          </div>
+          <TestSendOutcome outcome={testOutcomes[r.webhook_id]} />
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <PageHeader title="Notifications">
+        <button
+          className="btn btn-primary"
+          onClick={openCreate}
+          disabled={!warehouseId}
+        >
+          New Webhook
+        </button>
+      </PageHeader>
+      {!warehouseId && (
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+          Pick a warehouse from the top bar to manage its notification webhooks.
+        </p>
+      )}
+      {successBanner && (
+        <div
+          role="status"
+          style={{
+            margin: '0 0 12px 0',
+            padding: '8px 12px',
+            background: 'var(--success-bg, #e8f5e9)',
+            color: 'var(--success, #2e7d32)',
+            border: '1px solid var(--success, #2e7d32)',
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {successBanner}
+        </div>
+      )}
+      {pageError && (
+        <div className="form-error" style={{ marginBottom: 12 }}>{pageError}</div>
+      )}
+      <div className="section">
+        <DataTable
+          columns={columns}
+          data={rows}
+          loading={loading}
+          emptyMessage="No notification webhooks configured for this warehouse."
+        />
+      </div>
+
+      {creating && (
+        <Modal
+          title="New Notification Webhook"
+          onClose={closeCreate}
+          footer={
+            <>
+              <button className="btn" onClick={closeCreate} disabled={createSubmitting}>Cancel</button>
+              <button
+                className="btn btn-primary"
+                onClick={submitCreate}
+                disabled={createSubmitting}
+              >
+                {createSubmitting ? 'Creating...' : 'Create'}
+              </button>
+            </>
+          }
+        >
+          {createError && (
+            <div className="form-error" style={{ marginBottom: 12 }}>{createError}</div>
+          )}
+          <p style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
+            URL is encrypted at rest and never returned by the API. The
+            value you enter here is the only chance to capture it
+            visually -- record it elsewhere if you need a backup.
+            "Rotate URL" later replaces the ciphertext but does not
+            expose the old value.
+          </p>
+          <div className="form-row">
+            <div className="form-group">
+              <label>Channel</label>
+              <select
+                className="form-select"
+                value={createForm.channel_kind}
+                onChange={(e) => setCreateForm({ ...createForm, channel_kind: e.target.value })}
+              >
+                {SUPPORTED_CHANNELS.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </select>
+            </div>
+            <div className="form-group">
+              <label>Enabled</label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 8 }}>
+                <input
+                  type="checkbox"
+                  checked={createForm.enabled}
+                  onChange={(e) => setCreateForm({ ...createForm, enabled: e.target.checked })}
+                />
+                <span style={{ fontSize: 13 }}>Receive events immediately</span>
+              </label>
+            </div>
+          </div>
+          <div className="form-group">
+            <label>URL</label>
+            <input
+              className="form-input"
+              type="url"
+              placeholder="https://outlook.office.com/webhook/..."
+              value={createForm.url}
+              onChange={(e) => setCreateForm({ ...createForm, url: e.target.value })}
+            />
+          </div>
+          <div className="form-group">
+            <label>Events</label>
+            <EventFilterCheckboxes
+              value={createForm.event_filter}
+              onChange={(v) => setCreateForm({ ...createForm, event_filter: v })}
+            />
+          </div>
+          <div className="form-group">
+            <label>HMAC secret (optional)</label>
+            <input
+              className="form-input"
+              type="text"
+              placeholder="Leave blank for Teams incoming webhooks."
+              value={createForm.secret}
+              onChange={(e) => setCreateForm({ ...createForm, secret: e.target.value })}
+            />
+          </div>
+        </Modal>
+      )}
+
+      {rotating && (
+        <Modal
+          title={`Rotate URL for webhook #${rotating.webhook_id}`}
+          onClose={closeRotate}
+          footer={
+            <>
+              <button className="btn" onClick={closeRotate} disabled={rotateSubmitting}>Cancel</button>
+              <button
+                className="btn btn-primary"
+                onClick={submitRotate}
+                disabled={rotateSubmitting}
+              >
+                {rotateSubmitting ? 'Rotating...' : 'Rotate'}
+              </button>
+            </>
+          }
+        >
+          {rotateError && (
+            <div className="form-error" style={{ marginBottom: 12 }}>{rotateError}</div>
+          )}
+          <p style={{ fontSize: 13, marginBottom: 12 }}>
+            Replaces the encrypted URL on this row. The previous value
+            is not recoverable from the UI; if you need it, take it
+            from your Teams admin before rotating.
+          </p>
+          <div className="form-group">
+            <label>New URL</label>
+            <input
+              className="form-input"
+              type="url"
+              value={rotateUrl}
+              onChange={(e) => setRotateUrl(e.target.value)}
+              placeholder="https://outlook.office.com/webhook/..."
+            />
+          </div>
+        </Modal>
+      )}
+
+      {deleting && (
+        <Modal
+          title={`Delete webhook #${deleting.webhook_id}?`}
+          onClose={closeDelete}
+          footer={
+            <>
+              <button className="btn" onClick={closeDelete} disabled={deleteSubmitting}>Cancel</button>
+              <button
+                className="btn btn-danger"
+                onClick={submitDelete}
+                disabled={deleteSubmitting}
+              >
+                {deleteSubmitting ? 'Deleting...' : 'Delete'}
+              </button>
+            </>
+          }
+        >
+          <p style={{ fontSize: 13 }}>
+            Backorder events for this warehouse will no longer reach this
+            destination. The integration_events outbox is unaffected; a
+            future polling worker could still replay if you re-create
+            the row.
+          </p>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -143,6 +143,29 @@ export default function SalesOrders() {
 
   useEffect(() => { loadOrders(); }, [page, statusFilter, search]);  // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ?focus=<so_number> deep-link. /backorders click-through
+  // and the Teams adaptive card both land here with focus set so the
+  // operator goes straight to the edit modal instead of hunting for
+  // the row in the list. Effect runs once per focus param change;
+  // looks up the SO by number via the list endpoint, opens the
+  // modal on the first match.
+  useEffect(() => {
+    const target = searchParams.get('focus');
+    if (!target) return;
+    let cancelled = false;
+    (async () => {
+      const qs = new URLSearchParams({ q: target, per_page: '1' });
+      const res = await api.get(`/admin/sales-orders?${qs.toString()}`);
+      if (!res?.ok || cancelled) return;
+      const data = await res.json();
+      const row = (data.sales_orders || []).find(
+        (r) => String(r.so_number).toLowerCase() === String(target).toLowerCase(),
+      );
+      if (row && !cancelled) openEdit(row);
+    })();
+    return () => { cancelled = true; };
+  }, [searchParams]);  // eslint-disable-line react-hooks/exhaustive-deps
+
   useEffect(() => {
     api.get('/admin/source-systems', { silentPermissionDenied: true }).then(async (res) => {
       if (!res?.ok) return;

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -111,6 +111,16 @@ export default function SalesOrders() {
   // Address fields moved inline into editForm; the separate
   // address modal is retired.
   const [revertConfirm, setRevertConfirm] = useState(null);
+  // Partial-fulfill sub-modal. partialFulfilling holds the SO
+  // being shorted; partialForm carries the per-line short_qty inputs
+  // (keyed by so_line_id) plus a free-text reason. Banner message
+  // appears on the SO list after a successful partial-fulfill so the
+  // operator sees "Backorder SO-12345-BO created" without a toast lib.
+  const [partialFulfilling, setPartialFulfilling] = useState(null);
+  const [partialForm, setPartialForm] = useState({ shorts: {}, reason: '' });
+  const [partialError, setPartialError] = useState('');
+  const [partialSubmitting, setPartialSubmitting] = useState(false);
+  const [successBanner, setSuccessBanner] = useState('');
   // SO line CRUD inside the edit modal (mig 062). State
   // mirrors PurchaseOrders.jsx: editLines is the working copy, optimistic
   // PATCH/POST/DELETE update it without refetching; lineErrors keep
@@ -692,6 +702,68 @@ export default function SalesOrders() {
     }
   }
 
+  // ── Partial-fulfill ──────────────────────────────────────────────────────
+
+  function openPartialFulfill() {
+    // Seed the form with empty short_qty per pickable line so the
+    // operator only needs to fill rows they actually want to short.
+    // Pickable lines = quantity_ordered > quantity_picked (the spec's
+    // PICKED-shorting validation; OPEN lines have quantity_picked=0).
+    const shorts = {};
+    for (const line of editLines || []) {
+      const unshipped = (line.quantity_ordered || 0) - (line.quantity_picked || 0);
+      if (unshipped > 0) shorts[line.so_line_id] = '';
+    }
+    setPartialForm({ shorts, reason: '' });
+    setPartialError('');
+    setPartialFulfilling(editing);
+  }
+
+  function closePartialFulfill() {
+    setPartialFulfilling(null);
+    setPartialForm({ shorts: {}, reason: '' });
+    setPartialError('');
+    setPartialSubmitting(false);
+  }
+
+  async function submitPartialFulfill() {
+    setPartialError('');
+    const lines = [];
+    for (const [solId, raw] of Object.entries(partialForm.shorts)) {
+      const qty = parseInt(raw, 10);
+      if (!raw || isNaN(qty) || qty <= 0) continue;
+      lines.push({ so_line_id: Number(solId), short_qty: qty });
+    }
+    if (lines.length === 0) {
+      setPartialError('Enter a short qty on at least one line.');
+      return;
+    }
+    setPartialSubmitting(true);
+    try {
+      const res = await api.post(
+        `/admin/sales-orders/${partialFulfilling.so_id}/partial-fulfill`,
+        { lines, reason_detail: partialForm.reason || undefined },
+      );
+      if (!res?.ok) {
+        let data = null;
+        try { data = await res?.json(); } catch (_) { /* non-JSON */ }
+        setPartialError(formatApiError(data, 'Failed to partial-fulfill'));
+        return;
+      }
+      const data = await res.json();
+      const boNumber = data.backorder_so?.so_number || '(unknown BO)';
+      closePartialFulfill();
+      closeEdit();
+      setSuccessBanner(`Backorder ${boNumber} created.`);
+      // Auto-clear the banner after a few seconds so it does not
+      // shadow later actions on the list.
+      setTimeout(() => setSuccessBanner(''), 6000);
+      loadOrders();
+    } finally {
+      setPartialSubmitting(false);
+    }
+  }
+
   async function cancelSO() {
     setEditError('');
     const res = await api.post(`/admin/sales-orders/${editing.so_id}/cancel`, {});
@@ -720,6 +792,22 @@ export default function SalesOrders() {
   return (
     <div>
       <PageHeader title="Sales Orders" />
+      {successBanner && (
+        <div
+          role="status"
+          style={{
+            margin: '0 0 12px 0',
+            padding: '8px 12px',
+            background: 'var(--success-bg, #e8f5e9)',
+            color: 'var(--success, #2e7d32)',
+            border: '1px solid var(--success, #2e7d32)',
+            borderRadius: 4,
+            fontSize: 13,
+          }}
+        >
+          {successBanner}
+        </div>
+      )}
 
       <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
         <label style={{ fontSize: 13, color: 'var(--text-secondary)' }}>Status:</label>
@@ -908,6 +996,23 @@ export default function SalesOrders() {
                     onClick={() => openReleaseOnly(editing._pick_tasks || [])}
                     title="Release picked inventory back to source bins without changing status"
                   >Release Picked Quantities</button>
+                )}
+                {/* Partial-fulfill. Status gate {OPEN, PICKED};
+                    PICKED requires admin/so-full-edit so the button
+                    hides for a base sales-orders USER on a PICKED SO
+                    (the backend would 403 anyway). Hidden on
+                    backorders to enforce the one-level chaining cap
+                    (the backend rejects too; UI hides for clarity). */}
+                {['OPEN', 'PICKED'].includes(status)
+                  && !editing.parent_so_id
+                  && editing.order_type !== 'refund'
+                  && (isAdmin || hasSOFullEdit || status === 'OPEN') && (
+                  <button
+                    className="btn btn-warning"
+                    onClick={openPartialFulfill}
+                  >
+                    Partially Fulfill
+                  </button>
                 )}
                 <button className="btn" onClick={closeEdit}>Cancel</button>
                 <button className="btn btn-primary" onClick={saveEdit} disabled={!headerEditable}>Save</button>
@@ -1520,6 +1625,102 @@ export default function SalesOrders() {
           </Modal>
         );
       })()}
+
+      {/* Partial-fulfill sub-modal. Renders on top of the SO edit
+          modal; submit closes both. Per-line short_qty inputs gated
+          by max = quantity_ordered - quantity_picked so the UI mirrors
+          the server validation. */}
+      {partialFulfilling && (
+        <Modal
+          title={`Partially fulfill ${partialFulfilling.so_number}`}
+          onClose={closePartialFulfill}
+          size="wide"
+          footer={
+            <>
+              <button className="btn" onClick={closePartialFulfill} disabled={partialSubmitting}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-warning"
+                onClick={submitPartialFulfill}
+                disabled={partialSubmitting}
+              >
+                {partialSubmitting ? 'Creating BO...' : 'Ship Available + Create Backorder'}
+              </button>
+            </>
+          }
+        >
+          {partialError && (
+            <div className="form-error" style={{ marginBottom: 12 }}>{partialError}</div>
+          )}
+          <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 12 }}>
+            Enter the number of units you cannot ship per line. Shorted
+            quantities move to a new backorder ({partialFulfilling.so_number}-BO,
+            status WAITING_STOCK) and the original SO continues with the
+            remainder. Lines shrunk to zero are removed; rows below
+            already-picked qty are not editable.
+          </p>
+          {(editLines || []).length === 0 ? (
+            <p style={{ fontSize: 13 }}>No lines on this order.</p>
+          ) : (
+            <table className="data-table" style={{ marginBottom: 12 }}>
+              <thead>
+                <tr>
+                  <th>Line</th>
+                  <th>SKU</th>
+                  <th>Item</th>
+                  <th style={{ textAlign: 'right' }}>Ordered</th>
+                  <th style={{ textAlign: 'right' }}>Picked</th>
+                  <th style={{ textAlign: 'right' }}>Unshipped</th>
+                  <th style={{ width: 100 }}>Short</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(editLines || []).map((line) => {
+                  const unshipped = (line.quantity_ordered || 0) - (line.quantity_picked || 0);
+                  const disabled = unshipped <= 0;
+                  return (
+                    <tr key={line.so_line_id}>
+                      <td>{line.line_number}</td>
+                      <td className="mono">{line.sku}</td>
+                      <td>{line.item_name}</td>
+                      <td style={{ textAlign: 'right' }}>{line.quantity_ordered}</td>
+                      <td style={{ textAlign: 'right' }}>{line.quantity_picked}</td>
+                      <td style={{ textAlign: 'right' }}>{unshipped}</td>
+                      <td>
+                        <input
+                          type="number"
+                          className="form-input"
+                          min={0}
+                          max={unshipped}
+                          step={1}
+                          disabled={disabled}
+                          value={partialForm.shorts[line.so_line_id] ?? ''}
+                          onChange={(e) => setPartialForm((prev) => ({
+                            ...prev,
+                            shorts: { ...prev.shorts, [line.so_line_id]: e.target.value },
+                          }))}
+                          placeholder={disabled ? '-' : '0'}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+          <div className="form-group">
+            <label>Reason (free text, audit-logged)</label>
+            <input
+              className="form-input"
+              value={partialForm.reason}
+              onChange={(e) => setPartialForm((prev) => ({ ...prev, reason: e.target.value }))}
+              placeholder="e.g. physical count came up short"
+              maxLength={500}
+            />
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/api/constants.py
+++ b/api/constants.py
@@ -250,6 +250,12 @@ ALL_PAGE_KEYS = (
     "inventory", "cycle-counts", "count-approvals",
     "purchase-orders", "receiving", "putaway",
     "sales-orders",
+    # Partial-fulfill / backorders (Outbound). Holders see the
+    # /backorders dashboard plus the cancel-backorder action. The
+    # partial-fulfill action itself is gated by 'sales-orders' since it
+    # lives on the SO edit modal; this key only gates the dedicated
+    # dashboard.
+    "backorders",
     # Fraud (Outbound): the review queue for SOs held at FRAUD_REVIEW.
     # Holders see the /fraud page and can edit the CSR memo or push an
     # order back into the picking queue.

--- a/api/constants.py
+++ b/api/constants.py
@@ -276,7 +276,11 @@ ALL_PAGE_KEYS = (
     "adjustments", "inter-warehouse-transfers", "transfer-orders",
     "warehouses", "bins", "zones", "preferred-bins",
     "users", "api-tokens", "inbound", "consumer-groups",
-    "webhooks", "audit-log", "imports", "integrations", "settings",
+    # Notifications: per-warehouse Teams notification webhooks for the
+    # backorder.* event family. Holders see the /notifications page and
+    # can CRUD + test-send destinations. Distinct from 'webhooks'
+    # (signed-envelope HTTP subscribers).
+    "webhooks", "notifications", "audit-log", "imports", "integrations", "settings",
 )
 
 # Override grants (mig 062): feature-flag grants that ride on the same

--- a/api/constants.py
+++ b/api/constants.py
@@ -29,6 +29,34 @@ SO_CANCELLED = "CANCELLED"
 # billing/shipping heuristic is enabled, or set manually). Excluded
 # from the picking queue until a CSR clears via the Fraud page.
 SO_FRAUD_REVIEW = "FRAUD_REVIEW"
+
+# mig 067: backorder-only off-ramp. A BO SO created via
+# /partial-fulfill starts here and flips to OPEN when receipt.completed
+# makes all its lines satisfiable. Hidden from picker queues by the
+# existing status != OPEN gate in create_pick_batch / wave_create.
+SO_WAITING_STOCK = "WAITING_STOCK"
+
+# Sales Order order_type (mig 056 + mig 067 CHECK expansion)
+ORDER_TYPE_SALE      = "sale"
+ORDER_TYPE_REFUND    = "refund"
+ORDER_TYPE_BACKORDER = "backorder"
+
+# mig 067: sales_orders.cancellation_reason allowed values.
+# App-enforced enum (no DB CHECK). Set by /cancel-backorder
+# (operator-supplied) or by the parent-cancel cascade in
+# sales_order_service.cancel_sales_order.
+CANCEL_REASON_FOUND            = "found"
+CANCEL_REASON_CUSTOMER_ASKED   = "customer_asked"
+CANCEL_REASON_REFUNDED         = "refunded"
+CANCEL_REASON_PARENT_CANCELLED = "parent_cancelled"
+CANCEL_REASON_OTHER            = "other"
+CANCEL_REASONS = (
+    CANCEL_REASON_FOUND,
+    CANCEL_REASON_CUSTOMER_ASKED,
+    CANCEL_REASON_REFUNDED,
+    CANCEL_REASON_PARENT_CANCELLED,
+    CANCEL_REASON_OTHER,
+)
 # Company-wide timezone for operator-facing calendar dates (e.g. the
 # Shipped Date on the SO modal). Timestamps are stored in UTC; this is
 # the single zone used to convert them to the local calendar date
@@ -65,6 +93,16 @@ ADJ_PENDING = "PENDING"
 ADJ_APPROVED = "APPROVED"
 ADJ_REJECTED = "REJECTED"
 
+# Inventory Adjustment reason codes (mig 067 added SHORT). App-enforced
+# enum (no DB CHECK). SHORT is written by /partial-fulfill when on-hand
+# stock exists for a shorted line; reason_detail carries the BO SO #.
+ADJ_REASON_CYCLE_COUNT = "CYCLE_COUNT"
+ADJ_REASON_DAMAGE      = "DAMAGE"
+ADJ_REASON_FOUND       = "FOUND"
+ADJ_REASON_LOST        = "LOST"
+ADJ_REASON_CORRECTION  = "CORRECTION"
+ADJ_REASON_SHORT       = "SHORT"
+
 # Audit Log action types
 ACTION_RECEIVE = "RECEIVE"
 ACTION_RECEIVE_CANCEL = "RECEIVE_CANCEL"
@@ -84,6 +122,14 @@ ACTION_POS_REFUND = "POS_REFUND"
 # operator. Pre-PICKED states release allocation; PICKED/PACKED states
 # revert inventory to the default receiving bin.
 ACTION_CANCEL = "CANCEL"
+# Partial-fulfill / backorders. Two rows per partial-fulfill
+# call: one on the original SO (shrink summary), one on the new BO SO
+# (creation). BACKORDER_CANCELLED is emitted by /cancel-backorder
+# alongside the existing CANCEL row that cancel_sales_order writes;
+# kept distinct so dashboards can split BO-only cancels from regular
+# CANCEL volume.
+ACTION_PARTIAL_FULFILL     = "PARTIAL_FULFILL"
+ACTION_BACKORDER_CANCELLED = "BACKORDER_CANCELLED"
 ACTION_TRANSFER = "TRANSFER"
 ACTION_ADJUST = "ADJUST"
 ACTION_COUNT = "COUNT"

--- a/api/routes/admin/__init__.py
+++ b/api/routes/admin/__init__.py
@@ -51,6 +51,7 @@ from routes.admin import (  # noqa: E402, F401
     admin_consumer_groups,
     admin_inbound,
     admin_items,
+    admin_notifications,
     admin_orders,
     admin_pick_batches,
     admin_pos,

--- a/api/routes/admin/admin_notifications.py
+++ b/api/routes/admin/admin_notifications.py
@@ -1,0 +1,271 @@
+"""Admin CRUD for notification_webhooks (mig 068).
+
+Per-warehouse Teams notification destinations for the backorder.*
+event family. URLs are Fernet-encrypted at rest; the API never
+returns the plaintext URL, only a masked host preview.
+
+The live event -> Teams fan-out via a polling worker is deferred to
+a follow-up; for now the test-send endpoint is the only direct
+caller of send_to_teams. The events themselves emit
+unconditionally (see partial_fulfill, cancel_backorder, and the
+receipt hook), so the worker has a backlog to drain when it lands.
+"""
+
+import uuid
+from urllib.parse import urlparse
+
+from flask import g, jsonify
+from sqlalchemy import text
+
+from constants import ROLE_ADMIN
+from middleware.auth_middleware import (
+    require_admin_or_page_permission,
+    require_auth,
+)
+from middleware.db import with_db
+from routes.admin import admin_bp
+from schemas.notification_webhooks import (
+    CreateNotificationWebhookRequest,
+    RotateNotificationWebhookUrlRequest,
+    UpdateNotificationWebhookRequest,
+    DEFAULT_EVENT_FILTER,
+)
+from services.credential_vault import decrypt_string, encrypt_string
+from services.webhook_dispatcher.teams_adapter import (
+    SendOutcome,
+    build_adaptive_card,
+    send_to_teams,
+)
+from utils.validation import validate_body
+
+
+def _row_to_summary(row):
+    """Public-safe row shape. Host preview is best-effort: a
+    decrypt failure returns None rather than raising, so an
+    operator can still see the row and delete it if the
+    encryption key has rotated and the row is now stranded."""
+    host_preview = None
+    try:
+        plaintext_url = decrypt_string(row.url)
+        parsed = urlparse(plaintext_url)
+        host_preview = parsed.netloc or parsed.path[:40]
+    except Exception:
+        host_preview = None
+    return {
+        "webhook_id":   row.webhook_id,
+        "warehouse_id": row.warehouse_id,
+        "channel_kind": row.channel_kind,
+        "host_preview": host_preview,
+        "event_filter": list(row.event_filter or []),
+        "enabled":      row.enabled,
+        "has_secret":   bool(row.secret),
+        "external_id":  str(row.external_id),
+        "created_at":   row.created_at.isoformat() if row.created_at else None,
+        "created_by":   row.created_by,
+    }
+
+
+@admin_bp.route("/notification-webhooks", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission("notifications")
+@with_db
+def list_notification_webhooks():
+    from flask import request as flask_request
+    warehouse_id = flask_request.args.get("warehouse_id", type=int)
+    wh_clause = " WHERE warehouse_id = :wid " if warehouse_id else ""
+    wh_params = {"wid": warehouse_id} if warehouse_id else {}
+    rows = g.db.execute(
+        text(
+            "SELECT webhook_id, warehouse_id, channel_kind, url, event_filter, "
+            "       enabled, secret, external_id, created_at, created_by "
+            f"  FROM notification_webhooks {wh_clause}"
+            " ORDER BY webhook_id DESC"
+        ),
+        wh_params,
+    ).fetchall()
+    return jsonify({
+        "notification_webhooks": [_row_to_summary(r) for r in rows],
+    })
+
+
+@admin_bp.route("/notification-webhooks", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("notifications")
+@validate_body(CreateNotificationWebhookRequest)
+@with_db
+def create_notification_webhook(validated):
+    wh_exists = g.db.execute(
+        text("SELECT 1 FROM warehouses WHERE warehouse_id = :wid"),
+        {"wid": validated.warehouse_id},
+    ).scalar()
+    if not wh_exists:
+        return jsonify({"error": f"warehouse_id {validated.warehouse_id} not found"}), 400
+
+    event_filter = validated.event_filter or DEFAULT_EVENT_FILTER
+
+    encrypted_url = encrypt_string(validated.url)
+    row = g.db.execute(
+        text(
+            "INSERT INTO notification_webhooks ("
+            "  warehouse_id, channel_kind, url, event_filter, enabled, "
+            "  secret, created_by, external_id"
+            ") VALUES ("
+            "  :wid, :kind, :url, :filter, :enabled, :secret, :by, :ext_id"
+            ") RETURNING webhook_id, warehouse_id, channel_kind, url, "
+            "          event_filter, enabled, secret, external_id, "
+            "          created_at, created_by"
+        ),
+        {
+            "wid": validated.warehouse_id,
+            "kind": validated.channel_kind,
+            "url": encrypted_url,
+            "filter": event_filter,
+            "enabled": validated.enabled,
+            "secret": validated.secret,
+            "by": g.current_user["username"],
+            "ext_id": str(uuid.uuid4()),
+        },
+    ).fetchone()
+    g.db.commit()
+    return jsonify(_row_to_summary(row)), 201
+
+
+@admin_bp.route("/notification-webhooks/<int:webhook_id>", methods=["PATCH"])
+@require_auth
+@require_admin_or_page_permission("notifications")
+@validate_body(UpdateNotificationWebhookRequest)
+@with_db
+def update_notification_webhook(webhook_id, validated):
+    if not any([
+        validated.enabled is not None,
+        validated.event_filter is not None,
+        validated.secret is not None,
+    ]):
+        return jsonify({"error": "at least one field must be set"}), 400
+
+    sets, params = [], {"wid": webhook_id}
+    if validated.enabled is not None:
+        sets.append("enabled = :enabled")
+        params["enabled"] = validated.enabled
+    if validated.event_filter is not None:
+        sets.append("event_filter = :filter")
+        params["filter"] = validated.event_filter
+    if validated.secret is not None:
+        sets.append("secret = :secret")
+        params["secret"] = validated.secret
+
+    row = g.db.execute(
+        text(
+            f"UPDATE notification_webhooks SET {', '.join(sets)} "
+            " WHERE webhook_id = :wid "
+            " RETURNING webhook_id, warehouse_id, channel_kind, url, "
+            "          event_filter, enabled, secret, external_id, "
+            "          created_at, created_by"
+        ),
+        params,
+    ).fetchone()
+    if not row:
+        g.db.rollback()
+        return jsonify({"error": "notification webhook not found"}), 404
+    g.db.commit()
+    return jsonify(_row_to_summary(row))
+
+
+@admin_bp.route("/notification-webhooks/<int:webhook_id>/rotate-url", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("notifications")
+@validate_body(RotateNotificationWebhookUrlRequest)
+@with_db
+def rotate_notification_webhook_url(webhook_id, validated):
+    encrypted = encrypt_string(validated.url)
+    row = g.db.execute(
+        text(
+            "UPDATE notification_webhooks SET url = :url "
+            " WHERE webhook_id = :wid "
+            " RETURNING webhook_id, warehouse_id, channel_kind, url, "
+            "          event_filter, enabled, secret, external_id, "
+            "          created_at, created_by"
+        ),
+        {"url": encrypted, "wid": webhook_id},
+    ).fetchone()
+    if not row:
+        g.db.rollback()
+        return jsonify({"error": "notification webhook not found"}), 404
+    g.db.commit()
+    return jsonify(_row_to_summary(row))
+
+
+@admin_bp.route("/notification-webhooks/<int:webhook_id>", methods=["DELETE"])
+@require_auth
+@require_admin_or_page_permission("notifications")
+@with_db
+def delete_notification_webhook(webhook_id):
+    deleted = g.db.execute(
+        text(
+            "DELETE FROM notification_webhooks WHERE webhook_id = :wid "
+            " RETURNING webhook_id"
+        ),
+        {"wid": webhook_id},
+    ).fetchone()
+    if not deleted:
+        g.db.rollback()
+        return jsonify({"error": "notification webhook not found"}), 404
+    g.db.commit()
+    return jsonify({"webhook_id": webhook_id, "message": "deleted"})
+
+
+_SAMPLE_OPENED_PAYLOAD = {
+    "backorder_so_external_id": "00000000-0000-0000-0000-000000000000",
+    "backorder_so_number": "SO-TEST-BO",
+    "parent_so_external_id": "00000000-0000-0000-0000-000000000000",
+    "parent_so_number": "SO-TEST",
+    "warehouse_id": 0,
+    "customer_name": "Test Customer",
+    "items": [
+        {"item_external_id": "00000000-0000-0000-0000-000000000000", "sku": "DEMO-SKU", "qty": 1},
+    ],
+    "opened_by_user_external_id": "00000000-0000-0000-0000-000000000000",
+    "opened_at": "2026-01-01T00:00:00Z",
+}
+
+
+@admin_bp.route("/notification-webhooks/<int:webhook_id>/test-send", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("notifications")
+@with_db
+def test_send_notification_webhook(webhook_id):
+    """Fire a sample backorder.opened adaptive card at the configured
+    URL so the operator can verify the Teams channel renders the card
+    they expect. Does NOT touch integration_events; the live event-
+    drain worker is a follow-up."""
+    row = g.db.execute(
+        text(
+            "SELECT webhook_id, channel_kind, url FROM notification_webhooks "
+            " WHERE webhook_id = :wid"
+        ),
+        {"wid": webhook_id},
+    ).fetchone()
+    if not row:
+        return jsonify({"error": "notification webhook not found"}), 404
+
+    if row.channel_kind != "teams":
+        return jsonify({
+            "error": f"test-send only supports channel_kind='teams'; got {row.channel_kind!r}",
+        }), 400
+
+    try:
+        plaintext_url = decrypt_string(row.url)
+    except Exception as exc:
+        return jsonify({
+            "error": "stored URL could not be decrypted (key rotated?). Rotate the URL or delete the row.",
+            "detail": str(exc),
+        }), 500
+
+    card = build_adaptive_card("backorder.opened", _SAMPLE_OPENED_PAYLOAD)
+    outcome: SendOutcome = send_to_teams(plaintext_url, card)
+    return jsonify({
+        "delivered": outcome.delivered,
+        "status_code": outcome.status_code,
+        "error_kind": outcome.error_kind,
+        "error_detail": outcome.error_detail,
+    })

--- a/api/routes/admin/admin_notifications.py
+++ b/api/routes/admin/admin_notifications.py
@@ -222,7 +222,12 @@ _SAMPLE_OPENED_PAYLOAD = {
     "warehouse_id": 0,
     "customer_name": "Test Customer",
     "items": [
-        {"item_external_id": "00000000-0000-0000-0000-000000000000", "sku": "DEMO-SKU", "qty": 1},
+        {
+            "item_external_id": "00000000-0000-0000-0000-000000000000",
+            "sku": "DEMO-SKU",
+            "item_name": "Demo widget",
+            "qty": 1,
+        },
     ],
     "opened_by_user_external_id": "00000000-0000-0000-0000-000000000000",
     "opened_at": "2026-01-01T00:00:00Z",

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -73,6 +73,9 @@ from services.sales_order_service import (
     record_admin_pick,
     revert_sales_order_status as _revert_so_status,
 )
+from services.webhook_dispatcher.backorder_notifier import (
+    dispatch_backorder_notification,
+)
 from utils.validation import validate_body
 
 
@@ -1416,6 +1419,17 @@ def cancel_sales_order(so_id):
             "current_status": exc.current_status,
         }), 400
     g.db.commit()
+
+    # Drain any backorder.cancelled notifications collected by the
+    # service (cascade-cancelled child BOs land here). Fire-and-forget;
+    # the daemon threads exit independently of the request.
+    for event_type, payload, warehouse_id in result.get("deferred_notifications", []):
+        dispatch_backorder_notification(
+            event_type=event_type,
+            payload=payload,
+            warehouse_id=warehouse_id,
+        )
+
     return jsonify({
         "message": "Sales order cancelled",
         "pre_status": result["pre_status"],
@@ -1943,6 +1957,24 @@ def partial_fulfill_sales_order(so_id, validated):
     #    backfill.
     user_external_id = get_user_external_id(g.db, username)
     opened_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    backorder_opened_payload = {
+        "backorder_so_external_id": bo_external_id,
+        "backorder_so_number": bo_so_number,
+        "parent_so_external_id": str(so.external_id),
+        "parent_so_number": so.so_number,
+        "warehouse_id": so.warehouse_id,
+        "customer_name": so.customer_name,
+        "items": [
+            {
+                "item_external_id": s["item_external_id"],
+                "sku": s["sku"],
+                "qty": s["short_qty"],
+            }
+            for s in short_summary
+        ],
+        "opened_by_user_external_id": user_external_id,
+        "opened_at": opened_at,
+    }
     emit_event(
         g.db,
         event_type="backorder.opened",
@@ -1952,27 +1984,19 @@ def partial_fulfill_sales_order(so_id, validated):
         aggregate_external_id=bo_external_id,
         warehouse_id=so.warehouse_id,
         source_txn_id=g.source_txn_id,
-        payload={
-            "backorder_so_external_id": bo_external_id,
-            "backorder_so_number": bo_so_number,
-            "parent_so_external_id": str(so.external_id),
-            "parent_so_number": so.so_number,
-            "warehouse_id": so.warehouse_id,
-            "customer_name": so.customer_name,
-            "items": [
-                {
-                    "item_external_id": s["item_external_id"],
-                    "sku": s["sku"],
-                    "qty": s["short_qty"],
-                }
-                for s in short_summary
-            ],
-            "opened_by_user_external_id": user_external_id,
-            "opened_at": opened_at,
-        },
+        payload=backorder_opened_payload,
     )
 
     g.db.commit()
+
+    # Fire-and-forget Teams notification after the commit lands. The
+    # daemon thread opens its own DB connection, so it does not need
+    # the request transaction to stay alive.
+    dispatch_backorder_notification(
+        event_type="backorder.opened",
+        payload=backorder_opened_payload,
+        warehouse_id=so.warehouse_id,
+    )
 
     return jsonify({
         "original_so": {
@@ -2057,6 +2081,17 @@ def cancel_backorder(bo_so_id, validated):
         }), 400
 
     g.db.commit()
+
+    # Fire-and-forget Teams cards for any backorder.cancelled events
+    # the service emitted (operator-initiated cancels emit exactly
+    # one here; a cascade-initiated cancel emits N).
+    for event_type, payload, warehouse_id in result.get("deferred_notifications", []):
+        dispatch_backorder_notification(
+            event_type=event_type,
+            payload=payload,
+            warehouse_id=warehouse_id,
+        )
+
     return jsonify({
         "message": "Backorder cancelled",
         "bo_so_id": bo_so_id,

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -1771,7 +1771,7 @@ def partial_fulfill_sales_order(so_id, validated):
             text(
                 "SELECT sol.so_line_id, sol.item_id, sol.quantity_ordered, "
                 "       sol.quantity_picked, sol.line_number, "
-                "       i.sku, i.external_id AS item_external_id "
+                "       i.sku, i.item_name, i.external_id AS item_external_id "
                 "  FROM sales_order_lines sol "
                 "  JOIN items i ON i.item_id = sol.item_id "
                 " WHERE sol.so_line_id = :sol_id AND sol.so_id = :sid "
@@ -1829,6 +1829,7 @@ def partial_fulfill_sales_order(so_id, validated):
             "so_line_id": line.so_line_id,
             "item_id": line.item_id,
             "sku": line.sku,
+            "item_name": line.item_name,
             "item_external_id": str(line.item_external_id),
             "line_number": line.line_number,
             "ordered_before": line.quantity_ordered,
@@ -1968,6 +1969,7 @@ def partial_fulfill_sales_order(so_id, validated):
             {
                 "item_external_id": s["item_external_id"],
                 "sku": s["sku"],
+                "item_name": s["item_name"],
                 "qty": s["short_qty"],
             }
             for s in short_summary

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -11,8 +11,10 @@ from sqlalchemy import text
 from constants import (
     PO_OPEN, PO_PARTIAL, PO_RECEIVED, PO_CLOSED, PO_ARCHIVED,
     SO_OPEN, SO_PICKED, SO_PACKED, SO_SHIPPED, SO_CANCELLED,
-    SO_FRAUD_REVIEW,
-    TASK_PENDING, ADJ_PENDING,
+    SO_FRAUD_REVIEW, SO_WAITING_STOCK,
+    TASK_PENDING, ADJ_PENDING, ADJ_APPROVED, ADJ_REASON_SHORT,
+    ORDER_TYPE_BACKORDER,
+    CANCEL_REASONS, CANCEL_REASON_OTHER,
     COMPANY_TIMEZONE,
     ACTION_PICK,
     ACTION_PO_STATUS_CHANGED,
@@ -28,6 +30,8 @@ from constants import (
     ACTION_SO_LINE_REMOVED,
     ACTION_SO_SOURCE_SYSTEM_REASSIGNED,
     ACTION_SO_ALLOCATION_RELEASED,
+    ACTION_PARTIAL_FULFILL,
+    ACTION_BACKORDER_CANCELLED,
     OVERRIDE_SO_FULL_EDIT,
     ROLE_ADMIN,
 )
@@ -48,8 +52,10 @@ from schemas.sales_orders import (
     ADDRESS_FIELD_NAMES,
     AddSalesOrderLineRequest,
     AdminPickRequest,
+    CancelBackorderRequest,
     CreateSalesOrderRequest,
     MarkSalesOrdersPrintedRequest,
+    PartialFulfillRequest,
     RevertSalesOrderStatusRequest,
     UpdateSalesOrderAddressRequest,
     UpdateSalesOrderLineRequest,
@@ -57,6 +63,7 @@ from schemas.sales_orders import (
     UpdateSalesOrderRequest,
 )
 from services.audit_service import write_audit_log
+from services.events_service import emit_event, get_user_external_id
 from services.sales_order_service import (
     AdminPickError,
     CancelNotAllowed,
@@ -1575,6 +1582,476 @@ def admin_pick_sales_order(so_id, validated):
         "promoted_to_picked": bool(promoted),
         **result,
     })
+
+
+# ── Partial Fulfill / Backorders ─────────────────────────────────────────────
+#
+# Partial-fulfill shrinks one or more lines on an existing SO and
+# creates a new backorder SO (status=WAITING_STOCK) carrying the
+# shorted qty. The original SO continues through pack -> ship with
+# what was actually picked; the BO waits for the receiving hook in
+# receiving.py to flip it to OPEN when matching stock arrives.
+#
+# Status gate: {OPEN, PICKED}. OPEN is allowed for any sales-orders
+# user; PICKED requires ADMIN or the so-full-edit override (same
+# escalation as the post-OPEN line edit gate at _so_line_edit_gate).
+# Validation rule `short_qty <= quantity_ordered - quantity_picked`
+# keeps PICKED-shorting safe: it is only valid when the SO has
+# unpicked qty (short-picks happened during the batch). The
+# defective-tote case (PICKED-with-everything-picked) requires the
+# operator to cancel and recreate; out of scope for v1.
+#
+# BO chaining is capped at one level: a SO with parent_so_id IS NOT
+# NULL rejects partial-fulfill (the UI hides the button too, but the
+# server is authoritative).
+
+ADDRESS_COPY_FIELDS = (
+    "billing_address_name", "billing_address_line1", "billing_address_line2",
+    "billing_address_city", "billing_address_state",
+    "billing_address_postal_code", "billing_address_country",
+    "billing_address_phone",
+    "shipping_address_name", "shipping_address_line1", "shipping_address_line2",
+    "shipping_address_city", "shipping_address_state",
+    "shipping_address_postal_code", "shipping_address_country",
+    "shipping_address_phone",
+)
+
+
+def _select_so_for_partial_fulfill(db, so_id):
+    """Returns the SO row with every column the BO clone needs.
+
+    Locked FOR UPDATE so a concurrent /cancel or /update cannot
+    transition past us mid-shrink. Centralised so the partial-fulfill
+    handler does not carry a 30-column SELECT inline."""
+    cols = (
+        "so_id, so_number, external_id, status, warehouse_id, parent_so_id, "
+        "order_type, customer_name, customer_id, customer_phone, "
+        "customer_address, ship_method, ship_address, source_system, memo, "
+        "created_by, "
+        + ", ".join(ADDRESS_COPY_FIELDS)
+    )
+    return db.execute(
+        text(f"SELECT {cols} FROM sales_orders WHERE so_id = :sid FOR UPDATE"),
+        {"sid": so_id},
+    ).fetchone()
+
+
+def _write_short_adjustment(db, *, item_id, warehouse_id, short_qty, reason_detail, bo_so_number, username):
+    """If there is on-hand stock for this item in this warehouse, write
+    a SHORT inventory_adjustments row and decrement on-hand from the bin
+    with the most available units.
+
+    Returns the adjusted qty (0 if no on-hand stock existed). The bin
+    pick is deterministic (most-available, then lowest bin_id) so
+    tests can assert against it."""
+    bin_row = db.execute(
+        text(
+            "SELECT bin_id, quantity_on_hand, quantity_allocated "
+            "  FROM inventory "
+            " WHERE item_id = :iid AND warehouse_id = :wid "
+            "   AND (quantity_on_hand - quantity_allocated) > 0 "
+            " ORDER BY (quantity_on_hand - quantity_allocated) DESC, bin_id ASC "
+            " LIMIT 1"
+        ),
+        {"iid": item_id, "wid": warehouse_id},
+    ).fetchone()
+    if not bin_row:
+        return 0
+    available = bin_row.quantity_on_hand - bin_row.quantity_allocated
+    adj_qty = min(available, short_qty)
+    if adj_qty <= 0:
+        return 0
+    db.execute(
+        text(
+            "UPDATE inventory "
+            "   SET quantity_on_hand = GREATEST(0, quantity_on_hand - :qty), "
+            "       updated_at = NOW() "
+            " WHERE item_id = :iid AND bin_id = :bid"
+        ),
+        {"qty": adj_qty, "iid": item_id, "bid": bin_row.bin_id},
+    )
+    db.execute(
+        text(
+            "INSERT INTO inventory_adjustments ("
+            "  item_id, bin_id, warehouse_id, quantity_change, reason_code, "
+            "  reason_detail, status, adjusted_by, adjusted_at, external_id"
+            ") VALUES ("
+            "  :iid, :bid, :wid, :qty_change, :reason_code, :reason_detail, "
+            "  :status, :user, NOW(), :ext_id"
+            ")"
+        ),
+        {
+            "iid": item_id,
+            "bid": bin_row.bin_id,
+            "wid": warehouse_id,
+            "qty_change": -adj_qty,
+            "reason_code": ADJ_REASON_SHORT,
+            "reason_detail": f"{reason_detail} (BO: {bo_so_number})",
+            "status": ADJ_APPROVED,
+            "user": username,
+            "ext_id": str(uuid.uuid4()),
+        },
+    )
+    return adj_qty
+
+
+@admin_bp.route("/sales-orders/<int:so_id>/partial-fulfill", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@validate_body(PartialFulfillRequest)
+@with_db
+def partial_fulfill_sales_order(so_id, validated):
+    """Ship what's pickable, create a backorder SO for the rest."""
+    so = _select_so_for_partial_fulfill(g.db, so_id)
+    if not so:
+        return jsonify({"error": "Sales order not found"}), 404
+
+    if so.status not in (SO_OPEN, SO_PICKED):
+        return jsonify({
+            "error": f"Can only partial-fulfill OPEN or PICKED orders. Current: {so.status}",
+            "current_status": so.status,
+        }), 400
+
+    # BO chaining cap: a backorder cannot itself spawn a backorder.
+    if so.parent_so_id is not None:
+        return jsonify({
+            "error": "This SO is a backorder; cancel it and create a fresh standalone SO instead of chaining backorders.",
+            "parent_so_id": so.parent_so_id,
+        }), 400
+
+    if so.order_type == "refund":
+        return jsonify({"error": "Cannot partial-fulfill a refund SO."}), 400
+
+    # PICKED requires ADMIN or so-full-edit override (mirrors
+    # _so_line_edit_gate). OPEN is allowed for any sales-orders user.
+    role = g.current_user.get("role")
+    if so.status == SO_PICKED and role != ROLE_ADMIN and not has_override(OVERRIDE_SO_FULL_EDIT):
+        return jsonify({
+            "error": "Partial-fulfill on a PICKED order requires ADMIN or so-full-edit override.",
+            "current_status": so.status,
+        }), 403
+
+    bo_so_number = f"{so.so_number}-BO"
+    reason_detail_base = (validated.reason_detail or "partial-fulfill").strip() or "partial-fulfill"
+    username = g.current_user["username"]
+
+    # 1. Validate every input line up-front (item exists, qty bounds).
+    #    Validating first lets us reject 400 cleanly without partial
+    #    inventory writes lingering in the transaction.
+    line_inputs = []
+    for entry in validated.lines:
+        line = g.db.execute(
+            text(
+                "SELECT sol.so_line_id, sol.item_id, sol.quantity_ordered, "
+                "       sol.quantity_picked, sol.line_number, "
+                "       i.sku, i.external_id AS item_external_id "
+                "  FROM sales_order_lines sol "
+                "  JOIN items i ON i.item_id = sol.item_id "
+                " WHERE sol.so_line_id = :sol_id AND sol.so_id = :sid "
+                " FOR UPDATE OF sol"
+            ),
+            {"sol_id": entry.so_line_id, "sid": so_id},
+        ).fetchone()
+        if not line:
+            return jsonify({
+                "error": f"so_line_id {entry.so_line_id} not on SO {so.so_number}",
+            }), 400
+        unshipped = line.quantity_ordered - line.quantity_picked
+        if entry.short_qty > unshipped:
+            return jsonify({
+                "error": (
+                    f"short_qty {entry.short_qty} on line {line.line_number} "
+                    f"exceeds unshipped qty ({line.quantity_ordered} ordered - "
+                    f"{line.quantity_picked} picked = {unshipped})"
+                ),
+                "so_line_id": entry.so_line_id,
+            }), 400
+        line_inputs.append((entry, line))
+
+    # 2. Apply per-line shrink + adjustment.
+    short_summary = []
+    for entry, line in line_inputs:
+        new_qty = line.quantity_ordered - entry.short_qty
+        if new_qty == 0:
+            # Hard-delete shrunk-to-zero lines. Zero-qty rows break the
+            # dockd payload + picker assumptions.
+            g.db.execute(
+                text("DELETE FROM sales_order_lines WHERE so_line_id = :sol_id"),
+                {"sol_id": line.so_line_id},
+            )
+        else:
+            g.db.execute(
+                text(
+                    "UPDATE sales_order_lines SET quantity_ordered = :qty "
+                    " WHERE so_line_id = :sol_id"
+                ),
+                {"qty": new_qty, "sol_id": line.so_line_id},
+            )
+
+        adj_qty = _write_short_adjustment(
+            g.db,
+            item_id=line.item_id,
+            warehouse_id=so.warehouse_id,
+            short_qty=entry.short_qty,
+            reason_detail=reason_detail_base,
+            bo_so_number=bo_so_number,
+            username=username,
+        )
+
+        short_summary.append({
+            "so_line_id": line.so_line_id,
+            "item_id": line.item_id,
+            "sku": line.sku,
+            "item_external_id": str(line.item_external_id),
+            "line_number": line.line_number,
+            "ordered_before": line.quantity_ordered,
+            "short_qty": entry.short_qty,
+            "ordered_after": new_qty,
+            "line_deleted": new_qty == 0,
+            "adjustment_qty": adj_qty,
+        })
+
+    # 3. Create the BO SO. Address fields + customer + ship_method
+    #    copied from the parent; order_total / customer_shipping_paid
+    #    are NULL on the BO because they were already paid on the
+    #    parent (downstream revenue reports must filter via
+    #    parent_so_id IS NULL or COALESCE).
+    bo_memo = f"[BACKORDER from {so.so_number}]\n" + (so.memo or "")
+    bo_external_id = str(uuid.uuid4())
+    address_cols = ", ".join(ADDRESS_COPY_FIELDS)
+    address_binds = ", ".join(f":{f}" for f in ADDRESS_COPY_FIELDS)
+    address_params = {f: getattr(so, f) for f in ADDRESS_COPY_FIELDS}
+
+    bo_row = g.db.execute(
+        text(f"""
+            INSERT INTO sales_orders (
+                so_number, customer_name, customer_id, customer_phone,
+                customer_address, status, warehouse_id, ship_method,
+                ship_address, {address_cols},
+                memo, order_total, customer_shipping_paid,
+                order_type, parent_so_id, backorder_opened_at,
+                created_by, external_id, source_system
+            ) VALUES (
+                :so_number, :customer_name, :customer_id, :customer_phone,
+                :customer_address, :status, :warehouse_id, :ship_method,
+                :ship_address, {address_binds},
+                :memo, NULL, NULL,
+                :order_type, :parent_so_id, NOW(),
+                :created_by, :external_id, :source_system
+            ) RETURNING so_id
+        """),
+        {
+            "so_number": bo_so_number,
+            "customer_name": so.customer_name,
+            "customer_id": so.customer_id,
+            "customer_phone": so.customer_phone,
+            "customer_address": so.customer_address,
+            "status": SO_WAITING_STOCK,
+            "warehouse_id": so.warehouse_id,
+            "ship_method": so.ship_method,
+            "ship_address": so.ship_address,
+            "memo": bo_memo,
+            "order_type": ORDER_TYPE_BACKORDER,
+            "parent_so_id": so.so_id,
+            "created_by": username,
+            "external_id": bo_external_id,
+            "source_system": so.source_system,
+            **address_params,
+        },
+    ).fetchone()
+    bo_so_id = bo_row.so_id
+
+    # 4. BO lines: one per shorted entry, line_number sequential.
+    for idx, shrink in enumerate(short_summary, 1):
+        g.db.execute(
+            text(
+                "INSERT INTO sales_order_lines "
+                "  (so_id, item_id, quantity_ordered, line_number, status) "
+                "VALUES (:sid, :iid, :qty, :ln, 'PENDING')"
+            ),
+            {
+                "sid": bo_so_id,
+                "iid": shrink["item_id"],
+                "qty": shrink["short_qty"],
+                "ln": idx,
+            },
+        )
+
+    # 5. Audit log. Two rows in the same transaction:
+    #    - Original SO: shrink summary + BO pointer.
+    #    - BO SO: creation hook + parent pointer.
+    write_audit_log(
+        g.db,
+        action_type=ACTION_PARTIAL_FULFILL,
+        entity_type="SO",
+        entity_id=so.so_id,
+        user_id=username,
+        warehouse_id=so.warehouse_id,
+        details={
+            "kind": "shrink",
+            "bo_so_id": bo_so_id,
+            "bo_so_number": bo_so_number,
+            "reason_detail": reason_detail_base,
+            "pre_status": so.status,
+            "lines": [
+                {
+                    k: v for k, v in s.items()
+                    if k in (
+                        "so_line_id", "sku", "line_number", "ordered_before",
+                        "short_qty", "ordered_after", "line_deleted",
+                        "adjustment_qty",
+                    )
+                }
+                for s in short_summary
+            ],
+        },
+    )
+    write_audit_log(
+        g.db,
+        action_type=ACTION_PARTIAL_FULFILL,
+        entity_type="SO",
+        entity_id=bo_so_id,
+        user_id=username,
+        warehouse_id=so.warehouse_id,
+        details={
+            "kind": "created_from_partial_fulfill",
+            "parent_so_id": so.so_id,
+            "parent_so_number": so.so_number,
+            "lines": [
+                {"sku": s["sku"], "qty": s["short_qty"]} for s in short_summary
+            ],
+        },
+    )
+
+    # 6. Emit backorder.opened on the integration_events outbox. No
+    #    consumer wires this yet (the Teams adapter does; marketplace
+    #    adapter is deferred to a follow-up branch), but emitting now
+    #    means "wire later" does not require an event-history
+    #    backfill.
+    user_external_id = get_user_external_id(g.db, username)
+    opened_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    emit_event(
+        g.db,
+        event_type="backorder.opened",
+        event_version=1,
+        aggregate_type="sales_order",
+        aggregate_id=bo_so_id,
+        aggregate_external_id=bo_external_id,
+        warehouse_id=so.warehouse_id,
+        source_txn_id=g.source_txn_id,
+        payload={
+            "backorder_so_external_id": bo_external_id,
+            "backorder_so_number": bo_so_number,
+            "parent_so_external_id": str(so.external_id),
+            "parent_so_number": so.so_number,
+            "warehouse_id": so.warehouse_id,
+            "customer_name": so.customer_name,
+            "items": [
+                {
+                    "item_external_id": s["item_external_id"],
+                    "sku": s["sku"],
+                    "qty": s["short_qty"],
+                }
+                for s in short_summary
+            ],
+            "opened_by_user_external_id": user_external_id,
+            "opened_at": opened_at,
+        },
+    )
+
+    g.db.commit()
+
+    return jsonify({
+        "original_so": {
+            "so_id": so.so_id,
+            "so_number": so.so_number,
+            "status": so.status,
+        },
+        "backorder_so": {
+            "so_id": bo_so_id,
+            "so_number": bo_so_number,
+            "status": SO_WAITING_STOCK,
+            "external_id": bo_external_id,
+        },
+        "shrink_summary": short_summary,
+    })
+
+
+@admin_bp.route("/sales-orders/<int:bo_so_id>/cancel-backorder", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@validate_body(CancelBackorderRequest)
+@with_db
+def cancel_backorder(bo_so_id, validated):
+    """Cancel a backorder SO. Thin wrapper that stamps
+    cancellation_reason then delegates to the shared cancel service.
+
+    The backorder.cancelled event is emitted inside
+    sales_order_service.cancel_sales_order (so the parent-cancel
+    cascade emits too); this endpoint only sets the reason and
+    handles the BO-specific validation."""
+    reason = (validated.cancellation_reason or CANCEL_REASON_OTHER).strip()
+    if reason not in CANCEL_REASONS:
+        return jsonify({
+            "error": (
+                f"Invalid cancellation_reason. Allowed: "
+                f"{', '.join(CANCEL_REASONS)}"
+            ),
+        }), 400
+
+    bo = g.db.execute(
+        text(
+            "SELECT so_id, status, parent_so_id, order_type "
+            "  FROM sales_orders WHERE so_id = :sid"
+        ),
+        {"sid": bo_so_id},
+    ).fetchone()
+    if not bo:
+        return jsonify({"error": "Sales order not found"}), 404
+    if bo.parent_so_id is None or bo.order_type != ORDER_TYPE_BACKORDER:
+        return jsonify({
+            "error": (
+                "Not a backorder SO. Use /cancel for non-backorder orders."
+            ),
+        }), 400
+    if bo.status == SO_CANCELLED:
+        return jsonify({
+            "error": "Backorder already cancelled.",
+            "current_status": bo.status,
+        }), 400
+
+    # Stamp the reason BEFORE cancel_sales_order so the service-side
+    # backorder.cancelled emit sees it on the row.
+    g.db.execute(
+        text(
+            "UPDATE sales_orders SET cancellation_reason = :reason "
+            " WHERE so_id = :sid"
+        ),
+        {"reason": reason, "sid": bo_so_id},
+    )
+
+    try:
+        result = _cancel_so(
+            g.db, so_id=bo_so_id, source="admin",
+            username=g.current_user["username"],
+        )
+    except CancelNotAllowed as exc:
+        if exc.current_status == "UNKNOWN":
+            return jsonify({"error": "Sales order not found"}), 404
+        return jsonify({
+            "error": str(exc),
+            "current_status": exc.current_status,
+        }), 400
+
+    g.db.commit()
+    return jsonify({
+        "message": "Backorder cancelled",
+        "bo_so_id": bo_so_id,
+        "cancellation_reason": reason,
+        "audit_log_id": result["audit_log_id"],
+    })
+
+
 # ── Sales Order Lines (add / update / remove) ────────────────────────────────
 #
 # Mirrors the PO line surface shape but layers an

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -2052,6 +2052,109 @@ def cancel_backorder(bo_so_id, validated):
     })
 
 
+@admin_bp.route("/backorders", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission("backorders")
+@with_db
+def list_backorders():
+    """List backorder SOs grouped by tab.
+
+    Query params:
+      - warehouse_id (optional): scope to one warehouse
+      - tab: 'waiting' (status=WAITING_STOCK) or 'ready-to-ship'
+        (status IN OPEN/PICKED/PACKED AND backorder_opened_at is set)
+        Defaults to 'waiting'.
+
+    Response carries per-BO items[] + days_waiting; the
+    ready-to-ship tab also carries fulfillable_since
+    (backorder_fulfillable_at). Latest open-PO ETA per item is
+    omitted because purchase_order_lines does not carry an
+    expected_arrival_date column yet; revisit once that's wired."""
+    tab = (request.args.get("tab") or "waiting").lower()
+    warehouse_id = request.args.get("warehouse_id", type=int)
+
+    if tab == "waiting":
+        status_clause = "bo.status = :waiting"
+        params = {"waiting": SO_WAITING_STOCK}
+    elif tab in ("ready-to-ship", "ready_to_ship", "ready"):
+        status_clause = (
+            "bo.status IN (:s_open, :s_picked, :s_packed) "
+            "  AND bo.backorder_opened_at IS NOT NULL"
+        )
+        params = {"s_open": SO_OPEN, "s_picked": SO_PICKED, "s_packed": SO_PACKED}
+    else:
+        return jsonify({
+            "error": "tab must be 'waiting' or 'ready-to-ship'",
+            "got": tab,
+        }), 400
+
+    if warehouse_id:
+        status_clause += " AND bo.warehouse_id = :wid"
+        params["wid"] = warehouse_id
+
+    rows = g.db.execute(
+        text(
+            f"""
+            SELECT bo.so_id, bo.so_number, bo.warehouse_id, bo.status,
+                   bo.customer_name, bo.backorder_opened_at,
+                   bo.backorder_fulfillable_at,
+                   parent.so_number AS parent_so_number,
+                   EXTRACT(EPOCH FROM (NOW() - bo.backorder_opened_at))::bigint AS waiting_seconds
+              FROM sales_orders bo
+              LEFT JOIN sales_orders parent ON parent.so_id = bo.parent_so_id
+             WHERE {status_clause}
+               AND bo.order_type = :backorder
+             ORDER BY bo.backorder_opened_at ASC
+            """
+        ),
+        {**params, "backorder": ORDER_TYPE_BACKORDER},
+    ).fetchall()
+
+    so_ids = [r.so_id for r in rows]
+    items_by_so = {}
+    if so_ids:
+        line_rows = g.db.execute(
+            text(
+                "SELECT sol.so_id, i.sku, sol.quantity_ordered "
+                "  FROM sales_order_lines sol "
+                "  JOIN items i ON i.item_id = sol.item_id "
+                " WHERE sol.so_id = ANY(:so_ids) "
+                " ORDER BY sol.line_number"
+            ),
+            {"so_ids": so_ids},
+        ).fetchall()
+        for lr in line_rows:
+            items_by_so.setdefault(lr.so_id, []).append({
+                "sku": lr.sku,
+                "qty": lr.quantity_ordered,
+            })
+
+    return jsonify({
+        "tab": tab,
+        "backorders": [
+            {
+                "so_id":           r.so_id,
+                "so_number":       r.so_number,
+                "parent_so_number": r.parent_so_number,
+                "warehouse_id":    r.warehouse_id,
+                "status":          r.status,
+                "customer_name":   r.customer_name,
+                "items":           items_by_so.get(r.so_id, []),
+                "days_waiting":    (int(r.waiting_seconds) // 86400) if r.waiting_seconds else 0,
+                "backorder_opened_at": (
+                    r.backorder_opened_at.isoformat()
+                    if r.backorder_opened_at else None
+                ),
+                "fulfillable_since": (
+                    r.backorder_fulfillable_at.isoformat()
+                    if r.backorder_fulfillable_at else None
+                ),
+            }
+            for r in rows
+        ],
+    })
+
+
 # ── Sales Order Lines (add / update / remove) ────────────────────────────────
 #
 # Mirrors the PO line surface shape but layers an

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -750,6 +750,9 @@ def get_sales_order(so_id):
                    source_system,
                    order_origin,
                    carrier, tracking_number,
+                   order_type, parent_so_id,
+                   backorder_opened_at, backorder_fulfillable_at,
+                   cancellation_reason,
                    billing_address_name, billing_address_line1, billing_address_line2,
                    billing_address_city, billing_address_state,
                    billing_address_postal_code, billing_address_country,
@@ -840,6 +843,16 @@ def get_sales_order(so_id):
             # current tracking number and the view modal can display it.
             "carrier": so.carrier,
             "tracking_number": so.tracking_number,
+            # Backorder lifecycle (mig 067). The admin Edit modal uses
+            # order_type + parent_so_id to gate the "Partially Fulfill"
+            # button (rejects backorders to enforce the one-level
+            # chaining cap). backorder_*_at + cancellation_reason are
+            # read-only context for the Backorders page detail view.
+            "order_type":                so.order_type,
+            "parent_so_id":              so.parent_so_id,
+            "backorder_opened_at":       so.backorder_opened_at.isoformat() if so.backorder_opened_at else None,
+            "backorder_fulfillable_at":  so.backorder_fulfillable_at.isoformat() if so.backorder_fulfillable_at else None,
+            "cancellation_reason":       so.cancellation_reason,
             # v1.8.0 (#288): structured billing/shipping address fields.
             **{name: getattr(so, name) for name in ADDRESS_FIELD_NAMES},
         },

--- a/api/routes/receiving.py
+++ b/api/routes/receiving.py
@@ -21,17 +21,23 @@ from schemas.receiving import CancelReceivingRequest, ReceiveItemsRequest
 from services.audit_service import write_audit_log
 from services.events_service import emit_event, get_user_external_id
 from services.inventory_service import add_inventory
+from services.webhook_dispatcher.backorder_notifier import (
+    dispatch_backorder_notification,
+)
 from utils.validation import validate_body
 
 receiving_bp = Blueprint("receiving", __name__)
 
 
-def _check_waiting_backorders_for_item(db, *, warehouse_id, item_id, source_txn_id):
+def _check_waiting_backorders_for_item(db, *, warehouse_id, item_id, source_txn_id, deferred_notifications):
     """After a receipt lands inventory for (warehouse_id, item_id),
     look at WAITING_STOCK backorders in that warehouse that carry a line
     on this item. For each, check whether ALL its lines are now satisfiable
     against current pickable on-hand. Flip the satisfiable ones to OPEN,
-    stamp backorder_fulfillable_at, and emit backorder.fulfillable.
+    stamp backorder_fulfillable_at, and emit backorder.fulfillable. The
+    helper appends one (event_type, payload, warehouse_id) tuple per
+    flipped BO to ``deferred_notifications``; the caller drains the
+    list AFTER its commit to fire the corresponding Teams cards.
 
     Partial-satisfaction stays in WAITING_STOCK with no event (matches the
     spec's "notify only when fully available" decision so a Teams ping
@@ -134,6 +140,23 @@ def _check_waiting_backorders_for_item(db, *, warehouse_id, item_id, source_txn_
         fulfillable_at = (
             datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         )
+        fulfillable_payload = {
+            "backorder_so_external_id": str(bo.external_id),
+            "backorder_so_number": bo.so_number,
+            "parent_so_number": parent_so_number,
+            "warehouse_id": warehouse_id,
+            "customer_name": bo.customer_name,
+            "items": [
+                {
+                    "item_external_id": str(line.item_external_id),
+                    "sku": line.sku,
+                    "qty": line.quantity_ordered,
+                }
+                for line in bo_lines
+            ],
+            "days_waiting": days_waiting,
+            "fulfillable_at": fulfillable_at,
+        }
         emit_event(
             db,
             event_type="backorder.fulfillable",
@@ -143,23 +166,10 @@ def _check_waiting_backorders_for_item(db, *, warehouse_id, item_id, source_txn_
             aggregate_external_id=bo.external_id,
             warehouse_id=warehouse_id,
             source_txn_id=source_txn_id,
-            payload={
-                "backorder_so_external_id": str(bo.external_id),
-                "backorder_so_number": bo.so_number,
-                "parent_so_number": parent_so_number,
-                "warehouse_id": warehouse_id,
-                "customer_name": bo.customer_name,
-                "items": [
-                    {
-                        "item_external_id": str(line.item_external_id),
-                        "sku": line.sku,
-                        "qty": line.quantity_ordered,
-                    }
-                    for line in bo_lines
-                ],
-                "days_waiting": days_waiting,
-                "fulfillable_at": fulfillable_at,
-            },
+            payload=fulfillable_payload,
+        )
+        deferred_notifications.append(
+            ("backorder.fulfillable", fulfillable_payload, warehouse_id)
         )
 
 
@@ -276,6 +286,9 @@ def receive_items(validated):
     username = g.current_user["username"]
     receipt_ids = []
     warnings = []
+    # Collected by _check_waiting_backorders_for_item per flipped BO,
+    # drained after g.db.commit() to fire Teams cards.
+    _deferred_notifications: list = []
 
     for item_entry in items:
         item_id = item_entry.item_id
@@ -445,11 +458,15 @@ def receive_items(validated):
         # Flip any WAITING_STOCK backorders in this warehouse
         # that this receipt makes fully satisfiable. Same transaction;
         # the partial index from mig 067 covers the candidate lookup.
+        # Notifications are collected here and fired AFTER the commit
+        # below so a fire-and-forget Teams send does not block the
+        # receipt's HTTP response.
         _check_waiting_backorders_for_item(
             g.db,
             warehouse_id=warehouse_id,
             item_id=item_id,
             source_txn_id=g.source_txn_id,
+            deferred_notifications=_deferred_notifications,
         )
 
     # Update PO status based on all lines
@@ -472,6 +489,16 @@ def receive_items(validated):
         po_status = PO_PARTIAL
 
     g.db.commit()
+
+    # Drain backorder.fulfillable notifications collected by
+    # _check_waiting_backorders_for_item. Fire-and-forget Teams cards
+    # spawned in daemon threads.
+    for event_type, payload, wid in _deferred_notifications:
+        dispatch_backorder_notification(
+            event_type=event_type,
+            payload=payload,
+            warehouse_id=wid,
+        )
 
     return jsonify({
         "message": "Receipt submitted successfully",

--- a/api/routes/receiving.py
+++ b/api/routes/receiving.py
@@ -70,7 +70,7 @@ def _check_waiting_backorders_for_item(db, *, warehouse_id, item_id, source_txn_
             text(
                 """
                 SELECT sol.so_line_id, sol.item_id, sol.quantity_ordered,
-                       i.sku, i.external_id AS item_external_id
+                       i.sku, i.item_name, i.external_id AS item_external_id
                   FROM sales_order_lines sol
                   JOIN items i ON i.item_id = sol.item_id
                  WHERE sol.so_id = :bid
@@ -150,6 +150,7 @@ def _check_waiting_backorders_for_item(db, *, warehouse_id, item_id, source_txn_
                 {
                     "item_external_id": str(line.item_external_id),
                     "sku": line.sku,
+                    "item_name": line.item_name,
                     "qty": line.quantity_ordered,
                 }
                 for line in bo_lines

--- a/api/routes/receiving.py
+++ b/api/routes/receiving.py
@@ -12,6 +12,8 @@ from constants import (
     PO_OPEN, PO_PARTIAL, PO_RECEIVED, PO_CLOSED,
     POL_PENDING, POL_PARTIAL, POL_RECEIVED,
     ACTION_RECEIVE, ACTION_RECEIVE_CANCEL,
+    SO_OPEN, SO_WAITING_STOCK,
+    BIN_PICKABLE, BIN_PICKABLE_STAGING,
 )
 from middleware.auth_middleware import require_auth, warehouse_scope_clause
 from middleware.db import with_db
@@ -22,6 +24,143 @@ from services.inventory_service import add_inventory
 from utils.validation import validate_body
 
 receiving_bp = Blueprint("receiving", __name__)
+
+
+def _check_waiting_backorders_for_item(db, *, warehouse_id, item_id, source_txn_id):
+    """After a receipt lands inventory for (warehouse_id, item_id),
+    look at WAITING_STOCK backorders in that warehouse that carry a line
+    on this item. For each, check whether ALL its lines are now satisfiable
+    against current pickable on-hand. Flip the satisfiable ones to OPEN,
+    stamp backorder_fulfillable_at, and emit backorder.fulfillable.
+
+    Partial-satisfaction stays in WAITING_STOCK with no event (matches the
+    spec's "notify only when fully available" decision so a Teams ping
+    doesn't fire until the warehouse can actually pull the BO).
+
+    Inventory is NOT consumed here; the BO becomes pickable for the
+    next batch builder.
+    """
+    candidates = db.execute(
+        text(
+            """
+            SELECT bo.so_id, bo.so_number, bo.external_id, bo.warehouse_id,
+                   bo.backorder_opened_at, bo.parent_so_id, bo.customer_name
+              FROM sales_orders bo
+             WHERE bo.status = :waiting
+               AND bo.warehouse_id = :wid
+               AND EXISTS (
+                 SELECT 1 FROM sales_order_lines bol
+                  WHERE bol.so_id = bo.so_id
+                    AND bol.item_id = :iid
+               )
+             ORDER BY bo.backorder_opened_at ASC
+            """
+        ),
+        {"waiting": SO_WAITING_STOCK, "wid": warehouse_id, "iid": item_id},
+    ).fetchall()
+
+    for bo in candidates:
+        bo_lines = db.execute(
+            text(
+                """
+                SELECT sol.so_line_id, sol.item_id, sol.quantity_ordered,
+                       i.sku, i.external_id AS item_external_id
+                  FROM sales_order_lines sol
+                  JOIN items i ON i.item_id = sol.item_id
+                 WHERE sol.so_id = :bid
+                """
+            ),
+            {"bid": bo.so_id},
+        ).fetchall()
+        if not bo_lines:
+            continue
+
+        all_satisfiable = True
+        for line in bo_lines:
+            available = db.execute(
+                text(
+                    """
+                    SELECT COALESCE(
+                             SUM(GREATEST(inv.quantity_on_hand - inv.quantity_allocated, 0)),
+                             0
+                           )
+                      FROM inventory inv
+                      JOIN bins b ON b.bin_id = inv.bin_id
+                     WHERE inv.item_id = :iid
+                       AND inv.warehouse_id = :wid
+                       AND b.bin_type IN (:bp, :bps)
+                    """
+                ),
+                {
+                    "iid": line.item_id,
+                    "wid": warehouse_id,
+                    "bp": BIN_PICKABLE,
+                    "bps": BIN_PICKABLE_STAGING,
+                },
+            ).scalar() or 0
+            if available < line.quantity_ordered:
+                all_satisfiable = False
+                break
+        if not all_satisfiable:
+            continue
+
+        db.execute(
+            text(
+                "UPDATE sales_orders "
+                "   SET status = :open, backorder_fulfillable_at = NOW() "
+                " WHERE so_id = :bid"
+            ),
+            {"open": SO_OPEN, "bid": bo.so_id},
+        )
+
+        days_waiting = 0
+        if bo.backorder_opened_at:
+            row = db.execute(
+                text(
+                    "SELECT EXTRACT(EPOCH FROM (NOW() - :opened))::bigint AS s"
+                ),
+                {"opened": bo.backorder_opened_at},
+            ).fetchone()
+            if row and row.s:
+                days_waiting = int(row.s) // 86400
+
+        parent_so_number = ""
+        if bo.parent_so_id is not None:
+            parent_so_number = db.execute(
+                text("SELECT so_number FROM sales_orders WHERE so_id = :sid"),
+                {"sid": bo.parent_so_id},
+            ).scalar() or ""
+
+        fulfillable_at = (
+            datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        )
+        emit_event(
+            db,
+            event_type="backorder.fulfillable",
+            event_version=1,
+            aggregate_type="sales_order",
+            aggregate_id=bo.so_id,
+            aggregate_external_id=bo.external_id,
+            warehouse_id=warehouse_id,
+            source_txn_id=source_txn_id,
+            payload={
+                "backorder_so_external_id": str(bo.external_id),
+                "backorder_so_number": bo.so_number,
+                "parent_so_number": parent_so_number,
+                "warehouse_id": warehouse_id,
+                "customer_name": bo.customer_name,
+                "items": [
+                    {
+                        "item_external_id": str(line.item_external_id),
+                        "sku": line.sku,
+                        "qty": line.quantity_ordered,
+                    }
+                    for line in bo_lines
+                ],
+                "days_waiting": days_waiting,
+                "fulfillable_at": fulfillable_at,
+            },
+        )
 
 
 @receiving_bp.route("/po/<barcode>")
@@ -301,6 +440,16 @@ def receive_items(validated):
                 "completed_by_user_external_id": get_user_external_id(g.db, username),
                 "completed_at": receipt_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
             },
+        )
+
+        # Flip any WAITING_STOCK backorders in this warehouse
+        # that this receipt makes fully satisfiable. Same transaction;
+        # the partial index from mig 067 covers the candidate lookup.
+        _check_waiting_backorders_for_item(
+            g.db,
+            warehouse_id=warehouse_id,
+            item_id=item_id,
+            source_txn_id=g.source_txn_id,
         )
 
     # Update PO status based on all lines

--- a/api/schemas/notification_webhooks.py
+++ b/api/schemas/notification_webhooks.py
@@ -1,0 +1,80 @@
+"""Request schemas for /api/admin/notification-webhooks.
+
+The table backs per-warehouse Teams (initially) notification
+destinations for the backorder.* event family. URLs are
+Fernet-encrypted at rest via SENTRY_ENCRYPTION_KEY; the API never
+echoes the plaintext URL back, only a masked host preview.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+SUPPORTED_CHANNELS = ("teams",)
+
+DEFAULT_EVENT_FILTER = ["backorder.opened", "backorder.fulfillable"]
+
+# Mirrors the registered backorder.* set in
+# api/services/events_schema_registry.py. Kept inline so a typo in the
+# admin UI is rejected at the Pydantic layer rather than at emit time.
+ALLOWED_EVENT_TYPES = (
+    "backorder.opened",
+    "backorder.fulfillable",
+    "backorder.cancelled",
+)
+
+
+class CreateNotificationWebhookRequest(BaseModel):
+    warehouse_id: int = Field(..., gt=0)
+    channel_kind: str = Field(..., min_length=1, max_length=20)
+    url:          str = Field(..., min_length=1, max_length=2048)
+    event_filter: Optional[List[str]] = Field(default=None)
+    enabled:      bool = Field(default=True)
+    secret:       Optional[str] = Field(default=None, max_length=128)
+
+    @field_validator("channel_kind")
+    @classmethod
+    def _kind_must_be_supported(cls, v: str) -> str:
+        if v not in SUPPORTED_CHANNELS:
+            raise ValueError(
+                f"channel_kind must be one of {SUPPORTED_CHANNELS}; got {v!r}"
+            )
+        return v
+
+    @field_validator("event_filter")
+    @classmethod
+    def _filter_values_must_be_known(cls, v):
+        if v is None:
+            return v
+        for entry in v:
+            if entry not in ALLOWED_EVENT_TYPES:
+                raise ValueError(
+                    f"event_filter value {entry!r} is not one of {ALLOWED_EVENT_TYPES}"
+                )
+        return v
+
+
+class UpdateNotificationWebhookRequest(BaseModel):
+    """Patches the enabled flag, event filter, or secret. The URL is
+    write-only after create; use /rotate-url for that path so a
+    rotation looks distinct in the audit trail."""
+    enabled:      Optional[bool] = None
+    event_filter: Optional[List[str]] = None
+    secret:       Optional[str] = Field(default=None, max_length=128)
+
+    @field_validator("event_filter")
+    @classmethod
+    def _filter_values_must_be_known(cls, v):
+        if v is None:
+            return v
+        for entry in v:
+            if entry not in ALLOWED_EVENT_TYPES:
+                raise ValueError(
+                    f"event_filter value {entry!r} is not one of {ALLOWED_EVENT_TYPES}"
+                )
+        return v
+
+
+class RotateNotificationWebhookUrlRequest(BaseModel):
+    url: str = Field(..., min_length=1, max_length=2048)

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -174,6 +174,46 @@ class UpdateSalesOrderAddressRequest(BaseModel):
         return self
 
 
+class PartialFulfillLineEntry(BaseModel):
+    """Partial-fulfill: per-line short input.
+
+    short_qty is the number of units the operator is declaring as
+    unshippable for this line; it shifts onto the new BO SO. The
+    handler enforces ``short_qty <= quantity_ordered - quantity_picked``
+    at request time (server-side; the UI's max= attribute is hinting,
+    not authoritative)."""
+
+    so_line_id: int = Field(..., gt=0)
+    short_qty:  int = Field(..., gt=0, le=1000000)
+
+
+class PartialFulfillRequest(BaseModel):
+    """Partial-fulfill: POST body for
+    /admin/sales-orders/<so_id>/partial-fulfill.
+
+    lines carries one entry per shorted line; lines that are NOT
+    shorted are simply omitted (no zero-qty entries needed). At
+    least one entry is required.
+
+    reason_detail is free-text operator-supplied context that lands
+    in the audit row and in the inventory_adjustments.reason_detail
+    column on any SHORT adjustments written. Optional; the handler
+    falls back to a generated stub when omitted."""
+
+    lines: List[PartialFulfillLineEntry] = Field(..., min_length=1, max_length=200)
+    reason_detail: Optional[str] = Field(None, max_length=500)
+
+
+class CancelBackorderRequest(BaseModel):
+    """Partial-fulfill: POST body for
+    /admin/sales-orders/<bo_so_id>/cancel-backorder.
+
+    cancellation_reason is an app-enforced enum; valid values live
+    in constants.CANCEL_REASONS. Defaults to 'other' if omitted."""
+
+    cancellation_reason: Optional[str] = Field("other", max_length=50)
+
+
 class MarkSalesOrdersPrintedRequest(BaseModel):
     """mig 064: POST body to stamp printed_at on a batch of SOs. Sent by
     the picking-ticket print page after the client-side render confirms

--- a/api/schemas_v1/events/backorder.cancelled/1.json
+++ b/api/schemas_v1/events/backorder.cancelled/1.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sentry-wms.example/events/backorder.cancelled/1.json",
+  "title": "backorder.cancelled v1",
+  "description": "A backorder SO has been cancelled. Emitted by api/routes/admin/admin_orders.py::cancel_backorder (operator path) and by services/sales_order_service.cancel_sales_order when the parent-cancel cascade walks a child BO. Aggregate: sales_order (the BO so_id).",
+  "type": "object",
+  "required": [
+    "backorder_so_external_id",
+    "backorder_so_number",
+    "parent_so_number",
+    "warehouse_id",
+    "cancellation_reason",
+    "cancelled_by_user_external_id",
+    "cancelled_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "backorder_so_external_id":   { "type": "string", "format": "uuid" },
+    "backorder_so_number":        { "type": "string" },
+    "parent_so_number":           { "type": "string" },
+    "warehouse_id":               { "type": "integer", "minimum": 1 },
+    "cancellation_reason": {
+      "type": "string",
+      "enum": ["found", "customer_asked", "refunded", "parent_cancelled", "other"]
+    },
+    "cancelled_by_user_external_id": { "type": "string", "format": "uuid" },
+    "cancelled_at":               { "type": "string", "format": "date-time" }
+  }
+}

--- a/api/schemas_v1/events/backorder.fulfillable/1.json
+++ b/api/schemas_v1/events/backorder.fulfillable/1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sentry-wms.example/events/backorder.fulfillable/1.json",
+  "title": "backorder.fulfillable v1",
+  "description": "All lines on a WAITING_STOCK backorder are now satisfiable; Sentry flipped it to OPEN. Emitted by api/routes/receiving.py inside the receipt.completed transaction. Aggregate: sales_order (the BO so_id).",
+  "type": "object",
+  "required": [
+    "backorder_so_external_id",
+    "backorder_so_number",
+    "parent_so_number",
+    "warehouse_id",
+    "items",
+    "days_waiting",
+    "fulfillable_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "backorder_so_external_id":   { "type": "string", "format": "uuid" },
+    "backorder_so_number":        { "type": "string" },
+    "parent_so_number":           { "type": "string" },
+    "warehouse_id":               { "type": "integer", "minimum": 1 },
+    "customer_name":              { "type": ["string", "null"] },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["item_external_id", "sku", "qty"],
+        "additionalProperties": false,
+        "properties": {
+          "item_external_id":     { "type": "string", "format": "uuid" },
+          "sku":                  { "type": "string" },
+          "qty":                  { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "days_waiting":               { "type": "integer", "minimum": 0 },
+    "fulfillable_at":             { "type": "string", "format": "date-time" }
+  }
+}

--- a/api/schemas_v1/events/backorder.fulfillable/1.json
+++ b/api/schemas_v1/events/backorder.fulfillable/1.json
@@ -30,6 +30,7 @@
         "properties": {
           "item_external_id":     { "type": "string", "format": "uuid" },
           "sku":                  { "type": "string" },
+          "item_name":            { "type": ["string", "null"] },
           "qty":                  { "type": "integer", "minimum": 1 }
         }
       }

--- a/api/schemas_v1/events/backorder.opened/1.json
+++ b/api/schemas_v1/events/backorder.opened/1.json
@@ -32,6 +32,7 @@
         "properties": {
           "item_external_id":     { "type": "string", "format": "uuid" },
           "sku":                  { "type": "string" },
+          "item_name":            { "type": ["string", "null"] },
           "qty":                  { "type": "integer", "minimum": 1 }
         }
       }

--- a/api/schemas_v1/events/backorder.opened/1.json
+++ b/api/schemas_v1/events/backorder.opened/1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sentry-wms.example/events/backorder.opened/1.json",
+  "title": "backorder.opened v1",
+  "description": "A backorder SO has been created via /partial-fulfill. Emitted by api/routes/admin/admin_orders.py::partial_fulfill_sales_order. Aggregate: sales_order (the BO so_id).",
+  "type": "object",
+  "required": [
+    "backorder_so_external_id",
+    "backorder_so_number",
+    "parent_so_external_id",
+    "parent_so_number",
+    "warehouse_id",
+    "items",
+    "opened_by_user_external_id",
+    "opened_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "backorder_so_external_id":   { "type": "string", "format": "uuid" },
+    "backorder_so_number":        { "type": "string" },
+    "parent_so_external_id":      { "type": "string", "format": "uuid" },
+    "parent_so_number":           { "type": "string" },
+    "warehouse_id":               { "type": "integer", "minimum": 1 },
+    "customer_name":              { "type": ["string", "null"] },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["item_external_id", "sku", "qty"],
+        "additionalProperties": false,
+        "properties": {
+          "item_external_id":     { "type": "string", "format": "uuid" },
+          "sku":                  { "type": "string" },
+          "qty":                  { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "opened_by_user_external_id": { "type": "string", "format": "uuid" },
+    "opened_at":                  { "type": "string", "format": "date-time" }
+  }
+}

--- a/api/services/credential_vault.py
+++ b/api/services/credential_vault.py
@@ -57,6 +57,26 @@ def _decrypt(ciphertext: str) -> str:
     return _get_fernet().decrypt(ciphertext.encode()).decode()
 
 
+def encrypt_string(plaintext: str) -> str:
+    """Public wrapper around the Fernet encrypt used for the
+    notification_webhooks.url column. Reuses SENTRY_ENCRYPTION_KEY so
+    a single key rotation re-encrypts both connector secrets and
+    notification URLs in lock-step. Inputs of non-string or empty
+    string are treated as caller bugs and raise."""
+    if not isinstance(plaintext, str) or not plaintext:
+        raise ValueError("encrypt_string requires a non-empty string")
+    return _encrypt(plaintext)
+
+
+def decrypt_string(ciphertext: str) -> str:
+    """Public wrapper around the Fernet decrypt. Mirrors
+    encrypt_string. Use for the notification_webhooks.url column when
+    the dispatcher needs the plaintext URL to send a card."""
+    if not isinstance(ciphertext, str) or not ciphertext:
+        raise ValueError("decrypt_string requires a non-empty string")
+    return _decrypt(ciphertext)
+
+
 def store_credential(connector_name: str, warehouse_id: int, key: str, plaintext_value: str) -> None:
     """Encrypt and store a credential. Upserts on conflict.
 

--- a/api/services/events_schema_registry.py
+++ b/api/services/events_schema_registry.py
@@ -39,6 +39,16 @@ V150_CATALOG: Tuple[Tuple[str, int, str], ...] = (
     # v1.9.0 dockd: emitted when a previously-shipped sales order is
     # voided through the /api/v1/dockd/orders/{so}/void-ship route.
     ("ship.voided",          1, "sales_order"),
+    # Partial-fulfill / backorders. opened: a BO SO has been
+    # created via /partial-fulfill (status WAITING_STOCK). fulfillable:
+    # the receipt hook found that all of a waiting BO's lines are
+    # satisfiable and flipped it to OPEN. cancelled: the BO has been
+    # cancelled, either operator-initiated via /cancel-backorder or
+    # cascaded from the parent SO's cancel. All three carry the
+    # sales_order aggregate (the BO so_id).
+    ("backorder.opened",      1, "sales_order"),
+    ("backorder.fulfillable", 1, "sales_order"),
+    ("backorder.cancelled",   1, "sales_order"),
 )
 
 # Resolved once at module import from api/schemas_v1/events. The

--- a/api/services/sales_order_service.py
+++ b/api/services/sales_order_service.py
@@ -128,7 +128,12 @@ def cancel_sales_order(
         username: actor for audit_log.user_id.
 
     Returns dict with pre_status, so_number, audit_log_id (None on the
-    idempotent already-cancelled path).
+    idempotent already-cancelled path), and deferred_notifications: a
+    list of (event_type, payload, warehouse_id) tuples the caller must
+    fire AFTER its own commit (each entry typically maps to a
+    fire-and-forget Teams card). The list aggregates across the
+    cascade so a single top-level cancel returns every BO-side
+    notification the recursive walk produced.
 
     Raises:
         CancelNotAllowed when the SO is SHIPPED or not found.
@@ -164,6 +169,7 @@ def cancel_sales_order(
             "pre_status": SO_CANCELLED,
             "so_number": so.so_number,
             "audit_log_id": None,
+            "deferred_notifications": [],
         }
 
     pre_status = so.status
@@ -201,12 +207,15 @@ def cancel_sales_order(
         },
     )
 
-    # If this SO is a backorder, emit backorder.cancelled on
-    # the integration_events outbox. Both the operator path
-    # (/cancel-backorder) and the parent-cancel cascade reach this
+    # If this SO is a backorder, emit backorder.cancelled on the
+    # integration_events outbox and collect the payload so the caller
+    # can fire-and-forget a Teams card after commit. Both the operator
+    # path (/cancel-backorder) and the parent-cancel cascade reach this
     # branch, so the consumer always sees the event regardless of
-    # initiator. Emit is skipped outside a Flask request context
-    # (unit tests that call cancel_sales_order directly).
+    # initiator. Emit is skipped outside a Flask request context (unit
+    # tests that call cancel_sales_order directly); the
+    # deferred-notifications list then stays empty for those callers.
+    deferred_notifications = []
     if so.order_type == ORDER_TYPE_BACKORDER and has_request_context():
         parent_so_number = db.execute(
             text("SELECT so_number FROM sales_orders WHERE so_id = :sid"),
@@ -227,6 +236,15 @@ def cancel_sales_order(
 
         cancelled_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         user_external_id = get_user_external_id(db, username)
+        cancelled_payload = {
+            "backorder_so_external_id": str(so.external_id),
+            "backorder_so_number": so.so_number,
+            "parent_so_number": parent_so_number or "",
+            "warehouse_id": warehouse_id,
+            "cancellation_reason": reason,
+            "cancelled_by_user_external_id": user_external_id,
+            "cancelled_at": cancelled_at,
+        }
         emit_event(
             db,
             event_type="backorder.cancelled",
@@ -236,15 +254,10 @@ def cancel_sales_order(
             aggregate_external_id=so.external_id,
             warehouse_id=warehouse_id,
             source_txn_id=g.source_txn_id,
-            payload={
-                "backorder_so_external_id": str(so.external_id),
-                "backorder_so_number": so.so_number,
-                "parent_so_number": parent_so_number or "",
-                "warehouse_id": warehouse_id,
-                "cancellation_reason": reason,
-                "cancelled_by_user_external_id": user_external_id,
-                "cancelled_at": cancelled_at,
-            },
+            payload=cancelled_payload,
+        )
+        deferred_notifications.append(
+            ("backorder.cancelled", cancelled_payload, warehouse_id)
         )
 
     # Parent-cancel cascade. Walk any non-terminal child
@@ -278,14 +291,18 @@ def cancel_sales_order(
                 ),
                 {"reason": CANCEL_REASON_PARENT_CANCELLED, "cid": child.so_id},
             )
-            cancel_sales_order(
+            child_result = cancel_sales_order(
                 db, so_id=child.so_id, source=source, username=username,
+            )
+            deferred_notifications.extend(
+                child_result.get("deferred_notifications", [])
             )
 
     return {
         "pre_status": pre_status,
         "so_number": so.so_number,
         "audit_log_id": audit_log_id,
+        "deferred_notifications": deferred_notifications,
     }
 
 

--- a/api/services/sales_order_service.py
+++ b/api/services/sales_order_service.py
@@ -2,16 +2,33 @@
 
 v1.9.0 introduces one shared cancel handler. Two callers converge here:
 
-- Admin operator path: POST /api/admin/sales-orders/<id>/cancel.
+- Admin operator path: POST /api/admin/sales-orders/<id>/cancel
+  (and /cancel-backorder, which delegates here after stamping
+  cancellation_reason).
 - Inbound path: an ERP-pushed update on an existing SO whose
   canonical status field has flipped to CANCELLED.
 
 The cancel transition is the only state-changing SO operation that
 historically did NOT write audit_log; routing both paths through this
 service closes that hole and gives the inventory unwind one source of
-truth. Cancellation does not emit an outbox event (Sentry follows the
-ERP for cancel; downstream consumers learn through their own ERP
-integration).
+truth.
+
+Backorders add two things on top:
+
+- Parent-cancel cascade: after the per-status unwind, any non-terminal
+  child backorder (order_type='backorder') is recursively cancelled
+  with cancellation_reason='parent_cancelled'. Keeps Sentry from
+  stranding a BO when the parent is cancelled.
+- backorder.cancelled emit: when the SO being cancelled is itself a
+  BO (order_type='backorder'), emit on the integration_events outbox
+  so the Teams adapter / future marketplace adapter see the event.
+  The operator-initiated path and the cascade both emit; no consumer
+  needs to know which.
+
+The emit relies on the Flask request context for source_txn_id /
+user_external_id, mirroring complete_batch's pattern. Outside a
+request (unit tests that call cancel_sales_order directly) the emit
+is skipped.
 """
 
 from datetime import datetime, timezone
@@ -28,6 +45,8 @@ from constants import (
     ACTION_SO_UNPACKED,
     ACTION_SO_UNSHIPPED,
     BATCH_COMPLETED,
+    CANCEL_REASON_PARENT_CANCELLED,
+    ORDER_TYPE_BACKORDER,
     SO_CANCELLED,
     SO_OPEN,
     SO_PACKED,
@@ -121,7 +140,8 @@ def cancel_sales_order(
 
     so = db.execute(
         text(
-            "SELECT so_id, so_number, status, warehouse_id "
+            "SELECT so_id, so_number, external_id, status, warehouse_id, "
+            "       parent_so_id, order_type, cancellation_reason "
             "  FROM sales_orders "
             " WHERE so_id = :sid "
             " FOR UPDATE"
@@ -157,6 +177,8 @@ def cancel_sales_order(
         _unwind_allocated(db, so_id)
     elif pre_status in (SO_PICKED, SO_PACKED):
         _unwind_picked_or_packed(db, so_id, warehouse_id)
+    # WAITING_STOCK (mig 067) is BO-only and inventory-free; no
+    # per-status unwind beyond the status flip below.
 
     db.execute(
         text(
@@ -178,6 +200,87 @@ def cancel_sales_order(
             "source": source,
         },
     )
+
+    # If this SO is a backorder, emit backorder.cancelled on
+    # the integration_events outbox. Both the operator path
+    # (/cancel-backorder) and the parent-cancel cascade reach this
+    # branch, so the consumer always sees the event regardless of
+    # initiator. Emit is skipped outside a Flask request context
+    # (unit tests that call cancel_sales_order directly).
+    if so.order_type == ORDER_TYPE_BACKORDER and has_request_context():
+        parent_so_number = db.execute(
+            text("SELECT so_number FROM sales_orders WHERE so_id = :sid"),
+            {"sid": so.parent_so_id},
+        ).scalar() if so.parent_so_id is not None else None
+
+        # cancellation_reason may have been stamped by the caller
+        # (/cancel-backorder) or by the cascade below. Re-read so the
+        # emit reflects the latest value.
+        reason_row = db.execute(
+            text(
+                "SELECT cancellation_reason FROM sales_orders "
+                " WHERE so_id = :sid"
+            ),
+            {"sid": so_id},
+        ).fetchone()
+        reason = (reason_row.cancellation_reason if reason_row else None) or "other"
+
+        cancelled_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        user_external_id = get_user_external_id(db, username)
+        emit_event(
+            db,
+            event_type="backorder.cancelled",
+            event_version=1,
+            aggregate_type="sales_order",
+            aggregate_id=so_id,
+            aggregate_external_id=so.external_id,
+            warehouse_id=warehouse_id,
+            source_txn_id=g.source_txn_id,
+            payload={
+                "backorder_so_external_id": str(so.external_id),
+                "backorder_so_number": so.so_number,
+                "parent_so_number": parent_so_number or "",
+                "warehouse_id": warehouse_id,
+                "cancellation_reason": reason,
+                "cancelled_by_user_external_id": user_external_id,
+                "cancelled_at": cancelled_at,
+            },
+        )
+
+    # Parent-cancel cascade. Walk any non-terminal child
+    # backorder, stamp 'parent_cancelled' as its reason, and
+    # recursively cancel. The recursive call re-enters this function
+    # on the child's so_id (a different row, so FOR UPDATE does not
+    # deadlock); the child path's own emit handles backorder.cancelled.
+    # cancel_sales_order is idempotent on already-CANCELLED so a child
+    # that is already CANCELLED is a no-op.
+    if so.order_type != ORDER_TYPE_BACKORDER:
+        children = db.execute(
+            text(
+                "SELECT so_id FROM sales_orders "
+                " WHERE parent_so_id = :sid "
+                "   AND order_type = :backorder "
+                "   AND status NOT IN (:cancelled, :shipped)"
+            ),
+            {
+                "sid": so_id,
+                "backorder": ORDER_TYPE_BACKORDER,
+                "cancelled": SO_CANCELLED,
+                "shipped": SO_SHIPPED,
+            },
+        ).fetchall()
+        for child in children:
+            db.execute(
+                text(
+                    "UPDATE sales_orders "
+                    "   SET cancellation_reason = :reason "
+                    " WHERE so_id = :cid"
+                ),
+                {"reason": CANCEL_REASON_PARENT_CANCELLED, "cid": child.so_id},
+            )
+            cancel_sales_order(
+                db, so_id=child.so_id, source=source, username=username,
+            )
 
     return {
         "pre_status": pre_status,

--- a/api/services/webhook_dispatcher/backorder_notifier.py
+++ b/api/services/webhook_dispatcher/backorder_notifier.py
@@ -1,0 +1,225 @@
+"""Fire-and-forget Teams notification dispatcher for backorder.* events.
+
+Each backorder.* emit site (partial_fulfill, cancel_backorder, the
+parent-cancel cascade, and the receipt-hook matcher) calls
+:func:`dispatch_backorder_notification` AFTER its DB transaction
+commits. The helper spawns a daemon thread that:
+
+1. Opens its own psycopg2 connection (the request's connection is
+   closed once the response is sent).
+2. Loads matching :code:`notification_webhooks` rows for the
+   warehouse + event_type filter, gated on :code:`enabled = TRUE`.
+3. For each match, decrypts the URL, builds the adaptive card via
+   :mod:`teams_adapter`, and POSTs.
+4. Logs the outcome and exits.
+
+Why a thread, not a polling worker:
+
+- Teams responses can take seconds. Doing the send synchronously in
+  the request path would couple operator HTTP latency to Teams
+  uptime; the request path already carries enough downstream
+  integration latency.
+- A separate polling worker would need a cursor table, retry
+  state, and cooperation with the existing dispatcher's process
+  manager. That is the right shape for a future delivery-tracking
+  iteration; for now fire-and-forget is the proportionate response
+  to "send a chat ping when stock arrives."
+- Silent drops on transient Teams failures are acceptable because
+  the /backorders dashboard is the operational source of truth.
+  The :code:`integration_events` row persists regardless, so a
+  follow-up worker (or an operator running a replay script) can
+  back-fill from the outbox without losing context.
+
+Caller contract: must be called AFTER the parent DB transaction
+commits. Calling before commit means the thread may run before the
+row is visible to its own connection. None of the current call
+sites violate this; tests assert the ordering.
+"""
+
+import logging
+import os
+import threading
+from typing import Any, Dict, Optional
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+from services.credential_vault import decrypt_string
+from services.webhook_dispatcher.teams_adapter import (
+    build_adaptive_card,
+    send_to_teams,
+)
+
+
+LOGGER = logging.getLogger("webhook_dispatcher.backorder_notifier")
+
+
+_SENTRY_BASE_URL_ENV = "SENTRY_ADMIN_BASE_URL"
+
+
+def _resolve_base_url() -> str:
+    """Optional. The MessageCard "Open in Sentry" link falls back to
+    a relative URL when this is unset; relative still resolves
+    inside Teams desktop / web clients."""
+    return os.environ.get(_SENTRY_BASE_URL_ENV, "")
+
+
+def dispatch_backorder_notification(
+    *,
+    event_type: str,
+    payload: Dict[str, Any],
+    warehouse_id: int,
+    database_url: Optional[str] = None,
+) -> threading.Thread:
+    """Spawn a daemon thread that fans the event to every matching
+    notification_webhook for the warehouse.
+
+    Returns the started thread. Tests wait on it via ``thread.join()``;
+    production callers ignore the return value.
+
+    ``database_url`` defaults to :code:`os.environ['DATABASE_URL']`;
+    tests can pass a specific value (e.g. the
+    :code:`TEST_DATABASE_URL`) to keep the worker on the test DB."""
+    if database_url is None:
+        database_url = os.environ.get("DATABASE_URL", "")
+
+    thread = threading.Thread(
+        target=_dispatch,
+        kwargs={
+            "event_type":   event_type,
+            "payload":      payload,
+            "warehouse_id": warehouse_id,
+            "database_url": database_url,
+            "sentry_base_url": _resolve_base_url(),
+        },
+        daemon=True,
+        name=f"backorder-notifier-{event_type}-{warehouse_id}",
+    )
+    thread.start()
+    return thread
+
+
+def _dispatch(
+    *,
+    event_type: str,
+    payload: Dict[str, Any],
+    warehouse_id: int,
+    database_url: str,
+    sentry_base_url: str,
+) -> None:
+    """Thread body. Wrapped in a broad try/except so a thread-side
+    surprise (DB unreachable, malformed row, etc.) is logged and
+    contained instead of bubbling into a noisy unhandled-exception
+    log."""
+    try:
+        if not database_url:
+            LOGGER.warning(
+                "backorder_notifier: skipping dispatch for event_type=%s "
+                "warehouse_id=%d -- DATABASE_URL unset",
+                event_type, warehouse_id,
+            )
+            return
+
+        webhooks = _load_matching_webhooks(
+            database_url=database_url,
+            event_type=event_type,
+            warehouse_id=warehouse_id,
+        )
+        if not webhooks:
+            LOGGER.info(
+                "backorder_notifier: no enabled webhooks for "
+                "event_type=%s warehouse_id=%d",
+                event_type, warehouse_id,
+            )
+            return
+
+        card = build_adaptive_card(
+            event_type, payload, sentry_base_url=sentry_base_url
+        )
+        for webhook in webhooks:
+            # Per-webhook isolation: a raise inside _send_one (e.g. a
+            # mocked send_to_teams in a test, or an unexpected DB
+            # access path) must NOT stop the loop. Otherwise one bad
+            # row poisons every later webhook in the fan-out.
+            try:
+                _send_one(webhook, event_type, card)
+            except Exception as exc:  # noqa: BLE001 -- per-webhook isolation
+                LOGGER.exception(
+                    "backorder_notifier: webhook_id=%s send raised: %s",
+                    webhook.get("webhook_id"), exc,
+                )
+    except Exception as exc:  # noqa: BLE001 -- isolate thread
+        LOGGER.exception(
+            "backorder_notifier: unhandled error dispatching event_type=%s "
+            "warehouse_id=%d: %s",
+            event_type, warehouse_id, exc,
+        )
+
+
+def _load_matching_webhooks(
+    *,
+    database_url: str,
+    event_type: str,
+    warehouse_id: int,
+) -> list:
+    """Return enabled notification_webhooks rows for the warehouse
+    whose event_filter includes :code:`event_type`. Opens and closes
+    its own connection per call; intentional because the helper is
+    called once per emit and threading-per-call is fine for the
+    expected emit volume (handfuls per day, not bursts per
+    second)."""
+    conn = psycopg2.connect(database_url)
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT webhook_id, warehouse_id, channel_kind, url,
+                       event_filter, enabled, secret, external_id
+                  FROM notification_webhooks
+                 WHERE warehouse_id = %s
+                   AND enabled = TRUE
+                   AND %s = ANY(event_filter)
+                """,
+                (warehouse_id, event_type),
+            )
+            return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def _send_one(webhook: Dict[str, Any], event_type: str, card: Dict[str, Any]) -> None:
+    """Decrypt URL, send card, log outcome. Each webhook is wrapped
+    in its own try/except so one bad row does not poison the rest
+    of the fan-out."""
+    webhook_id = webhook.get("webhook_id")
+    channel_kind = webhook.get("channel_kind")
+    if channel_kind != "teams":
+        LOGGER.warning(
+            "backorder_notifier: skipping webhook_id=%s -- "
+            "channel_kind=%r is not supported",
+            webhook_id, channel_kind,
+        )
+        return
+    try:
+        plaintext_url = decrypt_string(webhook["url"])
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.error(
+            "backorder_notifier: webhook_id=%s URL decrypt failed: %s "
+            "(stranded by an encryption-key rotation?)",
+            webhook_id, exc,
+        )
+        return
+    outcome = send_to_teams(plaintext_url, card)
+    if outcome.delivered:
+        LOGGER.info(
+            "backorder_notifier: webhook_id=%s event_type=%s delivered "
+            "(status=%s)",
+            webhook_id, event_type, outcome.status_code,
+        )
+    else:
+        LOGGER.warning(
+            "backorder_notifier: webhook_id=%s event_type=%s failed "
+            "(kind=%s status=%s detail=%s)",
+            webhook_id, event_type, outcome.error_kind,
+            outcome.status_code, outcome.error_detail,
+        )

--- a/api/services/webhook_dispatcher/teams_adapter.py
+++ b/api/services/webhook_dispatcher/teams_adapter.py
@@ -1,0 +1,229 @@
+"""Teams adapter for the backorder.* event family.
+
+The adapter has two pure functions and one IO function:
+
+- :func:`build_adaptive_card(event_type, payload)` returns a Microsoft
+  Teams MessageCard dict ready to POST to a Teams incoming-webhook
+  URL. Pure, no IO, no DB; trivial to unit-test.
+- :func:`send_to_teams(url, card)` POSTs the card. Wraps the URL in
+  the dispatcher's existing SSRF guard so a misconfigured webhook
+  cannot point at AWS IMDS or other internal addresses. Returns
+  :class:`SendOutcome`.
+- The polling worker that drains :code:`integration_events` and
+  fans out to :code:`notification_webhooks` is deferred to a
+  follow-up; for now the test-send endpoint
+  (:code:`POST /admin/notification-webhooks/<id>/test-send`) is the
+  only live caller of :func:`send_to_teams`. The events themselves
+  emit unconditionally, so the worker has a backlog to drain when
+  it lands.
+
+MessageCard format intentionally over Adaptive Cards: incoming-webhook
+URLs in Teams accept the legacy MessageCard JSON directly. Adaptive
+Cards 1.5+ require a Power Automate flow as middleware, which would
+add a per-tenant moving part we do not need for a warehouse
+notification surface.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+from .ssrf_guard import SsrfRejected, assert_url_safe
+
+
+_SENTRY_ADMIN_BASE_DEFAULT = "/sales-orders"
+_THEME_OPENED      = "FF8C00"   # warm orange: attention needed
+_THEME_FULFILLABLE = "2E7D32"   # green: ready to ship
+_THEME_CANCELLED   = "9E9E9E"   # gray: terminal / informational
+
+_REQUEST_TIMEOUT_SECONDS = 10
+
+
+@dataclass
+class SendOutcome:
+    """Result of a single :func:`send_to_teams` call.
+
+    ``status_code`` is the HTTP status from the Teams endpoint, or
+    None if the SSRF guard or a network error fired before any
+    response was received. ``error_kind`` is a short string for
+    logging / dashboards; mirrors the dispatcher's existing error
+    taxonomy."""
+    delivered: bool
+    status_code: Optional[int] = None
+    error_kind: Optional[str] = None
+    error_detail: Optional[str] = None
+
+
+def _sentry_link(base_url: str, so_number: str) -> str:
+    """Compose the deep-link the card's action button hands to the
+    operator. ``base_url`` is the absolute base
+    (e.g. ``https://sentry.example.com``); on a stack that runs the
+    admin behind a relative path, callers can pass an empty string
+    and the focus query-param alone will resolve against the page
+    that opens the link."""
+    suffix = f"?focus={so_number}"
+    if not base_url:
+        return f"{_SENTRY_ADMIN_BASE_DEFAULT}{suffix}"
+    return f"{base_url.rstrip('/')}{_SENTRY_ADMIN_BASE_DEFAULT}{suffix}"
+
+
+def _items_summary(items: list) -> str:
+    """Render the items list for the card body. Keeps the line short
+    enough to render cleanly in the Teams desktop client (one line
+    per item, up to 5; trailing "+N more" if longer)."""
+    if not items:
+        return "(no items)"
+    head = items[:5]
+    rendered = [f"- {it['sku']} × {it['qty']}" for it in head]
+    if len(items) > 5:
+        rendered.append(f"- (+{len(items) - 5} more)")
+    return "\n".join(rendered)
+
+
+def build_adaptive_card(event_type: str, payload: Dict[str, Any], *, sentry_base_url: str = "") -> Dict[str, Any]:
+    """Return the Teams MessageCard dict for one of the backorder.*
+    events. Raises :class:`ValueError` for an unknown event_type so a
+    caller bug fails loud rather than sending an empty card."""
+    if event_type == "backorder.opened":
+        return _build_opened_card(payload, sentry_base_url)
+    if event_type == "backorder.fulfillable":
+        return _build_fulfillable_card(payload, sentry_base_url)
+    if event_type == "backorder.cancelled":
+        return _build_cancelled_card(payload, sentry_base_url)
+    raise ValueError(f"teams_adapter: unsupported event_type {event_type!r}")
+
+
+def _base_card(*, theme: str, summary: str, title: str, text_body: str) -> Dict[str, Any]:
+    return {
+        "@type":       "MessageCard",
+        "@context":    "https://schema.org/extensions",
+        "themeColor":  theme,
+        "summary":     summary,
+        "title":       title,
+        "text":        text_body,
+    }
+
+
+def _open_action(label: str, uri: str) -> Dict[str, Any]:
+    return {
+        "@type":   "OpenUri",
+        "name":    label,
+        "targets": [{"os": "default", "uri": uri}],
+    }
+
+
+def _build_opened_card(payload: Dict[str, Any], base_url: str) -> Dict[str, Any]:
+    bo_number     = payload.get("backorder_so_number", "")
+    parent_number = payload.get("parent_so_number", "")
+    customer      = payload.get("customer_name") or "(unknown customer)"
+    items         = payload.get("items", [])
+    link          = _sentry_link(base_url, bo_number)
+
+    title = f"Item shorted on {parent_number}"
+    body = (
+        f"**Customer:** {customer}\n\n"
+        f"**Backorder:** {bo_number}\n\n"
+        f"**Items shorted:**\n{_items_summary(items)}"
+    )
+    card = _base_card(
+        theme=_THEME_OPENED,
+        summary=f"Backorder opened: {bo_number}",
+        title=title,
+        text_body=body,
+    )
+    card["potentialAction"] = [_open_action("Open in Sentry", link)]
+    return card
+
+
+def _build_fulfillable_card(payload: Dict[str, Any], base_url: str) -> Dict[str, Any]:
+    bo_number     = payload.get("backorder_so_number", "")
+    parent_number = payload.get("parent_so_number", "")
+    customer      = payload.get("customer_name") or "(unknown customer)"
+    items         = payload.get("items", [])
+    days          = payload.get("days_waiting", 0)
+    link          = _sentry_link(base_url, bo_number)
+
+    title = f"Backorder ready to ship: {bo_number}"
+    body = (
+        f"**Customer:** {customer}\n\n"
+        f"**Original SO:** {parent_number}\n\n"
+        f"**Days waiting:** {days}\n\n"
+        f"**Items:**\n{_items_summary(items)}"
+    )
+    card = _base_card(
+        theme=_THEME_FULFILLABLE,
+        summary=f"Backorder fulfillable: {bo_number}",
+        title=title,
+        text_body=body,
+    )
+    card["potentialAction"] = [_open_action("Open in Sentry", link)]
+    return card
+
+
+def _build_cancelled_card(payload: Dict[str, Any], base_url: str) -> Dict[str, Any]:
+    bo_number     = payload.get("backorder_so_number", "")
+    parent_number = payload.get("parent_so_number", "")
+    reason        = payload.get("cancellation_reason", "other")
+    link          = _sentry_link(base_url, bo_number)
+
+    title = f"Backorder cancelled: {bo_number}"
+    body = (
+        f"**Original SO:** {parent_number}\n\n"
+        f"**Reason:** {reason}"
+    )
+    card = _base_card(
+        theme=_THEME_CANCELLED,
+        summary=f"Backorder cancelled: {bo_number}",
+        title=title,
+        text_body=body,
+    )
+    card["potentialAction"] = [_open_action("Open in Sentry", link)]
+    return card
+
+
+def send_to_teams(url: str, card: Dict[str, Any]) -> SendOutcome:
+    """POST the card to the Teams webhook URL. SSRF-guarded; a URL
+    that resolves to a private range is rejected without an HTTP
+    call. Network and Teams-side errors are captured and returned as
+    :class:`SendOutcome` rather than raised so a caller can log a
+    structured failure without try/except wrapping."""
+    try:
+        assert_url_safe(url)
+    except SsrfRejected as exc:
+        return SendOutcome(
+            delivered=False,
+            error_kind="ssrf_rejected",
+            error_detail=str(exc),
+        )
+
+    try:
+        resp = requests.post(
+            url,
+            json=card,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+            headers={"Content-Type": "application/json"},
+        )
+    except requests.exceptions.Timeout as exc:
+        return SendOutcome(
+            delivered=False,
+            error_kind="timeout",
+            error_detail=str(exc),
+        )
+    except requests.exceptions.RequestException as exc:
+        return SendOutcome(
+            delivered=False,
+            error_kind="network_error",
+            error_detail=str(exc),
+        )
+
+    # Teams accepts the card and returns 200 with body "1". Any 2xx
+    # is treated as delivered; non-2xx is a failure.
+    if 200 <= resp.status_code < 300:
+        return SendOutcome(delivered=True, status_code=resp.status_code)
+    return SendOutcome(
+        delivered=False,
+        status_code=resp.status_code,
+        error_kind="teams_rejected",
+        error_detail=(resp.text or "")[:500],
+    )

--- a/api/services/webhook_dispatcher/teams_adapter.py
+++ b/api/services/webhook_dispatcher/teams_adapter.py
@@ -71,11 +71,21 @@ def _sentry_link(base_url: str, so_number: str) -> str:
 def _items_summary(items: list) -> str:
     """Render the items list for the card body. Keeps the line short
     enough to render cleanly in the Teams desktop client (one line
-    per item, up to 5; trailing "+N more" if longer)."""
+    per item, up to 5; trailing "+N more" if longer). Includes
+    item_name when present so the warehouse can identify the SKU
+    without cross-referencing the admin UI; falls back to SKU-only
+    when the name is missing (the schema makes item_name nullable
+    for older payloads on the integration_events backfill path)."""
     if not items:
         return "(no items)"
     head = items[:5]
-    rendered = [f"- {it['sku']} × {it['qty']}" for it in head]
+    rendered = []
+    for it in head:
+        name = it.get("item_name")
+        if name:
+            rendered.append(f"- {it['sku']} {name} × {it['qty']}")
+        else:
+            rendered.append(f"- {it['sku']} × {it['qty']}")
     if len(items) > 5:
         rendered.append(f"- (+{len(items) - 5} more)")
     return "\n".join(rendered)

--- a/api/tests/test_admin_backorders_list.py
+++ b/api/tests/test_admin_backorders_list.py
@@ -1,0 +1,115 @@
+"""GET /api/admin/backorders.
+
+Tabs: 'waiting' (status=WAITING_STOCK) and 'ready-to-ship'
+(status IN OPEN/PICKED/PACKED AND backorder_opened_at IS NOT NULL).
+Returns per-BO items[] + days_waiting; ready-to-ship adds
+fulfillable_since.
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_val(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row[0] if row else None
+
+
+def _create_bo_via_partial_fulfill(client, auth_headers, so_id=1, short_qty=1):
+    sol_id = _query_val(
+        "SELECT so_line_id FROM sales_order_lines WHERE so_id = %s LIMIT 1",
+        (so_id,),
+    )
+    resp = client.post(
+        f"/api/admin/sales-orders/{so_id}/partial-fulfill",
+        json={"lines": [{"so_line_id": sol_id, "short_qty": short_qty}]},
+        headers=auth_headers,
+    )
+    return resp.get_json()["backorder_so"]["so_id"]
+
+
+class TestListBackorders:
+    def test_waiting_tab_lists_waiting_bo(self, client, auth_headers):
+        bo_so_id = _create_bo_via_partial_fulfill(client, auth_headers)
+
+        resp = client.get("/api/admin/backorders?tab=waiting", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["tab"] == "waiting"
+
+        bo_ids = [b["so_id"] for b in data["backorders"]]
+        assert bo_so_id in bo_ids
+
+        # Card payload shape.
+        target = next(b for b in data["backorders"] if b["so_id"] == bo_so_id)
+        assert target["status"] == "WAITING_STOCK"
+        assert target["parent_so_number"] == "SO-2026-001"
+        assert target["so_number"] == "SO-2026-001-BO"
+        assert target["customer_name"] == "Test Customer 1"
+        assert len(target["items"]) == 1
+        assert target["items"][0]["sku"] == "TST-001"
+        assert target["items"][0]["qty"] == 1
+        assert target["days_waiting"] == 0  # just created
+        assert target["fulfillable_since"] is None
+
+    def test_default_tab_is_waiting(self, client, auth_headers):
+        _create_bo_via_partial_fulfill(client, auth_headers)
+        resp = client.get("/api/admin/backorders", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.get_json()["tab"] == "waiting"
+
+    def test_invalid_tab_rejected(self, client, auth_headers):
+        resp = client.get("/api/admin/backorders?tab=bogus", headers=auth_headers)
+        assert resp.status_code == 400
+
+    def test_ready_to_ship_tab_shows_flipped_bo(self, client, auth_headers):
+        # Force the BO to OPEN with a fulfillable_at stamp (simulating
+        # the receipt-hook flip without running a full receipt cycle).
+        bo_so_id = _create_bo_via_partial_fulfill(client, auth_headers)
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_orders SET status = 'OPEN', "
+            "                        backorder_fulfillable_at = NOW() "
+            " WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        cur.close()
+
+        # Waiting tab should NOT include it.
+        waiting = client.get(
+            "/api/admin/backorders?tab=waiting", headers=auth_headers
+        ).get_json()
+        assert bo_so_id not in [b["so_id"] for b in waiting["backorders"]]
+
+        # Ready-to-ship tab should.
+        ready = client.get(
+            "/api/admin/backorders?tab=ready-to-ship", headers=auth_headers
+        ).get_json()
+        assert bo_so_id in [b["so_id"] for b in ready["backorders"]]
+        target = next(b for b in ready["backorders"] if b["so_id"] == bo_so_id)
+        assert target["fulfillable_since"] is not None
+
+    def test_warehouse_id_filter(self, client, auth_headers):
+        _create_bo_via_partial_fulfill(client, auth_headers)
+        # Warehouse 1 returns the BO; warehouse 9999 returns empty.
+        wh1 = client.get(
+            "/api/admin/backorders?tab=waiting&warehouse_id=1",
+            headers=auth_headers,
+        ).get_json()
+        wh_none = client.get(
+            "/api/admin/backorders?tab=waiting&warehouse_id=9999",
+            headers=auth_headers,
+        ).get_json()
+        assert len(wh1["backorders"]) >= 1
+        assert wh_none["backorders"] == []
+
+    def test_non_backorder_so_not_listed(self, client, auth_headers):
+        # SO-2026-002 is a regular sale, not a BO. Listing should
+        # NOT include it.
+        resp = client.get("/api/admin/backorders?tab=waiting", headers=auth_headers)
+        bo_ids = [b["so_id"] for b in resp.get_json()["backorders"]]
+        assert 2 not in bo_ids

--- a/api/tests/test_backorder_notifier.py
+++ b/api/tests/test_backorder_notifier.py
@@ -1,0 +1,291 @@
+"""Fire-and-forget Teams notifier.
+
+Tests for services/webhook_dispatcher/backorder_notifier.py. The
+helper spawns a daemon thread that opens its own psycopg2
+connection. Because pytest's conftest uses a SAVEPOINT-rolled-back
+transaction for isolation, rows the test inserts via the API are
+NOT visible to a fresh outside-the-transaction connection. So these
+unit tests mock _load_matching_webhooks to bypass real DB
+round-trip; the integration test
+(test_partial_fulfill_fires_notification_for_configured_webhook)
+asserts the wrapper-is-invoked contract at the call site without
+exercising the thread internals.
+"""
+
+import os
+from unittest.mock import patch
+
+from db_test_context import get_raw_connection
+
+from services.webhook_dispatcher import backorder_notifier
+from services.webhook_dispatcher.backorder_notifier import (
+    dispatch_backorder_notification,
+)
+from services.webhook_dispatcher.teams_adapter import SendOutcome
+
+
+_OPENED_PAYLOAD = {
+    "backorder_so_external_id": "11111111-2222-3333-4444-555555555555",
+    "backorder_so_number": "SO-NOTIFIER-BO",
+    "parent_so_external_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "parent_so_number": "SO-NOTIFIER",
+    "warehouse_id": 1,
+    "customer_name": "Test",
+    "items": [{"item_external_id": "ext-1", "sku": "SKU-X", "qty": 2}],
+    "opened_by_user_external_id": "user-ext",
+    "opened_at": "2026-05-19T12:00:00Z",
+}
+
+
+def _encrypted_url(plaintext="https://outlook.office.com/webhook/x"):
+    """Build a Fernet-encrypted URL using the same key the notifier
+    decrypts with; lets the unit tests round-trip through the real
+    crypto path without depending on a DB row."""
+    from services.credential_vault import encrypt_string
+    return encrypt_string(plaintext)
+
+
+def _fake_webhook(webhook_id=1, channel_kind="teams", url=None, event_filter=None):
+    return {
+        "webhook_id":   webhook_id,
+        "warehouse_id": 1,
+        "channel_kind": channel_kind,
+        "url":          url or _encrypted_url(),
+        "event_filter": event_filter or ["backorder.opened", "backorder.fulfillable"],
+        "enabled":      True,
+        "secret":       None,
+        "external_id":  "00000000-0000-0000-0000-000000000000",
+    }
+
+
+class TestDispatch:
+    def test_dispatch_fires_one_post_per_loaded_webhook(self):
+        webhooks = [_fake_webhook(1), _fake_webhook(2)]
+        with patch.object(
+            backorder_notifier, "_load_matching_webhooks", return_value=webhooks
+        ), patch.object(
+            backorder_notifier, "send_to_teams",
+            return_value=SendOutcome(delivered=True, status_code=200),
+        ) as mock_send:
+            thread = dispatch_backorder_notification(
+                event_type="backorder.opened",
+                payload=_OPENED_PAYLOAD,
+                warehouse_id=1,
+                database_url=os.environ["TEST_DATABASE_URL"],
+            )
+            thread.join(timeout=5)
+        assert mock_send.call_count == 2
+
+    def test_no_webhooks_skips_send(self):
+        with patch.object(
+            backorder_notifier, "_load_matching_webhooks", return_value=[]
+        ), patch.object(
+            backorder_notifier, "send_to_teams"
+        ) as mock_send:
+            thread = dispatch_backorder_notification(
+                event_type="backorder.opened",
+                payload=_OPENED_PAYLOAD,
+                warehouse_id=1,
+                database_url=os.environ["TEST_DATABASE_URL"],
+            )
+            thread.join(timeout=5)
+        assert mock_send.call_count == 0
+
+    def test_per_webhook_failure_isolation(self):
+        webhooks = [_fake_webhook(1), _fake_webhook(2)]
+        call_state = {"n": 0}
+
+        def _fake_send(url, card):
+            call_state["n"] += 1
+            if call_state["n"] == 1:
+                raise RuntimeError("simulated failure")
+            return SendOutcome(delivered=True, status_code=200)
+
+        with patch.object(
+            backorder_notifier, "_load_matching_webhooks", return_value=webhooks
+        ), patch.object(
+            backorder_notifier, "send_to_teams", side_effect=_fake_send
+        ):
+            thread = dispatch_backorder_notification(
+                event_type="backorder.opened",
+                payload=_OPENED_PAYLOAD,
+                warehouse_id=1,
+                database_url=os.environ["TEST_DATABASE_URL"],
+            )
+            thread.join(timeout=5)
+        # Both webhooks attempted despite the first raising.
+        assert call_state["n"] == 2
+
+    def test_non_teams_channel_skipped(self):
+        webhooks = [_fake_webhook(1, channel_kind="slack")]
+        with patch.object(
+            backorder_notifier, "_load_matching_webhooks", return_value=webhooks
+        ), patch.object(
+            backorder_notifier, "send_to_teams"
+        ) as mock_send:
+            thread = dispatch_backorder_notification(
+                event_type="backorder.opened",
+                payload=_OPENED_PAYLOAD,
+                warehouse_id=1,
+                database_url=os.environ["TEST_DATABASE_URL"],
+            )
+            thread.join(timeout=5)
+        assert mock_send.call_count == 0
+
+    def test_decrypt_failure_skips_webhook_without_crashing(self):
+        # url field is gibberish so decrypt fails. Other webhooks in
+        # the list should still attempt.
+        bad = _fake_webhook(1, url="not-real-ciphertext")
+        good = _fake_webhook(2)
+        with patch.object(
+            backorder_notifier, "_load_matching_webhooks", return_value=[bad, good]
+        ), patch.object(
+            backorder_notifier, "send_to_teams",
+            return_value=SendOutcome(delivered=True, status_code=200),
+        ) as mock_send:
+            thread = dispatch_backorder_notification(
+                event_type="backorder.opened",
+                payload=_OPENED_PAYLOAD,
+                warehouse_id=1,
+                database_url=os.environ["TEST_DATABASE_URL"],
+            )
+            thread.join(timeout=5)
+        # Only the good one made it to the wire.
+        assert mock_send.call_count == 1
+
+    def test_empty_database_url_skips_silently(self):
+        with patch.object(
+            backorder_notifier, "send_to_teams"
+        ) as mock_send:
+            thread = dispatch_backorder_notification(
+                event_type="backorder.opened",
+                payload=_OPENED_PAYLOAD,
+                warehouse_id=1,
+                database_url="",
+            )
+            thread.join(timeout=5)
+        assert mock_send.call_count == 0
+
+
+def _query_val(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row[0] if row else None
+
+
+class TestCallSiteWiring:
+    """Assert the call-site wrapper is invoked from each emit path
+    with the right event_type and warehouse_id. Wrapping
+    dispatch_backorder_notification at the route module captures
+    the call BEFORE the daemon thread spawns, so these tests do
+    not depend on cross-connection visibility."""
+
+    def test_partial_fulfill_invokes_dispatcher(self, client, auth_headers):
+        sol_id = _query_val(
+            "SELECT so_line_id FROM sales_order_lines WHERE so_id = 1 LIMIT 1"
+        )
+        with patch(
+            "routes.admin.admin_orders.dispatch_backorder_notification"
+        ) as mock_dispatch:
+            resp = client.post(
+                "/api/admin/sales-orders/1/partial-fulfill",
+                json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+                headers=auth_headers,
+            )
+        assert resp.status_code == 200, resp.get_json()
+        assert mock_dispatch.call_count == 1
+        kwargs = mock_dispatch.call_args.kwargs
+        assert kwargs["event_type"] == "backorder.opened"
+        assert kwargs["warehouse_id"] == 1
+        assert kwargs["payload"]["backorder_so_number"] == "SO-2026-001-BO"
+
+    def test_cancel_backorder_invokes_dispatcher(self, client, auth_headers):
+        sol_id = _query_val(
+            "SELECT so_line_id FROM sales_order_lines WHERE so_id = 1 LIMIT 1"
+        )
+        bo_resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        bo_so_id = bo_resp.get_json()["backorder_so"]["so_id"]
+
+        with patch(
+            "routes.admin.admin_orders.dispatch_backorder_notification"
+        ) as mock_dispatch:
+            resp = client.post(
+                f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+                json={"cancellation_reason": "found"},
+                headers=auth_headers,
+            )
+        assert resp.status_code == 200, resp.get_json()
+        # Exactly one backorder.cancelled dispatch for the BO.
+        assert mock_dispatch.call_count == 1
+        kwargs = mock_dispatch.call_args.kwargs
+        assert kwargs["event_type"] == "backorder.cancelled"
+        assert kwargs["warehouse_id"] == 1
+        assert kwargs["payload"]["cancellation_reason"] == "found"
+
+    def test_parent_cancel_cascade_invokes_dispatcher_for_child(self, client, auth_headers):
+        sol_id = _query_val(
+            "SELECT so_line_id FROM sales_order_lines WHERE so_id = 1 LIMIT 1"
+        )
+        client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+
+        with patch(
+            "routes.admin.admin_orders.dispatch_backorder_notification"
+        ) as mock_dispatch:
+            resp = client.post(
+                "/api/admin/sales-orders/1/cancel",
+                headers=auth_headers,
+            )
+        assert resp.status_code == 200, resp.get_json()
+        # One cascade-fired backorder.cancelled.
+        assert mock_dispatch.call_count == 1
+        kwargs = mock_dispatch.call_args.kwargs
+        assert kwargs["event_type"] == "backorder.cancelled"
+        assert kwargs["payload"]["cancellation_reason"] == "parent_cancelled"
+
+    def test_receipt_hook_invokes_dispatcher_when_bo_flips(self, client, auth_headers):
+        # Reproduce the happy path from test_receiving_backorder_match:
+        # zero on-hand, partial-fulfill, then receive enough to satisfy.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE inventory SET quantity_on_hand = 0, quantity_allocated = 0 "
+            " WHERE item_id = 1"
+        )
+        cur.close()
+        sol_id = _query_val(
+            "SELECT so_line_id FROM sales_order_lines WHERE so_id = 1 LIMIT 1"
+        )
+        client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 2}]},
+            headers=auth_headers,
+        )
+
+        with patch(
+            "routes.receiving.dispatch_backorder_notification"
+        ) as mock_dispatch:
+            resp = client.post(
+                "/api/receiving/receive",
+                json={
+                    "po_id": 1,
+                    "items": [{"item_id": 1, "quantity": 5, "bin_id": 3}],
+                },
+                headers=auth_headers,
+            )
+        assert resp.status_code == 200, resp.get_json()
+        # One backorder.fulfillable card fired.
+        assert mock_dispatch.call_count == 1
+        kwargs = mock_dispatch.call_args.kwargs
+        assert kwargs["event_type"] == "backorder.fulfillable"
+        assert kwargs["warehouse_id"] == 1

--- a/api/tests/test_cancel_backorder.py
+++ b/api/tests/test_cancel_backorder.py
@@ -1,0 +1,211 @@
+"""Cancel-backorder endpoint.
+
+Thin wrapper over sales_order_service.cancel_sales_order; this file
+covers the wrapper-specific validation (must be a BO; valid reason;
+not already cancelled) and confirms the event + audit emission via
+the underlying service.
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_one(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row
+
+
+def _query_val(sql, params=None):
+    row = _query_one(sql, params)
+    return row[0] if row else None
+
+
+def _partial_fulfill_seed_so(client, auth_headers, so_id=1, short_qty=1):
+    """Run /partial-fulfill against a seeded OPEN SO to create a BO
+    we can then cancel. Returns the BO's so_id."""
+    sol_id = _query_val(
+        "SELECT so_line_id FROM sales_order_lines WHERE so_id = %s LIMIT 1",
+        (so_id,),
+    )
+    resp = client.post(
+        f"/api/admin/sales-orders/{so_id}/partial-fulfill",
+        json={"lines": [{"so_line_id": sol_id, "short_qty": short_qty}]},
+        headers=auth_headers,
+    )
+    return resp.get_json()["backorder_so"]["so_id"]
+
+
+class TestHappyPath:
+    def test_cancel_waiting_stock_bo(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers)
+
+        resp = client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["bo_so_id"] == bo_so_id
+        assert body["cancellation_reason"] == "found"
+
+        row = _query_one(
+            "SELECT status, cancellation_reason FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert row == ("CANCELLED", "found")
+
+        # CANCEL audit row + backorder.cancelled event on the outbox.
+        cancel_audit_count = _query_val(
+            "SELECT COUNT(*) FROM audit_log "
+            " WHERE entity_type = 'SO' AND entity_id = %s "
+            "   AND action_type = 'CANCEL'",
+            (bo_so_id,),
+        )
+        assert cancel_audit_count == 1
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.cancelled' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 1
+
+    def test_cancel_with_default_reason_is_other(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers)
+        # Omitting cancellation_reason should default to 'other'.
+        resp = client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["cancellation_reason"] == "other"
+
+
+class TestValidation:
+    def test_non_bo_so_rejected(self, client, auth_headers):
+        # SO-2026-002 has no parent_so_id and order_type='sale'.
+        resp = client.post(
+            "/api/admin/sales-orders/2/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "Not a backorder" in resp.get_json()["error"]
+
+    def test_already_cancelled_bo_rejected(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers)
+        # Cancel once.
+        client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        # Second cancel: 400 at the wrapper layer (service is
+        # idempotent but the UI wants the explicit error).
+        resp = client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "already cancelled" in resp.get_json()["error"].lower()
+
+    def test_invalid_reason_rejected(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers)
+        resp = client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "made_up_value"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "Allowed:" in resp.get_json()["error"]
+
+
+class TestParentCancelCascade:
+    """Cascade lives in sales_order_service.cancel_sales_order. These
+    tests confirm the cascade fires when the parent is cancelled via
+    the regular /cancel endpoint."""
+
+    def test_cancelling_parent_cascades_to_bo(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers, so_id=1)
+
+        # Cancel the parent (SO-2026-001, so_id=1) via the regular
+        # /cancel endpoint.
+        resp = client.post(
+            "/api/admin/sales-orders/1/cancel",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+
+        # Both parent and BO are CANCELLED.
+        parent_status = _query_val(
+            "SELECT status FROM sales_orders WHERE so_id = 1"
+        )
+        assert parent_status == "CANCELLED"
+
+        bo_row = _query_one(
+            "SELECT status, cancellation_reason FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert bo_row == ("CANCELLED", "parent_cancelled")
+
+        # backorder.cancelled was emitted for the BO (cascade path).
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.cancelled' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 1
+
+    def test_parent_with_already_cancelled_bo_is_idempotent(self, client, auth_headers):
+        bo_so_id = _partial_fulfill_seed_so(client, auth_headers, so_id=1)
+
+        # Cancel BO first.
+        client.post(
+            f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+            json={"cancellation_reason": "found"},
+            headers=auth_headers,
+        )
+        # Now cancel parent.
+        resp = client.post(
+            "/api/admin/sales-orders/1/cancel",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # BO keeps its original reason (the cascade does not overwrite
+        # a CANCELLED child).
+        bo_reason = _query_val(
+            "SELECT cancellation_reason FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        # Either the original "found" (cascade skipped) or
+        # "parent_cancelled" (cascade overwrote then idempotent
+        # cancel returned no-op). Either is acceptable behavior; the
+        # invariant is exactly one backorder.cancelled event.
+        assert bo_reason in ("found", "parent_cancelled")
+
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.cancelled' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 1
+
+    def test_parent_with_no_bo_does_not_cascade(self, client, auth_headers):
+        # SO-2026-002 has no children; cancel should behave normally.
+        resp = client.post(
+            "/api/admin/sales-orders/2/cancel",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.cancelled'",
+        )
+        assert emit_count == 0

--- a/api/tests/test_notification_webhooks_crud.py
+++ b/api/tests/test_notification_webhooks_crud.py
@@ -1,0 +1,248 @@
+"""notification_webhooks CRUD + test-send.
+
+Covers the admin surface: create / list / patch / rotate-url /
+delete / test-send. URL plaintext is never returned (the list and
+create responses expose only a masked host preview).
+"""
+
+from unittest.mock import patch
+
+from db_test_context import get_raw_connection
+
+
+def _query_val(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row[0] if row else None
+
+
+_VALID_URL = "https://outlook.office.com/webhook/teamsink"
+
+
+class TestCreateAndList:
+    def test_create_then_list(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/notification-webhooks",
+            json={
+                "warehouse_id": 1,
+                "channel_kind": "teams",
+                "url": _VALID_URL,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201, resp.get_json()
+        body = resp.get_json()
+        assert body["warehouse_id"] == 1
+        assert body["channel_kind"] == "teams"
+        assert body["enabled"] is True
+        assert "host_preview" in body
+        assert "url" not in body  # plaintext URL never returned
+
+        # The default filter is the backorder-opened/fulfillable pair.
+        assert body["event_filter"] == ["backorder.opened", "backorder.fulfillable"]
+
+        # List shows the row.
+        list_resp = client.get(
+            "/api/admin/notification-webhooks?warehouse_id=1",
+            headers=auth_headers,
+        )
+        assert list_resp.status_code == 200
+        rows = list_resp.get_json()["notification_webhooks"]
+        assert len(rows) == 1
+        assert rows[0]["webhook_id"] == body["webhook_id"]
+        assert "url" not in rows[0]
+
+    def test_create_with_explicit_event_filter(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/notification-webhooks",
+            json={
+                "warehouse_id": 1,
+                "channel_kind": "teams",
+                "url": _VALID_URL,
+                "event_filter": ["backorder.cancelled"],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["event_filter"] == ["backorder.cancelled"]
+
+    def test_create_rejects_unknown_channel_kind(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/notification-webhooks",
+            json={
+                "warehouse_id": 1,
+                "channel_kind": "slack",
+                "url": _VALID_URL,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_create_rejects_unknown_event_filter_value(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/notification-webhooks",
+            json={
+                "warehouse_id": 1,
+                "channel_kind": "teams",
+                "url": _VALID_URL,
+                "event_filter": ["backorder.opened", "totally.made.up"],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_create_rejects_unknown_warehouse(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/notification-webhooks",
+            json={
+                "warehouse_id": 9999,
+                "channel_kind": "teams",
+                "url": _VALID_URL,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+
+def _create_webhook(client, auth_headers):
+    resp = client.post(
+        "/api/admin/notification-webhooks",
+        json={"warehouse_id": 1, "channel_kind": "teams", "url": _VALID_URL},
+        headers=auth_headers,
+    )
+    return resp.get_json()["webhook_id"]
+
+
+class TestPatch:
+    def test_disable_webhook(self, client, auth_headers):
+        webhook_id = _create_webhook(client, auth_headers)
+        resp = client.patch(
+            f"/api/admin/notification-webhooks/{webhook_id}",
+            json={"enabled": False},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["enabled"] is False
+
+    def test_update_event_filter(self, client, auth_headers):
+        webhook_id = _create_webhook(client, auth_headers)
+        resp = client.patch(
+            f"/api/admin/notification-webhooks/{webhook_id}",
+            json={"event_filter": ["backorder.cancelled"]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["event_filter"] == ["backorder.cancelled"]
+
+    def test_patch_with_no_fields_rejected(self, client, auth_headers):
+        webhook_id = _create_webhook(client, auth_headers)
+        resp = client.patch(
+            f"/api/admin/notification-webhooks/{webhook_id}",
+            json={},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+
+class TestRotateUrl:
+    def test_rotate_changes_ciphertext(self, client, auth_headers):
+        webhook_id = _create_webhook(client, auth_headers)
+        before = _query_val(
+            "SELECT url FROM notification_webhooks WHERE webhook_id = %s",
+            (webhook_id,),
+        )
+
+        resp = client.post(
+            f"/api/admin/notification-webhooks/{webhook_id}/rotate-url",
+            json={"url": "https://outlook.office.com/webhook/rotated"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        after = _query_val(
+            "SELECT url FROM notification_webhooks WHERE webhook_id = %s",
+            (webhook_id,),
+        )
+        assert before != after  # ciphertext changed
+        assert "rotated" not in after  # value is encrypted, not plaintext
+
+
+class TestDelete:
+    def test_delete_returns_200_and_removes_row(self, client, auth_headers):
+        webhook_id = _create_webhook(client, auth_headers)
+        resp = client.delete(
+            f"/api/admin/notification-webhooks/{webhook_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        gone = _query_val(
+            "SELECT COUNT(*) FROM notification_webhooks WHERE webhook_id = %s",
+            (webhook_id,),
+        )
+        assert gone == 0
+
+    def test_delete_nonexistent_returns_404(self, client, auth_headers):
+        resp = client.delete(
+            "/api/admin/notification-webhooks/999999",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404
+
+
+class TestTestSend:
+    def test_test_send_happy_path_invokes_teams(self, client, auth_headers):
+        webhook_id = _create_webhook(client, auth_headers)
+
+        class _Resp:
+            status_code = 200
+            text = "1"
+
+        with patch(
+            "services.webhook_dispatcher.teams_adapter.requests.post",
+            return_value=_Resp(),
+        ) as mock_post:
+            resp = client.post(
+                f"/api/admin/notification-webhooks/{webhook_id}/test-send",
+                headers=auth_headers,
+            )
+
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["delivered"] is True
+        assert body["status_code"] == 200
+        # Card was sent with our valid URL (the decrypt round-trip
+        # worked and the SSRF guard let it through).
+        assert mock_post.call_count == 1
+        sent_url, sent_kwargs = mock_post.call_args.args, mock_post.call_args.kwargs
+        assert sent_url[0] == _VALID_URL
+        assert sent_kwargs["json"]["@type"] == "MessageCard"
+
+    def test_test_send_returns_outcome_on_teams_rejection(self, client, auth_headers):
+        webhook_id = _create_webhook(client, auth_headers)
+
+        class _Resp:
+            status_code = 410
+            text = "gone"
+
+        with patch(
+            "services.webhook_dispatcher.teams_adapter.requests.post",
+            return_value=_Resp(),
+        ):
+            resp = client.post(
+                f"/api/admin/notification-webhooks/{webhook_id}/test-send",
+                headers=auth_headers,
+            )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["delivered"] is False
+        assert body["status_code"] == 410
+        assert body["error_kind"] == "teams_rejected"
+
+    def test_test_send_404_for_unknown_webhook(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/notification-webhooks/999999/test-send",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404

--- a/api/tests/test_partial_fulfill.py
+++ b/api/tests/test_partial_fulfill.py
@@ -1,0 +1,374 @@
+"""Partial-fulfill endpoint.
+
+Covers the happy path against an OPEN seeded SO, the PICKED-with-
+short-picks variant, the gates that protect the surface (status,
+chaining, permission, validation), and the BO SO shape (address copy,
+memo prefix, NULL totals, order_type, audit + event emission).
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_one(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row
+
+
+def _query_val(sql, params=None):
+    row = _query_one(sql, params)
+    return row[0] if row else None
+
+
+def _query_all(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    rows = cur.fetchall()
+    cur.close()
+    return rows
+
+
+def _set_so_status(so_id, status):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE sales_orders SET status = %s WHERE so_id = %s",
+        (status, so_id),
+    )
+    cur.close()
+
+
+def _set_line_picked(so_line_id, picked):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE sales_order_lines SET quantity_picked = %s WHERE so_line_id = %s",
+        (picked, so_line_id),
+    )
+    cur.close()
+
+
+def _so_line_id_for(so_id):
+    return _query_val(
+        "SELECT so_line_id FROM sales_order_lines WHERE so_id = %s ORDER BY line_number LIMIT 1",
+        (so_id,),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestOpenHappyPath:
+    def test_open_so_shrinks_and_creates_backorder(self, client, auth_headers):
+        # SO-2026-001 is seeded OPEN with item 1, qty 2.
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}], "reason_detail": "test short"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        data = resp.get_json()
+        assert data["original_so"]["so_id"] == 1
+        assert data["backorder_so"]["so_number"] == "SO-2026-001-BO"
+        assert data["backorder_so"]["status"] == "WAITING_STOCK"
+
+        # Original line shrunk from 2 -> 1.
+        ordered_after = _query_val(
+            "SELECT quantity_ordered FROM sales_order_lines WHERE so_line_id = %s",
+            (sol_id,),
+        )
+        assert ordered_after == 1
+
+        # BO has one line for item 1, qty 1.
+        bo_so_id = data["backorder_so"]["so_id"]
+        bo_lines = _query_all(
+            "SELECT item_id, quantity_ordered, status FROM sales_order_lines WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert bo_lines == [(1, 1, "PENDING")]
+
+
+class TestPickedHappyPath:
+    def test_picked_so_with_short_picks_can_be_partial_fulfilled(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        # Simulate the post-batch state: SO is PICKED with one of the
+        # two units actually picked (the other short-confirmed during
+        # picking).
+        _set_so_status(1, "PICKED")
+        _set_line_picked(sol_id, 1)
+
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        # Original now has qty_ordered=1, qty_picked=1.
+        row = _query_one(
+            "SELECT quantity_ordered, quantity_picked FROM sales_order_lines WHERE so_line_id = %s",
+            (sol_id,),
+        )
+        assert row == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Gates
+# ---------------------------------------------------------------------------
+
+
+class TestStatusGate:
+    def test_packed_rejected(self, client, auth_headers):
+        _set_so_status(1, "PACKED")
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "Can only partial-fulfill" in resp.get_json()["error"]
+
+    def test_shipped_rejected(self, client, auth_headers):
+        _set_so_status(1, "SHIPPED")
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_waiting_stock_rejected(self, client, auth_headers):
+        _set_so_status(1, "WAITING_STOCK")
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+
+class TestBoChainingCap:
+    def test_so_with_parent_id_rejected(self, client, auth_headers):
+        # Promote SO-2026-002 to a "backorder" by stamping parent_so_id.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_orders SET parent_so_id = 1, order_type = 'backorder' WHERE so_id = 2"
+        )
+        cur.close()
+        sol_id = _so_line_id_for(2)
+
+        resp = client.post(
+            "/api/admin/sales-orders/2/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "backorder" in resp.get_json()["error"].lower()
+
+
+class TestValidation:
+    def test_short_qty_exceeds_unshipped_rejected(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        # SO-2026-001 has item 1 qty 2. Short 5 -> rejected.
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 5}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "exceeds unshipped qty" in resp.get_json()["error"]
+
+    def test_invalid_so_line_id_rejected(self, client, auth_headers):
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": 999999, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "not on SO" in resp.get_json()["error"]
+
+    def test_zero_short_qty_rejected_at_schema_layer(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 0}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Shrink semantics
+# ---------------------------------------------------------------------------
+
+
+class TestShrinkSemantics:
+    def test_shrink_to_zero_hard_deletes_line(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 2}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        # Line is gone.
+        remaining = _query_val(
+            "SELECT COUNT(*) FROM sales_order_lines WHERE so_line_id = %s",
+            (sol_id,),
+        )
+        assert remaining == 0
+
+
+# ---------------------------------------------------------------------------
+# BO SO shape
+# ---------------------------------------------------------------------------
+
+
+class TestBoSoShape:
+    def test_bo_has_order_type_backorder_and_parent_link(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        bo_so_id = resp.get_json()["backorder_so"]["so_id"]
+
+        row = _query_one(
+            "SELECT order_type, parent_so_id, status, "
+            "       order_total, customer_shipping_paid, "
+            "       customer_name, ship_method "
+            "  FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert row[0] == "backorder"
+        assert row[1] == 1
+        assert row[2] == "WAITING_STOCK"
+        assert row[3] is None  # order_total NULL on BO
+        assert row[4] is None  # customer_shipping_paid NULL on BO
+        assert row[5] == "Test Customer 1"  # customer copied
+        assert row[6] == "GROUND"  # ship_method copied
+
+    def test_bo_memo_prepended(self, client, auth_headers):
+        # Set a memo on the parent first.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE sales_orders SET memo = 'original note' WHERE so_id = 1"
+        )
+        cur.close()
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        bo_so_id = resp.get_json()["backorder_so"]["so_id"]
+        memo = _query_val(
+            "SELECT memo FROM sales_orders WHERE so_id = %s", (bo_so_id,)
+        )
+        assert memo.startswith("[BACKORDER from SO-2026-001]")
+        assert "original note" in memo
+
+    def test_bo_backorder_opened_at_stamped(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        bo_so_id = resp.get_json()["backorder_so"]["so_id"]
+        opened_at = _query_val(
+            "SELECT backorder_opened_at FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert opened_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Inventory adjustment
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryAdjustment:
+    def test_on_hand_nonzero_writes_short_adjustment(self, client, auth_headers):
+        # Item 1 in the seed has inventory. Verify a SHORT row lands.
+        sol_id = _so_line_id_for(1)
+        before = _query_val(
+            "SELECT COUNT(*) FROM inventory_adjustments WHERE reason_code = 'SHORT'"
+        )
+        client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        after = _query_val(
+            "SELECT COUNT(*) FROM inventory_adjustments WHERE reason_code = 'SHORT'"
+        )
+        assert after == before + 1
+
+    def test_on_hand_zero_no_adjustment_row(self, client, auth_headers):
+        # Drop on-hand for item 1 to zero across all bins.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute("UPDATE inventory SET quantity_on_hand = 0 WHERE item_id = 1")
+        cur.close()
+        sol_id = _so_line_id_for(1)
+        before = _query_val(
+            "SELECT COUNT(*) FROM inventory_adjustments WHERE reason_code = 'SHORT'"
+        )
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        after = _query_val(
+            "SELECT COUNT(*) FROM inventory_adjustments WHERE reason_code = 'SHORT'"
+        )
+        assert after == before  # no new SHORT row
+
+
+# ---------------------------------------------------------------------------
+# Audit + event emission
+# ---------------------------------------------------------------------------
+
+
+class TestAuditAndEvents:
+    def test_two_audit_rows_one_event_emitted(self, client, auth_headers):
+        sol_id = _so_line_id_for(1)
+        resp = client.post(
+            "/api/admin/sales-orders/1/partial-fulfill",
+            json={"lines": [{"so_line_id": sol_id, "short_qty": 1}]},
+            headers=auth_headers,
+        )
+        bo_so_id = resp.get_json()["backorder_so"]["so_id"]
+
+        audit_rows = _query_all(
+            "SELECT entity_id, action_type, details "
+            "  FROM audit_log "
+            " WHERE action_type = 'PARTIAL_FULFILL' "
+            " ORDER BY log_id",
+        )
+        # One row on original, one on BO.
+        entity_ids = [r[0] for r in audit_rows]
+        assert 1 in entity_ids
+        assert bo_so_id in entity_ids
+
+        # backorder.opened event landed on integration_events.
+        event_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.opened' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert event_count == 1

--- a/api/tests/test_receiving_backorder_match.py
+++ b/api/tests/test_receiving_backorder_match.py
@@ -1,0 +1,128 @@
+"""Receipt -> backorder.fulfillable matcher.
+
+When receipt.completed lands inventory in a warehouse, the matcher in
+receiving.py looks at WAITING_STOCK backorders in that warehouse and
+flips any whose lines are now fully satisfiable to OPEN. Emits
+backorder.fulfillable per flipped BO.
+
+Partial satisfaction stays WAITING_STOCK with no event (the operator
+explicitly chose "notify only when fully available").
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_one(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row
+
+
+def _query_val(sql, params=None):
+    row = _query_one(sql, params)
+    return row[0] if row else None
+
+
+def _zero_inventory_for_item(item_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE inventory SET quantity_on_hand = 0, quantity_allocated = 0 "
+        " WHERE item_id = %s",
+        (item_id,),
+    )
+    cur.close()
+
+
+def _create_bo_from_so1(client, auth_headers, short_qty):
+    """Drop inventory for item 1 to zero, then partial-fulfill SO-2026-001
+    so the resulting BO is WAITING_STOCK with on-hand=0."""
+    _zero_inventory_for_item(1)
+    sol_id = _query_val(
+        "SELECT so_line_id FROM sales_order_lines WHERE so_id = 1 LIMIT 1"
+    )
+    resp = client.post(
+        "/api/admin/sales-orders/1/partial-fulfill",
+        json={"lines": [{"so_line_id": sol_id, "short_qty": short_qty}]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.get_json()
+    return resp.get_json()["backorder_so"]["so_id"]
+
+
+def _receive(client, auth_headers, *, po_id=1, item_id=1, qty=5, bin_id=3):
+    return client.post(
+        "/api/receiving/receive",
+        json={
+            "po_id": po_id,
+            "items": [{"item_id": item_id, "quantity": qty, "bin_id": bin_id}],
+        },
+        headers=auth_headers,
+    )
+
+
+class TestFulfillable:
+    def test_receipt_satisfies_bo_flips_to_open_and_emits(self, client, auth_headers):
+        bo_so_id = _create_bo_from_so1(client, auth_headers, short_qty=2)
+
+        # Sanity: BO is WAITING_STOCK with no fulfillable timestamp.
+        before = _query_one(
+            "SELECT status, backorder_fulfillable_at FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert before[0] == "WAITING_STOCK"
+        assert before[1] is None
+
+        # Receive 5 of item 1 (more than the 2 the BO needs).
+        resp = _receive(client, auth_headers, qty=5)
+        assert resp.status_code == 200, resp.get_json()
+
+        # BO flipped.
+        after = _query_one(
+            "SELECT status, backorder_fulfillable_at FROM sales_orders WHERE so_id = %s",
+            (bo_so_id,),
+        )
+        assert after[0] == "OPEN"
+        assert after[1] is not None
+
+        # backorder.fulfillable on the outbox.
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.fulfillable' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 1
+
+    def test_partial_receipt_stays_waiting_no_event(self, client, auth_headers):
+        # SO-2026-001 only has qty 2, so we can only short up to 2.
+        # Force on-hand to 0, partial-fulfill 2, then receive only 1
+        # (BO needs 2; receipt of 1 is partial; BO stays WAITING).
+        bo_so_id = _create_bo_from_so1(client, auth_headers, short_qty=2)
+
+        resp = _receive(client, auth_headers, qty=1)
+        assert resp.status_code == 200, resp.get_json()
+
+        status = _query_val(
+            "SELECT status FROM sales_orders WHERE so_id = %s", (bo_so_id,)
+        )
+        assert status == "WAITING_STOCK"
+
+        emit_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            " WHERE event_type = 'backorder.fulfillable' AND aggregate_id = %s",
+            (bo_so_id,),
+        )
+        assert emit_count == 0
+
+    def test_receipt_for_unrelated_item_does_not_flip_bo(self, client, auth_headers):
+        bo_so_id = _create_bo_from_so1(client, auth_headers, short_qty=2)
+        # Receive item 2 (not the BO's item). BO stays WAITING.
+        resp = _receive(client, auth_headers, item_id=2, qty=5, bin_id=4)
+        assert resp.status_code == 200, resp.get_json()
+        status = _query_val(
+            "SELECT status FROM sales_orders WHERE so_id = %s", (bo_so_id,)
+        )
+        assert status == "WAITING_STOCK"

--- a/api/tests/test_teams_adapter.py
+++ b/api/tests/test_teams_adapter.py
@@ -1,0 +1,167 @@
+"""Teams adapter card builder + send_to_teams.
+
+build_adaptive_card is a pure function so this file is mostly assertions
+on the JSON shape. send_to_teams is tested against the SSRF guard
+(network-free) and against mocked requests.post for the happy and
+4xx paths.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from services.webhook_dispatcher import teams_adapter
+from services.webhook_dispatcher.teams_adapter import (
+    SendOutcome,
+    build_adaptive_card,
+    send_to_teams,
+)
+
+
+_OPENED_PAYLOAD = {
+    "backorder_so_external_id": "11111111-2222-3333-4444-555555555555",
+    "backorder_so_number": "SO-9001-BO",
+    "parent_so_external_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "parent_so_number": "SO-9001",
+    "warehouse_id": 1,
+    "customer_name": "Jane Doe",
+    "items": [
+        {"item_external_id": "ext-1", "sku": "SKU-A", "qty": 3},
+        {"item_external_id": "ext-2", "sku": "SKU-B", "qty": 1},
+    ],
+    "opened_by_user_external_id": "user-ext",
+    "opened_at": "2026-05-19T12:00:00Z",
+}
+
+_FULFILLABLE_PAYLOAD = {
+    **_OPENED_PAYLOAD,
+    "days_waiting": 7,
+    "fulfillable_at": "2026-05-26T12:00:00Z",
+}
+
+_CANCELLED_PAYLOAD = {
+    "backorder_so_external_id": "id",
+    "backorder_so_number": "SO-9001-BO",
+    "parent_so_number": "SO-9001",
+    "warehouse_id": 1,
+    "cancellation_reason": "customer_asked",
+    "cancelled_by_user_external_id": "user-ext",
+    "cancelled_at": "2026-05-20T08:00:00Z",
+}
+
+
+class TestCardBuilder:
+    def test_opened_card_shape(self):
+        card = build_adaptive_card("backorder.opened", _OPENED_PAYLOAD)
+        assert card["@type"] == "MessageCard"
+        assert "SO-9001" in card["title"]
+        assert "Jane Doe" in card["text"]
+        assert "SKU-A" in card["text"]
+        assert "SKU-B" in card["text"]
+        # One Open-in-Sentry action, linking with focus=<bo>
+        actions = card["potentialAction"]
+        assert len(actions) == 1
+        uri = actions[0]["targets"][0]["uri"]
+        assert "focus=SO-9001-BO" in uri
+
+    def test_fulfillable_card_shape(self):
+        card = build_adaptive_card("backorder.fulfillable", _FULFILLABLE_PAYLOAD)
+        assert "SO-9001-BO" in card["title"]
+        assert "Days waiting" in card["text"]
+        assert "7" in card["text"]
+
+    def test_cancelled_card_shape(self):
+        card = build_adaptive_card("backorder.cancelled", _CANCELLED_PAYLOAD)
+        assert "SO-9001-BO" in card["title"]
+        assert "customer_asked" in card["text"]
+
+    def test_unknown_event_type_raises(self):
+        with pytest.raises(ValueError):
+            build_adaptive_card("not.an.event", {})
+
+    def test_items_summary_truncates_after_five(self):
+        payload = dict(_OPENED_PAYLOAD)
+        payload["items"] = [
+            {"item_external_id": f"e{i}", "sku": f"SKU-{i}", "qty": i}
+            for i in range(1, 9)
+        ]
+        card = build_adaptive_card("backorder.opened", payload)
+        # First 5 items + a "(+3 more)" line are present.
+        assert "SKU-1" in card["text"]
+        assert "SKU-5" in card["text"]
+        assert "(+3 more)" in card["text"]
+        # Items past the truncation point are NOT inlined.
+        assert "SKU-7" not in card["text"]
+
+
+class TestSendToTeams:
+    def test_send_succeeds_on_2xx(self):
+        class _Resp:
+            status_code = 200
+            text = "1"
+
+        with patch.object(teams_adapter, "requests") as mock_requests:
+            mock_requests.post.return_value = _Resp()
+            # requests.exceptions stays a real module so the except
+            # clauses bind without blowing up.
+            import requests as _real_requests
+            mock_requests.exceptions = _real_requests.exceptions
+
+            outcome = send_to_teams(
+                "https://outlook.office.com/webhook/x",
+                {"@type": "MessageCard"},
+            )
+        assert outcome.delivered is True
+        assert outcome.status_code == 200
+        assert outcome.error_kind is None
+
+    def test_send_returns_teams_rejected_on_4xx(self):
+        class _Resp:
+            status_code = 410
+            text = "channel deleted"
+
+        with patch.object(teams_adapter, "requests") as mock_requests:
+            mock_requests.post.return_value = _Resp()
+            import requests as _real_requests
+            mock_requests.exceptions = _real_requests.exceptions
+
+            outcome = send_to_teams(
+                "https://outlook.office.com/webhook/x",
+                {"@type": "MessageCard"},
+            )
+        assert outcome.delivered is False
+        assert outcome.status_code == 410
+        assert outcome.error_kind == "teams_rejected"
+
+    def test_ssrf_guard_rejects_private_address(self, monkeypatch):
+        # test_webhook_dispatcher_http_client.py:29 sets
+        # SENTRY_ALLOW_INTERNAL_WEBHOOKS=true at module import time
+        # (permanent leak into the test session env). Force the var
+        # off so this assertion exercises the default-secure path
+        # regardless of test ordering.
+        monkeypatch.delenv("SENTRY_ALLOW_INTERNAL_WEBHOOKS", raising=False)
+
+        # 169.254.169.254 is the AWS IMDS address; ssrf_guard MUST reject.
+        outcome = send_to_teams(
+            "http://169.254.169.254/latest/meta-data/",
+            {"@type": "MessageCard"},
+        )
+        assert outcome.delivered is False
+        assert outcome.error_kind == "ssrf_rejected"
+        assert outcome.status_code is None
+
+    def test_network_error_captured_as_outcome(self):
+        import requests as _real_requests
+
+        with patch.object(teams_adapter, "requests") as mock_requests:
+            mock_requests.exceptions = _real_requests.exceptions
+            mock_requests.post.side_effect = _real_requests.exceptions.ConnectionError(
+                "boom"
+            )
+            outcome = send_to_teams(
+                "https://outlook.office.com/webhook/x",
+                {"@type": "MessageCard"},
+            )
+        assert outcome.delivered is False
+        assert outcome.error_kind == "network_error"
+        assert "boom" in outcome.error_detail

--- a/api/tests/test_teams_adapter.py
+++ b/api/tests/test_teams_adapter.py
@@ -26,8 +26,8 @@ _OPENED_PAYLOAD = {
     "warehouse_id": 1,
     "customer_name": "Jane Doe",
     "items": [
-        {"item_external_id": "ext-1", "sku": "SKU-A", "qty": 3},
-        {"item_external_id": "ext-2", "sku": "SKU-B", "qty": 1},
+        {"item_external_id": "ext-1", "sku": "SKU-A", "item_name": "Widget A", "qty": 3},
+        {"item_external_id": "ext-2", "sku": "SKU-B", "item_name": "Widget B", "qty": 1},
     ],
     "opened_by_user_external_id": "user-ext",
     "opened_at": "2026-05-19T12:00:00Z",
@@ -57,12 +57,25 @@ class TestCardBuilder:
         assert "SO-9001" in card["title"]
         assert "Jane Doe" in card["text"]
         assert "SKU-A" in card["text"]
+        assert "Widget A" in card["text"]
         assert "SKU-B" in card["text"]
+        assert "Widget B" in card["text"]
         # One Open-in-Sentry action, linking with focus=<bo>
         actions = card["potentialAction"]
         assert len(actions) == 1
         uri = actions[0]["targets"][0]["uri"]
         assert "focus=SO-9001-BO" in uri
+
+    def test_items_summary_falls_back_when_name_missing(self):
+        # Backfill / older payloads may not carry item_name; renderer
+        # must not crash and should fall back to SKU-only.
+        payload = dict(_OPENED_PAYLOAD)
+        payload["items"] = [
+            {"item_external_id": "ext-1", "sku": "SKU-X", "qty": 2},
+        ]
+        card = build_adaptive_card("backorder.opened", payload)
+        assert "SKU-X" in card["text"]
+        assert "Widget" not in card["text"]
 
     def test_fulfillable_card_shape(self):
         card = build_adaptive_card("backorder.fulfillable", _FULFILLABLE_PAYLOAD)

--- a/db/migrations/067_partial_fulfill_backorders.sql
+++ b/db/migrations/067_partial_fulfill_backorders.sql
@@ -1,0 +1,87 @@
+-- ============================================================
+-- Migration 067: partial-fulfill + backorders
+-- ============================================================
+-- Backs the new "Partially Fulfill" admin workflow plus the
+-- /backorders Outbound surface.
+--
+-- Additive shape:
+--
+--   backorder_opened_at        -- set on a BO SO when it is created
+--                                 via /partial-fulfill. NULL on every
+--                                 non-BO SO.
+--   backorder_fulfillable_at   -- set on a BO SO when receipt.completed
+--                                 makes all its lines satisfiable and
+--                                 the BO flips WAITING_STOCK -> OPEN.
+--   cancellation_reason        -- on a CANCELLED SO, free-form-ish
+--                                 enum (app-enforced, see
+--                                 api/constants.py). Used by
+--                                 /cancel-backorder and the parent
+--                                 cancellation cascade.
+--
+--   order_type CHECK gains 'backorder'. The column was added in
+--   mig 056 for POS refunds; backorder SOs reuse the existing
+--   parent_so_id FK and disambiguate via order_type='backorder'.
+--
+--   sales_orders.status comment gains 'WAITING_STOCK'. The status
+--   column is plain VARCHAR (no DB CHECK; matches mig 054 + mig 058
+--   pattern). The new lifecycle slot is a backorder-only off-ramp:
+--   a BO flips to OPEN when receipt.completed makes its lines
+--   satisfiable, picker-side workflow then runs unchanged.
+--
+--   inventory_adjustments.reason_code comment gains 'SHORT'. Same
+--   app-enforced enum pattern as the SO status; no DB CHECK.
+--
+--   ix_sales_orders_waiting_stock partial index covers the receipt
+--   hook's "find WAITING_STOCK BOs in this warehouse, oldest first"
+--   query.
+--
+-- v1.8.0 migration discipline (#213): SET lock_timeout /
+-- statement_timeout, BEGIN/COMMIT-wrapped. Constraint adds wrapped
+-- in DO $$ blocks so partial-apply re-runs do not abort.
+-- ============================================================
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+ALTER TABLE sales_orders
+    ADD COLUMN IF NOT EXISTS backorder_opened_at      TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS backorder_fulfillable_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS cancellation_reason      VARCHAR(50);
+
+-- order_type CHECK expansion. Drop-then-add inside a DO block so a
+-- partially-applied state (e.g. constraint already dropped from a
+-- prior aborted run) does not abort the migration. The replacement
+-- constraint keeps the existing ('sale','refund') values and adds
+-- ('backorder') for SOs created via the partial-fulfill endpoint.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'sales_orders_order_type_check'
+    ) THEN
+        ALTER TABLE sales_orders DROP CONSTRAINT sales_orders_order_type_check;
+    END IF;
+
+    ALTER TABLE sales_orders
+        ADD CONSTRAINT sales_orders_order_type_check
+        CHECK (order_type IN ('sale','refund','backorder'));
+END $$;
+
+COMMENT ON COLUMN sales_orders.status IS
+    'Lifecycle: OPEN, PICKED, PACKED, SHIPPED, CANCELLED, FRAUD_REVIEW, WAITING_STOCK. Enforced by api/constants.py, not by a DB CHECK. WAITING_STOCK (mig 067) is a backorder-only off-ramp; a BO flips to OPEN when receipt.completed makes all its lines satisfiable.';
+
+COMMENT ON COLUMN sales_order_lines.status IS
+    'Lifecycle: PENDING, PICKED, PACKED, SHIPPED. ALLOCATED retired in mig 058 (never written by app code).';
+
+COMMENT ON COLUMN inventory_adjustments.reason_code IS
+    'Reason for the adjustment. App-enforced enum (no DB CHECK): CYCLE_COUNT, DAMAGE, FOUND, LOST, CORRECTION, SHORT. SHORT (mig 067) is written by /partial-fulfill when on-hand stock exists for a shorted line.';
+
+COMMENT ON COLUMN sales_orders.cancellation_reason IS
+    'On a CANCELLED SO, the reason the cancel was issued. App-enforced enum (no DB CHECK): found, customer_asked, refunded, parent_cancelled, other. Set by /cancel-backorder (operator-supplied) or by the parent-cancel cascade in sales_order_service.cancel_sales_order (value: parent_cancelled). NULL on non-cancelled SOs and on cancels that predate mig 067.';
+
+CREATE INDEX IF NOT EXISTS ix_sales_orders_waiting_stock
+    ON sales_orders (warehouse_id, backorder_opened_at)
+    WHERE status = 'WAITING_STOCK';
+
+COMMIT;

--- a/db/migrations/068_notification_webhooks.sql
+++ b/db/migrations/068_notification_webhooks.sql
@@ -1,0 +1,61 @@
+-- ============================================================
+-- Migration 068: notification_webhooks table
+-- ============================================================
+-- Backs the per-warehouse Teams notification surface introduced
+-- alongside the partial-fulfill / backorder workflow.
+--
+-- Distinct from webhook_subscriptions: that table carries
+-- signed-envelope HTTP subscribers with a different
+-- payload shape, audit surface, and rate-limit ceiling. This table
+-- carries chat-channel destinations (Teams adaptive cards in v1).
+-- Both are routed through services/webhook_dispatcher; the
+-- dispatcher selects an adapter by channel_kind.
+--
+-- url is Fernet-encrypted at rest via the existing
+-- SENTRY_ENCRYPTION_KEY wrapper that token storage uses today
+-- (services/credential_vault.py). Plaintext URL never appears in
+-- the DB.
+--
+-- v1.8.0 mig discipline (#213): SET lock_timeout /
+-- statement_timeout, BEGIN/COMMIT-wrapped.
+-- ============================================================
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS notification_webhooks (
+    webhook_id    SERIAL PRIMARY KEY,
+    warehouse_id  INT NOT NULL REFERENCES warehouses(warehouse_id),
+    channel_kind  VARCHAR(20) NOT NULL,
+    url           TEXT NOT NULL,
+    event_filter  TEXT[] NOT NULL DEFAULT
+                  ARRAY['backorder.opened','backorder.fulfillable'],
+    enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+    secret        VARCHAR(128),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by    VARCHAR(100) NOT NULL,
+    external_id   UUID UNIQUE NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_notification_webhooks_active
+    ON notification_webhooks (warehouse_id, channel_kind)
+    WHERE enabled = TRUE;
+
+COMMENT ON TABLE notification_webhooks IS
+    'Chat-channel notification destinations (Teams adaptive cards in v1). Distinct from webhook_subscriptions, which carries signed-envelope HTTP subscribers with a different payload shape and audit surface. Folded into services/webhook_dispatcher via a channel_kind adapter; routing reads this table for events in the backorder.* family.';
+
+COMMENT ON COLUMN notification_webhooks.url IS
+    'Fernet-encrypted at rest via SENTRY_ENCRYPTION_KEY. Plaintext URL never appears in the DB; the admin-facing CRUD surface accepts the URL on create and exposes a "rotate URL" flow that swaps the ciphertext.';
+
+COMMENT ON COLUMN notification_webhooks.channel_kind IS
+    'Adapter selector. v1 only ships ''teams''; the column is sized for future ''slack'', ''pagerduty'', etc.';
+
+COMMENT ON COLUMN notification_webhooks.event_filter IS
+    'Allowlist of event_type values this webhook receives. Default carries the partial-fulfill events. An empty array means "receive nothing" (explicit opt-out without disabling the row).';
+
+COMMENT ON COLUMN notification_webhooks.secret IS
+    'Optional HMAC key for sign-verify on the receiving end. Teams adaptive cards do not require this; Slack and self-hosted webhooks may. NULL on rows that do not need it.';
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -185,7 +185,7 @@ CREATE TABLE sales_orders (
     customer_id VARCHAR(50),
     customer_phone VARCHAR(50),
     customer_address TEXT,
-    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED', 'FRAUD_REVIEW'. PICKING/PACKING retired in mig 060; "in picking" is derived from pick_batches.
+    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED', 'FRAUD_REVIEW', 'WAITING_STOCK'. PICKING/PACKING retired in mig 060; "in picking" is derived from pick_batches. WAITING_STOCK added in mig 067 (backorder-only off-ramp).
     priority INT DEFAULT 0,                -- higher = pick first
     warehouse_id INT NOT NULL REFERENCES warehouses(warehouse_id),
     ship_method VARCHAR(50),
@@ -267,10 +267,20 @@ CREATE TABLE sales_orders (
     idempotency_body_hash   CHAR(64),
     cached_response_body    JSONB,
     order_type              VARCHAR(20) NOT NULL DEFAULT 'sale'
-                            CHECK (order_type IN ('sale','refund')),
+                            CHECK (order_type IN ('sale','refund','backorder')),
     parent_so_id            INT REFERENCES sales_orders(so_id),
     refunded_at             TIMESTAMPTZ,
     refund_so_id            INT REFERENCES sales_orders(so_id),
+    -- mig 067: partial-fulfill / backorder lifecycle stamps.
+    -- backorder_opened_at is set on a BO SO when it is created via
+    -- /partial-fulfill; backorder_fulfillable_at is set when the
+    -- receipt hook flips a WAITING_STOCK BO to OPEN. cancellation_reason
+    -- is set on a CANCELLED SO (by /cancel-backorder or by the
+    -- parent-cancel cascade). All three are NULL on non-BO / non-cancel
+    -- SOs.
+    backorder_opened_at      TIMESTAMPTZ,
+    backorder_fulfillable_at TIMESTAMPTZ,
+    cancellation_reason      VARCHAR(50),
     -- mig 064: timestamp set when a picking ticket has been
     -- confirmed-rendered for this SO. POST /sales-orders/mark-printed
     -- writes it once the client-side ticket render succeeds. NULL
@@ -281,6 +291,13 @@ CREATE TABLE sales_orders (
 CREATE INDEX IF NOT EXISTS ix_sales_orders_unprinted
     ON sales_orders (status, ship_by_date)
     WHERE printed_at IS NULL;
+
+-- mig 067: covers the receipt hook's "find WAITING_STOCK BOs
+-- in this warehouse, oldest first" lookup; also drives the
+-- /backorders Waiting tab.
+CREATE INDEX IF NOT EXISTS ix_sales_orders_waiting_stock
+    ON sales_orders (warehouse_id, backorder_opened_at)
+    WHERE status = 'WAITING_STOCK';
 
 CREATE TABLE sales_order_lines (
     so_line_id SERIAL PRIMARY KEY,
@@ -466,7 +483,7 @@ CREATE TABLE inventory_adjustments (
     bin_id INT NOT NULL REFERENCES bins(bin_id),
     warehouse_id INT NOT NULL REFERENCES warehouses(warehouse_id),
     quantity_change INT NOT NULL,           -- positive = add, negative = remove
-    reason_code VARCHAR(50) NOT NULL,      -- 'CYCLE_COUNT', 'DAMAGE', 'FOUND', 'LOST', 'CORRECTION'
+    reason_code VARCHAR(50) NOT NULL,      -- 'CYCLE_COUNT', 'DAMAGE', 'FOUND', 'LOST', 'CORRECTION', 'SHORT'. SHORT (mig 063) is written by /partial-fulfill when on-hand exists for a shorted line.
     reason_detail VARCHAR(500),
     status VARCHAR(20) NOT NULL DEFAULT 'PENDING',  -- 'PENDING', 'APPROVED', 'REJECTED'
     adjusted_by VARCHAR(100) NOT NULL,
@@ -1854,6 +1871,39 @@ CREATE TABLE webhook_subscriptions_tombstones (
 CREATE INDEX webhook_subscriptions_tombstones_canonical_unack
     ON webhook_subscriptions_tombstones (delivery_url_canonical)
     WHERE acknowledged_at IS NULL;
+
+-- ============================================================
+-- NOTIFICATION WEBHOOKS (mig 068)
+-- ============================================================
+-- Chat-channel notification destinations (Teams adaptive cards in
+-- v1). Distinct from webhook_subscriptions, which carries
+-- signed-envelope HTTP subscribers with a different payload shape
+-- and audit surface. Folded into services/webhook_dispatcher via a
+-- channel_kind adapter; routing reads this table for events in the
+-- backorder.* family.
+
+CREATE TABLE notification_webhooks (
+    webhook_id    SERIAL PRIMARY KEY,
+    warehouse_id  INT NOT NULL REFERENCES warehouses(warehouse_id),
+    channel_kind  VARCHAR(20) NOT NULL,
+    -- Fernet-encrypted at rest via SENTRY_ENCRYPTION_KEY. Plaintext
+    -- URL never appears in the DB.
+    url           TEXT NOT NULL,
+    event_filter  TEXT[] NOT NULL DEFAULT
+                  ARRAY['backorder.opened','backorder.fulfillable'],
+    enabled       BOOLEAN NOT NULL DEFAULT TRUE,
+    -- Optional HMAC key for sign-verify on the receiving end. Teams
+    -- adaptive cards do not require this; Slack and self-hosted
+    -- webhooks may.
+    secret        VARCHAR(128),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by    VARCHAR(100) NOT NULL,
+    external_id   UUID UNIQUE NOT NULL
+);
+
+CREATE INDEX ix_notification_webhooks_active
+    ON notification_webhooks (warehouse_id, channel_kind)
+    WHERE enabled = TRUE;
 
 -- ============================================================
 -- TRANSFER ORDERS (v1.8.0 #281)


### PR DESCRIPTION
## Notification webhooks (Microsoft Teams)

Per-warehouse Microsoft Teams notifications for the `backorder.*` event family, so the floor gets a chat ping when an order is shorted, when a backorder becomes shippable, or when one is cancelled.

Builds on the `notification_webhooks` table (migration 068, landed in the backorders thread).

- **Teams adapter + CRUD + test-send**: a pure MessageCard builder (one card variant per event, themed, with an "Open in Sentry" deep-link), an SSRF-guarded `send_to_teams`, and admin CRUD endpoints (list / create / PATCH / rotate-url / delete / test-send) gated by a new `notifications` page key. URLs are Fernet-encrypted at rest and never returned in plaintext (only a masked host preview).
- **Fire-and-forget notifier on emit**: each `backorder.*` emit site (partial-fulfill, cancel-backorder + cascade, the receipt-hook matcher) dispatches its Teams card after the DB transaction commits, on a daemon thread with its own connection so a slow Teams response never couples to operator HTTP latency. Failures are isolated per-webhook and the `integration_events` row persists regardless, so a future delivery-tracking worker can replay.
- **/notifications admin page**: configure destinations per warehouse, toggle enabled, rotate the URL, and fire a test card with a per-row outcome badge.
- **item_name in payloads**: `backorder.opened` / `backorder.fulfillable` carry item names alongside SKUs (schema-nullable for older payloads) so the card is readable without cross-referencing the admin UI.

Depends on #384 (backorders thread); review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
