### PR TITLE
feat: admin unreceive (reverse a PO receipt)

### DIFF
--- a/admin/src/pages/Receiving.jsx
+++ b/admin/src/pages/Receiving.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Fragment } from 'react';
 import { api } from '../api.js';
 import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
@@ -21,6 +21,19 @@ export default function Receiving() {
   const [defaultBinId, setDefaultBinId] = useState(null);
   // Per-line draft state: { [po_line_id]: { qty, bin_id, error, saving } }
   const [lineDrafts, setLineDrafts] = useState({});
+  // Receipt history (the item_receipts rows for the PO) and the
+  // per-line expand state. Each line shows a "Receipts (N)" toggle;
+  // clicking it surfaces the rows + per-row Unreceive buttons. Loaded
+  // alongside the PO detail so the toggle is a pure UI operation.
+  const [receipts, setReceipts] = useState([]);
+  const [expandedLines, setExpandedLines] = useState(new Set());
+  // Unreceive confirm state. unreceiving holds the receipt row being
+  // reversed; unreceiveReason is the free-text the operator types
+  // (sent to the backend, capped server-side at 500 chars).
+  const [unreceiving, setUnreceiving] = useState(null);
+  const [unreceiveReason, setUnreceiveReason] = useState('');
+  const [unreceiveError, setUnreceiveError] = useState('');
+  const [unreceiveSubmitting, setUnreceiveSubmitting] = useState(false);
 
   useEffect(() => {
     loadPOs();
@@ -81,6 +94,7 @@ export default function Receiving() {
       }
     }
     setLineDrafts({});
+    await loadReceipts(id);
   }
 
   function closeDetail() {
@@ -89,13 +103,73 @@ export default function Receiving() {
     setWarehouseBins([]);
     setDefaultBinId(null);
     setLineDrafts({});
+    setReceipts([]);
+    setExpandedLines(new Set());
   }
 
   async function refreshDetail() {
     if (!detail?.purchase_order) return;
-    const res = await api.get(`/admin/purchase-orders/${detail.purchase_order.po_id}`);
+    const po_id = detail.purchase_order.po_id;
+    const res = await api.get(`/admin/purchase-orders/${po_id}`);
     if (res?.ok) {
       setDetail(await res.json());
+    }
+    await loadReceipts(po_id);
+  }
+
+  async function loadReceipts(po_id) {
+    const res = await api.get(`/admin/purchase-orders/${po_id}/receipts`);
+    if (res?.ok) {
+      const data = await res.json();
+      setReceipts(data.receipts || []);
+    } else {
+      setReceipts([]);
+    }
+  }
+
+  function toggleLineReceipts(lineId) {
+    setExpandedLines((prev) => {
+      const next = new Set(prev);
+      if (next.has(lineId)) next.delete(lineId); else next.add(lineId);
+      return next;
+    });
+  }
+
+  function openUnreceive(receipt) {
+    setUnreceiveReason('');
+    setUnreceiveError('');
+    setUnreceiving(receipt);
+  }
+
+  function closeUnreceive() {
+    setUnreceiving(null);
+    setUnreceiveReason('');
+    setUnreceiveError('');
+    setUnreceiveSubmitting(false);
+  }
+
+  async function submitUnreceive() {
+    if (!unreceiving) return;
+    setUnreceiveError('');
+    setUnreceiveSubmitting(true);
+    try {
+      const body = {};
+      if (unreceiveReason.trim()) body.reason = unreceiveReason.trim();
+      const res = await api.post(
+        `/admin/receipts/${unreceiving.receipt_id}/unreceive`,
+        body,
+      );
+      if (!res?.ok) {
+        let data = null;
+        try { data = await res?.json(); } catch (_) { /* non-JSON */ }
+        setUnreceiveError(data?.error || 'Failed to reverse receipt');
+        return;
+      }
+      closeUnreceive();
+      await refreshDetail();
+      loadPOs();
+    } finally {
+      setUnreceiveSubmitting(false);
     }
   }
 
@@ -218,57 +292,113 @@ export default function Receiving() {
                     const remaining = (l.quantity_ordered || 0) - (l.quantity_received || 0);
                     const draft = lineDrafts[l.po_line_id] || {};
                     const lineReceivable = canReceive && remaining > 0;
+                    const lineReceipts = receipts.filter((r) => r.po_line_id === l.po_line_id);
+                    const isExpanded = expandedLines.has(l.po_line_id);
                     return (
-                      <tr key={l.po_line_id}>
-                        <td className="mono">{l.sku}</td>
-                        <td style={{ color: 'var(--text-secondary)' }}>{l.item_name}</td>
-                        <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_ordered}</td>
-                        <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_received}</td>
-                        <td className="mono" style={{
-                          textAlign: 'right',
-                          color: remaining > 0 ? 'var(--copper)' : 'var(--text-secondary)',
-                          fontWeight: remaining > 0 ? 600 : 400,
-                        }}>{remaining}</td>
-                        {canReceive && (
-                          <>
-                            <td style={{ textAlign: 'right' }}>
-                              <input
-                                type="number" min={1} max={remaining}
-                                className="form-input mono"
-                                style={{ width: 76, textAlign: 'right', padding: '4px 8px' }}
-                                value={draft.qty ?? ''}
-                                disabled={!lineReceivable || draft.saving}
-                                placeholder={lineReceivable ? '0' : ''}
-                                onChange={(e) => updateDraft(l.po_line_id, { qty: e.target.value })}
-                              />
-                            </td>
-                            <td>
-                              <select
-                                className="form-select"
-                                style={{ padding: '4px 8px' }}
-                                value={draft.bin_id ?? defaultBinId ?? ''}
-                                disabled={!lineReceivable || draft.saving}
-                                onChange={(e) => updateDraft(l.po_line_id, { bin_id: e.target.value })}
+                      <Fragment key={l.po_line_id}>
+                        <tr>
+                          <td className="mono">{l.sku}</td>
+                          <td style={{ color: 'var(--text-secondary)' }}>
+                            {l.item_name}
+                            {lineReceipts.length > 0 && (
+                              <button
+                                type="button"
+                                onClick={() => toggleLineReceipts(l.po_line_id)}
+                                style={{
+                                  marginLeft: 8,
+                                  background: 'none',
+                                  border: 'none',
+                                  color: 'var(--accent)',
+                                  cursor: 'pointer',
+                                  fontSize: 12,
+                                  textDecoration: 'underline',
+                                  padding: 0,
+                                }}
+                                title={isExpanded
+                                  ? 'Hide receipt history'
+                                  : 'Show receipt history (with Unreceive)'}
                               >
-                                {warehouseBins.map((b) => (
-                                  <option key={b.bin_id} value={b.bin_id}>
-                                    {b.bin_code}{b.bin_type ? ` (${b.bin_type})` : ''}
-                                  </option>
-                                ))}
-                              </select>
+                                {isExpanded ? 'Hide' : 'Show'} receipts ({lineReceipts.length})
+                              </button>
+                            )}
+                          </td>
+                          <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_ordered}</td>
+                          <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_received}</td>
+                          <td className="mono" style={{
+                            textAlign: 'right',
+                            color: remaining > 0 ? 'var(--copper)' : 'var(--text-secondary)',
+                            fontWeight: remaining > 0 ? 600 : 400,
+                          }}>{remaining}</td>
+                          {canReceive && (
+                            <>
+                              <td style={{ textAlign: 'right' }}>
+                                <input
+                                  type="number" min={1} max={remaining}
+                                  className="form-input mono"
+                                  style={{ width: 76, textAlign: 'right', padding: '4px 8px' }}
+                                  value={draft.qty ?? ''}
+                                  disabled={!lineReceivable || draft.saving}
+                                  placeholder={lineReceivable ? '0' : ''}
+                                  onChange={(e) => updateDraft(l.po_line_id, { qty: e.target.value })}
+                                />
+                              </td>
+                              <td>
+                                <select
+                                  className="form-select"
+                                  style={{ padding: '4px 8px' }}
+                                  value={draft.bin_id ?? defaultBinId ?? ''}
+                                  disabled={!lineReceivable || draft.saving}
+                                  onChange={(e) => updateDraft(l.po_line_id, { bin_id: e.target.value })}
+                                >
+                                  {warehouseBins.map((b) => (
+                                    <option key={b.bin_id} value={b.bin_id}>
+                                      {b.bin_code}{b.bin_type ? ` (${b.bin_type})` : ''}
+                                    </option>
+                                  ))}
+                                </select>
+                              </td>
+                              <td style={{ textAlign: 'right' }}>
+                                <button
+                                  className="btn btn-sm btn-primary"
+                                  disabled={!lineReceivable || draft.saving}
+                                  onClick={() => receiveLine(l)}
+                                >
+                                  {draft.saving ? 'Receiving...' : 'Receive'}
+                                </button>
+                              </td>
+                            </>
+                          )}
+                        </tr>
+                        {/* Expanded receipt history for this line.
+                            Each row shows the receipt's qty, bin,
+                            receiver, and an Unreceive button that
+                            opens the confirm modal. */}
+                        {isExpanded && lineReceipts.map((r) => (
+                          <tr key={`receipt-${r.receipt_id}`} style={{ background: 'var(--surface)' }}>
+                            <td></td>
+                            <td colSpan={canReceive ? 6 : 3} style={{ fontSize: 12 }}>
+                              <span className="mono" style={{ color: 'var(--text-secondary)' }}>
+                                {r.received_at ? new Date(r.received_at).toLocaleString() : '-'}
+                              </span>
+                              {' - '}
+                              <strong>{r.quantity_received}</strong> units to bin{' '}
+                              <span className="mono">{r.bin_code}</span>
+                              {r.received_by ? <> by <strong>{r.received_by}</strong></> : null}
+                              {r.lot_number ? <> (lot {r.lot_number})</> : null}
+                              {r.serial_number ? <> (serial {r.serial_number})</> : null}
                             </td>
                             <td style={{ textAlign: 'right' }}>
                               <button
-                                className="btn btn-sm btn-primary"
-                                disabled={!lineReceivable || draft.saving}
-                                onClick={() => receiveLine(l)}
+                                className="btn btn-sm btn-danger"
+                                onClick={() => openUnreceive(r)}
+                                title="Reverse this receipt"
                               >
-                                {draft.saving ? 'Receiving...' : 'Receive'}
+                                Unreceive
                               </button>
                             </td>
-                          </>
-                        )}
-                      </tr>
+                          </tr>
+                        ))}
+                      </Fragment>
                     );
                   })}
                   {Object.entries(lineDrafts).filter(([, d]) => d.error).map(([lineId, d]) => (
@@ -286,6 +416,68 @@ export default function Receiving() {
               <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>No line items</p>
             )}
           </section>
+        </Modal>
+      )}
+
+      {/* Unreceive confirm modal. The operator sees what they're about
+          to back out (SKU, qty, bin, when, who) plus an optional
+          free-text reason that lands in the ACTION_RECEIVE_CANCEL
+          audit row + the receipt.cancelled event payload. */}
+      {unreceiving && (
+        <Modal
+          title={`Unreceive: ${unreceiving.sku}`}
+          onClose={closeUnreceive}
+          footer={
+            <>
+              <button
+                className="btn"
+                onClick={closeUnreceive}
+                disabled={unreceiveSubmitting}
+              >Cancel</button>
+              <button
+                className="btn btn-danger"
+                onClick={submitUnreceive}
+                disabled={unreceiveSubmitting}
+              >
+                {unreceiveSubmitting ? 'Reversing...' : 'Unreceive'}
+              </button>
+            </>
+          }
+        >
+          {unreceiveError && (
+            <div className="form-error" style={{ marginBottom: 12 }}>{unreceiveError}</div>
+          )}
+          <p style={{ fontSize: 13, marginBottom: 12 }}>
+            Reverse <strong>{unreceiving.quantity_received}</strong> units of{' '}
+            <span className="mono">{unreceiving.sku}</span>{' '}
+            ({unreceiving.item_name}) received to bin{' '}
+            <span className="mono">{unreceiving.bin_code}</span>
+            {unreceiving.received_at ? (
+              <> on {new Date(unreceiving.received_at).toLocaleString()}</>
+            ) : null}
+            {unreceiving.received_by ? (
+              <> by <strong>{unreceiving.received_by}</strong></>
+            ) : null}.
+          </p>
+          <p style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
+            Inventory decrements from the warehouse pool (preferring the
+            receipt's original bin; falls through to other bins holding
+            this item if the goods have already been put away).
+            The PO line counter and PO status update in step, and a
+            receipt.cancelled event fires so a downstream subscriber
+            reverses the inbound count.
+          </p>
+          <div className="form-group">
+            <label>Reason (optional, audit-logged)</label>
+            <input
+              className="form-input"
+              value={unreceiveReason}
+              onChange={(e) => setUnreceiveReason(e.target.value)}
+              placeholder="e.g. double scan"
+              maxLength={500}
+              disabled={unreceiveSubmitting}
+            />
+          </div>
         </Modal>
       )}
     </div>

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -73,6 +73,10 @@ from services.sales_order_service import (
     record_admin_pick,
     revert_sales_order_status as _revert_so_status,
 )
+from services.receiving_service import (
+    UnreceiveError,
+    record_unreceive,
+)
 from services.webhook_dispatcher.backorder_notifier import (
     dispatch_backorder_notification,
 )
@@ -572,6 +576,126 @@ def reopen_purchase_order(po_id):
     )
     g.db.commit()
     return jsonify({"message": "Purchase order reopened", "status": PO_OPEN})
+
+
+# ── PO Receipts: admin unreceive (double-scan fix) ────────────────────────
+
+
+@admin_bp.route("/purchase-orders/<int:po_id>/receipts", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission("receiving")
+@with_db
+def list_po_receipts(po_id):
+    """Receipt history for a single PO, scoped to the admin Receiving
+    modal. Returns one row per item_receipts entry with the human-
+    facing context the operator needs to decide what to unreceive
+    (sku + bin code + receiver + when). Excludes RMA goods-in rows
+    (po_id IS NULL) by virtue of the WHERE filter.
+    """
+    rows = g.db.execute(
+        text(
+            """
+            SELECT r.receipt_id, r.po_line_id, r.item_id, r.quantity_received,
+                   r.bin_id, r.warehouse_id, r.received_by, r.received_at,
+                   r.lot_number, r.serial_number, r.notes, r.external_id,
+                   i.sku, i.item_name,
+                   b.bin_code,
+                   pol.line_number
+              FROM item_receipts r
+              JOIN items i  ON i.item_id  = r.item_id
+              JOIN bins  b  ON b.bin_id   = r.bin_id
+              LEFT JOIN purchase_order_lines pol
+                ON pol.po_line_id = r.po_line_id
+             WHERE r.po_id = :pid
+             ORDER BY r.received_at DESC, r.receipt_id DESC
+            """
+        ),
+        {"pid": po_id},
+    ).fetchall()
+    return jsonify({
+        "po_id": po_id,
+        "receipts": [
+            {
+                "receipt_id": r.receipt_id,
+                "po_line_id": r.po_line_id,
+                "line_number": r.line_number,
+                "item_id": r.item_id,
+                "sku": r.sku,
+                "item_name": r.item_name,
+                "quantity_received": r.quantity_received,
+                "bin_id": r.bin_id,
+                "bin_code": r.bin_code,
+                "warehouse_id": r.warehouse_id,
+                "received_by": r.received_by,
+                "received_at": r.received_at.isoformat() if r.received_at else None,
+                "lot_number": r.lot_number,
+                "serial_number": r.serial_number,
+                "notes": r.notes,
+                "external_id": str(r.external_id),
+            }
+            for r in rows
+        ],
+    })
+
+
+@admin_bp.route("/receipts/<int:receipt_id>/unreceive", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission("receiving")
+@with_db
+def unreceive_receipt(receipt_id):
+    """Reverse one PO receipt (admin double-scan fix).
+
+    Body is optional: {"reason": "<free text>"}. Walks the warehouse
+    inventory pool to back out the receipt qty (preferring the
+    receipt's original bin, then other bins holding the item),
+    decrements the PO line, recomputes PO status, hard-deletes the
+    item_receipts row, writes one ACTION_RECEIVE_CANCEL audit row
+    with details.source='admin_unreceive', and emits
+    receipt.cancelled/1 so a downstream ERP/warehouse subscriber
+    decrements its inbound count.
+
+    Auth: receiving page permission (matches the GET) or ADMIN. The
+    decorator gates both shapes.
+
+    Idempotency: a same-second double click reuses g.source_txn_id;
+    integration_events ON CONFLICT (aggregate_type, aggregate_id,
+    event_type, source_txn_id) DO NOTHING absorbs the second event
+    cleanly. The second mutation pass would 404 on the receipt
+    (already deleted by the first), so the client gets a clear error
+    on the second click rather than a silent double-reverse.
+    """
+    body = request.get_json(silent=True) or {}
+    reason = body.get("reason")
+    if reason is not None and not isinstance(reason, str):
+        return jsonify({"error": "reason must be a string"}), 422
+    if reason and len(reason) > 500:
+        return jsonify({"error": "reason must be 500 chars or fewer"}), 422
+
+    try:
+        result = record_unreceive(
+            g.db,
+            receipt_id=receipt_id,
+            username=g.current_user["username"],
+            reason=reason,
+        )
+    except UnreceiveError as exc:
+        if exc.kind == "not_found":
+            status_code = 404
+        elif exc.kind == "insufficient_available":
+            status_code = 409
+        else:
+            status_code = 422
+        return jsonify({
+            "error": str(exc),
+            "kind": exc.kind,
+            **exc.context,
+        }), status_code
+
+    g.db.commit()
+    return jsonify({
+        "message": "Receipt reversed",
+        **result,
+    })
 
 
 # ── Source Systems ────────────────────────────────────────────────────────────

--- a/api/schemas_v1/events/receipt.cancelled/1.json
+++ b/api/schemas_v1/events/receipt.cancelled/1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sentry-wms.example/events/receipt.cancelled/1.json",
+  "title": "receipt.cancelled v1",
+  "description": "A previously-completed PO receipt has been reversed by an admin. Emitted by the admin unreceive route. Aggregate: item_receipt. Mirrors receipt.completed but with quantity_reversed in place of quantity_received and a cancelled_at instant.",
+  "type": "object",
+  "required": [
+    "receipt_external_id",
+    "po_external_id",
+    "lines",
+    "cancelled_by_user_external_id",
+    "cancelled_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "receipt_external_id": { "type": "string", "format": "uuid" },
+    "po_external_id": { "type": "string", "format": "uuid" },
+    "lines": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["item_external_id", "quantity_reversed"],
+        "additionalProperties": false,
+        "properties": {
+          "item_external_id": { "type": "string", "format": "uuid" },
+          "quantity_reversed": { "type": "integer", "minimum": 1 },
+          "lot_number": { "type": ["string", "null"] },
+          "serial_number": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "cancelled_by_user_external_id": { "type": "string", "format": "uuid" },
+    "cancelled_at": { "type": "string", "format": "date-time" },
+    "reason": { "type": ["string", "null"] }
+  }
+}

--- a/api/services/events_schema_registry.py
+++ b/api/services/events_schema_registry.py
@@ -30,6 +30,12 @@ from jsonschema import Draft202012Validator
 # schema body.
 V150_CATALOG: Tuple[Tuple[str, int, str], ...] = (
     ("receipt.completed",    1, "item_receipt"),
+    # admin-unreceive: a previously-completed PO receipt has been
+    # reversed by an admin (typical use: double-scan undo). Mirrors
+    # receipt.completed but with quantity_reversed and cancelled_at; a
+    # downstream ERP/warehouse consumer subscribes so the inbound count
+    # decrements in step.
+    ("receipt.cancelled",    1, "item_receipt"),
     ("adjustment.applied",   1, "inventory_adjustment"),
     ("transfer.completed",   1, "inventory_transfer"),
     ("pick.confirmed",       1, "sales_order"),

--- a/api/services/receiving_service.py
+++ b/api/services/receiving_service.py
@@ -1,0 +1,345 @@
+"""Receiving shared service: admin unreceive path.
+
+Mirrors the structure of sales_order_service.py: route handlers are
+thin, this module owns the multi-table reversal so the inventory walk,
+audit row, event emission, and PO status recompute share one
+transaction. The session-wide cancel path in api/routes/receiving.py
+(used by the mobile receive screen) is intentionally NOT consolidated
+here -- it predates the outbound event contract and operates on a list
+of receipt_ids in one tap, whereas record_unreceive targets a single
+receipt for the admin double-scan-undo flow.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from flask import g, has_request_context
+from sqlalchemy import text
+
+from constants import (
+    ACTION_RECEIVE_CANCEL,
+    PO_OPEN,
+    PO_PARTIAL,
+    PO_RECEIVED,
+    POL_PARTIAL,
+    POL_PENDING,
+    POL_RECEIVED,
+)
+from services.audit_service import write_audit_log
+from services.events_service import (
+    emit_event,
+    get_user_external_id,
+)
+
+
+class UnreceiveError(Exception):
+    """The unreceive request cannot be applied.
+
+    kind discriminates the four shapes the route layer maps to HTTP
+    status codes:
+
+      * 'not_found'             404 -- receipt does not exist or scope
+                                       filtered it
+      * 'not_a_po_receipt'      422 -- receipt is an RMA goods-in
+                                       (so_id NOT NULL), not a PO receipt
+      * 'insufficient_available' 409 -- warehouse pool lacks the qty
+                                        to back out (allocated/picked
+                                        elsewhere; operator must adjust
+                                        first)
+    """
+
+    def __init__(self, message: str, kind: str, **context):
+        super().__init__(message)
+        self.kind = kind
+        self.context = context
+
+
+def record_unreceive(
+    db,
+    *,
+    receipt_id: int,
+    username: str,
+    reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Reverse a single PO receipt.
+
+    Inventory model: prefer the receipt's original bin, then walk the
+    receipt's warehouse for any other bin holding this item with
+    available stock (on_hand - allocated). A strict-bin rule does not
+    fit the typical warehouse flow because items get put away from the
+    receive bin to a pick bin before the operator notices a
+    double-scan; the warehouse-pool model lets the unreceive land
+    even after putaway has moved the goods.
+
+    Refuses with kind='insufficient_available' when the warehouse
+    total available is below the receipt qty -- typically because the
+    item has been picked or shipped against an SO and the inventory
+    is gone. The operator handles that gap via an inventory adjustment,
+    not this path.
+
+    Caller owns the transaction boundary; this function does not
+    commit. The event emission is skipped when no Flask request
+    context exists (matches complete_batch / record_admin_pick).
+
+    Returns dict with receipt_id, po_id, po_status (post-recompute),
+    quantity_reversed, and per-bin decrement list for the audit.
+    """
+    receipt = db.execute(
+        text(
+            "SELECT receipt_id, external_id, po_id, po_line_id, "
+            "       item_id, bin_id, warehouse_id, quantity_received, "
+            "       lot_number, serial_number "
+            "  FROM item_receipts WHERE receipt_id = :rid FOR UPDATE"
+        ),
+        {"rid": receipt_id},
+    ).fetchone()
+    if receipt is None:
+        raise UnreceiveError(
+            f"receipt {receipt_id} not found", kind="not_found",
+        )
+    if receipt.po_id is None:
+        # RMA goods-in receipts go through their own reversal flow
+        # (cancel-RMA / restock) and carry so_id instead of po_id.
+        # Refusing here avoids muddling the two reversal contracts.
+        raise UnreceiveError(
+            "this receipt is an RMA goods-in row, not a PO receipt",
+            kind="not_a_po_receipt",
+            receipt_id=receipt_id,
+        )
+
+    qty_to_reverse = receipt.quantity_received
+
+    # Warehouse-pool availability check. If the item has been picked
+    # or shipped since the receipt, the warehouse total is below the
+    # receipt qty and we refuse -- the operator must adjust inventory
+    # first, then unreceive.
+    warehouse_available = db.execute(
+        text(
+            "SELECT COALESCE("
+            "  SUM(GREATEST(0, quantity_on_hand - quantity_allocated)), 0"
+            ") AS avail "
+            "  FROM inventory "
+            " WHERE item_id = :iid AND warehouse_id = :wid"
+        ),
+        {"iid": receipt.item_id, "wid": receipt.warehouse_id},
+    ).scalar()
+    if warehouse_available < qty_to_reverse:
+        raise UnreceiveError(
+            (
+                f"warehouse {receipt.warehouse_id} has only "
+                f"{warehouse_available} available of this item but the "
+                f"receipt is for {qty_to_reverse}. The goods may have "
+                f"been picked or shipped; adjust inventory before "
+                f"unreceiving."
+            ),
+            kind="insufficient_available",
+            warehouse_available=int(warehouse_available),
+            receipt_quantity=qty_to_reverse,
+        )
+
+    # Walk: try the receipt's original bin first, then other bins
+    # ordered by available DESC so we drain the bin most likely to be
+    # the putaway target. Per-bin decrement floored at the bin's
+    # available stock so we never write a negative on_hand.
+    bin_decrements: list[dict] = []
+    remaining = qty_to_reverse
+
+    orig = db.execute(
+        text(
+            "SELECT inventory_id, "
+            "       GREATEST(0, quantity_on_hand - quantity_allocated) AS avail "
+            "  FROM inventory "
+            " WHERE item_id = :iid AND bin_id = :bid AND warehouse_id = :wid "
+            " FOR UPDATE"
+        ),
+        {
+            "iid": receipt.item_id,
+            "bid": receipt.bin_id,
+            "wid": receipt.warehouse_id,
+        },
+    ).fetchone()
+    if orig is not None and orig.avail > 0:
+        take = min(remaining, int(orig.avail))
+        db.execute(
+            text(
+                "UPDATE inventory "
+                "   SET quantity_on_hand = quantity_on_hand - :d, "
+                "       updated_at = NOW() "
+                " WHERE inventory_id = :id"
+            ),
+            {"d": take, "id": orig.inventory_id},
+        )
+        bin_decrements.append({"bin_id": receipt.bin_id, "quantity": take})
+        remaining -= take
+
+    if remaining > 0:
+        other_invs = db.execute(
+            text(
+                "SELECT inventory_id, bin_id, "
+                "       GREATEST(0, quantity_on_hand - quantity_allocated) AS avail "
+                "  FROM inventory "
+                " WHERE item_id = :iid AND warehouse_id = :wid "
+                "   AND bin_id <> :origbid "
+                "   AND quantity_on_hand - quantity_allocated > 0 "
+                " ORDER BY (quantity_on_hand - quantity_allocated) DESC, bin_id ASC "
+                " FOR UPDATE"
+            ),
+            {
+                "iid": receipt.item_id,
+                "wid": receipt.warehouse_id,
+                "origbid": receipt.bin_id,
+            },
+        ).fetchall()
+        for inv in other_invs:
+            if remaining <= 0:
+                break
+            take = min(remaining, int(inv.avail))
+            if take <= 0:
+                continue
+            db.execute(
+                text(
+                    "UPDATE inventory "
+                    "   SET quantity_on_hand = quantity_on_hand - :d, "
+                    "       updated_at = NOW() "
+                    " WHERE inventory_id = :id"
+                ),
+                {"d": take, "id": inv.inventory_id},
+            )
+            bin_decrements.append({"bin_id": inv.bin_id, "quantity": take})
+            remaining -= take
+
+    if remaining > 0:
+        # Defence in depth: the warehouse_available check above already
+        # rules this out, but a FOR UPDATE race could in theory leave
+        # gap. Raise loudly so the caller rolls back rather than
+        # quietly under-reversing.
+        raise UnreceiveError(
+            "warehouse pool drained mid-walk; rolling back",
+            kind="insufficient_available",
+            warehouse_available=qty_to_reverse - remaining,
+            receipt_quantity=qty_to_reverse,
+        )
+
+    # Decrement PO line + flip its status. GREATEST(0, ...) is
+    # redundant once the warehouse-available check passes but keeps
+    # the same shape as cancel_receiving for reviewer familiarity.
+    db.execute(
+        text(
+            """
+            UPDATE purchase_order_lines
+               SET quantity_received = GREATEST(0, quantity_received - :qty),
+                   status = CASE
+                       WHEN GREATEST(0, quantity_received - :qty) = 0
+                           THEN :pol_pending
+                       WHEN GREATEST(0, quantity_received - :qty) >= quantity_ordered
+                           THEN :pol_received
+                       ELSE :pol_partial
+                   END
+             WHERE po_line_id = :plid
+            """
+        ),
+        {
+            "qty": qty_to_reverse,
+            "plid": receipt.po_line_id,
+            "pol_pending": POL_PENDING,
+            "pol_received": POL_RECEIVED,
+            "pol_partial": POL_PARTIAL,
+        },
+    )
+
+    # Hard-delete the receipt row -- the audit row + event carry the
+    # forensic record. Soft-delete (status column) would change the
+    # item_receipts contract that mobile cancel_receiving and the
+    # event-emission path both rely on.
+    db.execute(
+        text("DELETE FROM item_receipts WHERE receipt_id = :rid"),
+        {"rid": receipt_id},
+    )
+
+    # PO status recompute. Re-open if any line dropped below
+    # quantity_ordered; matches receive_items's status flip on the
+    # other side.
+    all_lines = db.execute(
+        text(
+            "SELECT quantity_received, quantity_ordered "
+            "  FROM purchase_order_lines WHERE po_id = :pid"
+        ),
+        {"pid": receipt.po_id},
+    ).fetchall()
+    if all(ln.quantity_received >= ln.quantity_ordered for ln in all_lines):
+        new_po_status = PO_RECEIVED
+    elif any(ln.quantity_received > 0 for ln in all_lines):
+        new_po_status = PO_PARTIAL
+    else:
+        new_po_status = PO_OPEN
+    db.execute(
+        text(
+            "UPDATE purchase_orders SET status = :s WHERE po_id = :pid"
+        ),
+        {"s": new_po_status, "pid": receipt.po_id},
+    )
+
+    write_audit_log(
+        db,
+        action_type=ACTION_RECEIVE_CANCEL,
+        entity_type="PO",
+        entity_id=receipt.po_id,
+        user_id=username,
+        warehouse_id=receipt.warehouse_id,
+        details={
+            "source": "admin_unreceive",
+            "receipt_id": receipt_id,
+            "receipt_external_id": str(receipt.external_id),
+            "po_line_id": receipt.po_line_id,
+            "item_id": receipt.item_id,
+            "quantity_reversed": qty_to_reverse,
+            "bin_decrements": bin_decrements,
+            "reason": reason,
+        },
+    )
+
+    if has_request_context():
+        po = db.execute(
+            text("SELECT external_id FROM purchase_orders WHERE po_id = :pid"),
+            {"pid": receipt.po_id},
+        ).fetchone()
+        item = db.execute(
+            text("SELECT external_id FROM items WHERE item_id = :iid"),
+            {"iid": receipt.item_id},
+        ).fetchone()
+        po_external_id_str = str(po.external_id)
+        emit_event(
+            db,
+            event_type="receipt.cancelled",
+            event_version=1,
+            aggregate_type="item_receipt",
+            aggregate_id=receipt_id,
+            aggregate_external_id=receipt.external_id,
+            warehouse_id=receipt.warehouse_id,
+            source_txn_id=g.source_txn_id,
+            payload={
+                "receipt_external_id": str(receipt.external_id),
+                "po_external_id": po_external_id_str,
+                "lines": [
+                    {
+                        "item_external_id": str(item.external_id),
+                        "quantity_reversed": qty_to_reverse,
+                        "lot_number": receipt.lot_number,
+                        "serial_number": receipt.serial_number,
+                    }
+                ],
+                "cancelled_by_user_external_id": get_user_external_id(db, username),
+                "cancelled_at": (
+                    datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+                ),
+                "reason": reason,
+            },
+        )
+
+    return {
+        "receipt_id": receipt_id,
+        "po_id": receipt.po_id,
+        "po_status": new_po_status,
+        "quantity_reversed": qty_to_reverse,
+        "bin_decrements": bin_decrements,
+    }

--- a/api/tests/test_admin_unreceive.py
+++ b/api/tests/test_admin_unreceive.py
@@ -1,0 +1,444 @@
+"""HTTP + service-layer tests for the admin unreceive flow.
+
+Two surfaces:
+
+  * GET  /api/admin/purchase-orders/<po_id>/receipts -- receipt
+                                                       history for the
+                                                       admin Receiving
+                                                       modal
+  * POST /api/admin/receipts/<receipt_id>/unreceive -- reverse one
+                                                      PO receipt
+
+Walks the warehouse pool, decrements the PO line, recomputes PO
+status, deletes the item_receipts row, writes ACTION_RECEIVE_CANCEL
+audit + emits receipt.cancelled/1. End state must be indistinguishable
+from "the receive never happened" plus the audit/event forensic trail.
+"""
+
+import json
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from db_test_context import get_raw_connection
+from services.events_schema_registry import get_validator
+
+
+def _admin_headers(client):
+    resp = client.post(
+        "/api/auth/login", json={"username": "admin", "password": "admin"},
+    )
+    return {"Authorization": f"Bearer {resp.get_json()['token']}"}
+
+
+def _receive(client, headers, po_id, item_id, qty, bin_id):
+    payload = {
+        "po_id": po_id,
+        "items": [{"item_id": item_id, "quantity": qty, "bin_id": bin_id}],
+    }
+    resp = client.post("/api/receiving/receive", json=payload, headers=headers)
+    assert resp.status_code == 200, resp.get_json()
+    return resp.get_json()["receipt_ids"][0]
+
+
+def _read_inv(item_id, bin_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT quantity_on_hand, quantity_allocated FROM inventory "
+        " WHERE item_id = %s AND bin_id = %s",
+        (item_id, bin_id),
+    )
+    row = cur.fetchone()
+    cur.close()
+    if row is None:
+        return None
+    return {"quantity_on_hand": row[0], "quantity_allocated": row[1]}
+
+
+def _read_pol(po_line_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT quantity_ordered, quantity_received, status "
+        "  FROM purchase_order_lines WHERE po_line_id = %s",
+        (po_line_id,),
+    )
+    row = cur.fetchone()
+    cur.close()
+    return {
+        "quantity_ordered": row[0],
+        "quantity_received": row[1],
+        "status": row[2],
+    }
+
+
+def _read_po_status(po_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT status FROM purchase_orders WHERE po_id = %s", (po_id,),
+    )
+    row = cur.fetchone()
+    cur.close()
+    return row[0]
+
+
+def _po_line_id_for(po_id, item_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT po_line_id FROM purchase_order_lines "
+        " WHERE po_id = %s AND item_id = %s",
+        (po_id, item_id),
+    )
+    row = cur.fetchone()
+    cur.close()
+    return row[0]
+
+
+def _receipt_exists(receipt_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT 1 FROM item_receipts WHERE receipt_id = %s", (receipt_id,),
+    )
+    exists = cur.fetchone() is not None
+    cur.close()
+    return exists
+
+
+def _audit_rows(po_id, action="RECEIVE_CANCEL"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT details FROM audit_log "
+        " WHERE entity_type = 'PO' AND entity_id = %s "
+        "   AND action_type = %s "
+        " ORDER BY log_id DESC",
+        (po_id, action),
+    )
+    rows = [r[0] if isinstance(r[0], dict) else json.loads(r[0]) for r in cur.fetchall()]
+    cur.close()
+    return rows
+
+
+def _event_rows(receipt_id, event_type="receipt.cancelled"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT event_type, payload FROM integration_events "
+        " WHERE aggregate_type = 'item_receipt' AND aggregate_id = %s "
+        "   AND event_type = %s",
+        (receipt_id, event_type),
+    )
+    rows = [
+        {
+            "event_type": r[0],
+            "payload": r[1] if isinstance(r[1], dict) else json.loads(r[1]),
+        }
+        for r in cur.fetchall()
+    ]
+    cur.close()
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/purchase-orders/<id>/receipts
+# ---------------------------------------------------------------------------
+
+
+class TestListPoReceipts:
+    def test_returns_receipts_for_po(self, client, auth_headers, seed_data):
+        bid = seed_data["staging_bin_id"]
+        rid = _receive(client, auth_headers, po_id=1, item_id=1, qty=3, bin_id=bid)
+        admin = _admin_headers(client)
+        resp = client.get("/api/admin/purchase-orders/1/receipts", headers=admin)
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        rids = [r["receipt_id"] for r in body["receipts"]]
+        assert rid in rids
+        sample = next(r for r in body["receipts"] if r["receipt_id"] == rid)
+        assert sample["quantity_received"] == 3
+        assert sample["item_id"] == 1
+        assert sample["bin_id"] == bid
+        assert sample["external_id"]
+
+    def test_empty_list_for_unreceived_po(self, client, auth_headers, seed_data):
+        admin = _admin_headers(client)
+        resp = client.get("/api/admin/purchase-orders/1/receipts", headers=admin)
+        assert resp.status_code == 200
+        assert resp.get_json()["receipts"] == []
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/receipts/<id>/unreceive -- happy path + invariants
+# ---------------------------------------------------------------------------
+
+
+class TestUnreceiveHappyPath:
+    def test_reverses_inventory_and_deletes_receipt(
+        self, client, auth_headers, seed_data,
+    ):
+        bid = seed_data["staging_bin_id"]
+        rid = _receive(client, auth_headers, po_id=1, item_id=1, qty=4, bin_id=bid)
+        assert _read_inv(1, bid)["quantity_on_hand"] == 4
+        po_line_id = _po_line_id_for(1, 1)
+        assert _read_pol(po_line_id)["quantity_received"] == 4
+
+        admin = _admin_headers(client)
+        resp = client.post(
+            f"/api/admin/receipts/{rid}/unreceive",
+            json={"reason": "double scan"},
+            headers=admin,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["quantity_reversed"] == 4
+        assert body["bin_decrements"] == [{"bin_id": bid, "quantity": 4}]
+
+        # Inventory back to zero, PO line back to PENDING, receipt gone.
+        assert _read_inv(1, bid)["quantity_on_hand"] == 0
+        pol = _read_pol(po_line_id)
+        assert pol["quantity_received"] == 0
+        assert pol["status"] == "PENDING"
+        assert not _receipt_exists(rid)
+
+    def test_writes_audit_row_with_admin_source(
+        self, client, auth_headers, seed_data,
+    ):
+        bid = seed_data["staging_bin_id"]
+        rid = _receive(client, auth_headers, po_id=1, item_id=1, qty=2, bin_id=bid)
+        admin = _admin_headers(client)
+        client.post(
+            f"/api/admin/receipts/{rid}/unreceive",
+            json={"reason": "ops typo"},
+            headers=admin,
+        )
+        rows = _audit_rows(1, "RECEIVE_CANCEL")
+        assert rows, "audit row missing"
+        latest = rows[0]
+        assert latest["source"] == "admin_unreceive"
+        assert latest["receipt_id"] == rid
+        assert latest["quantity_reversed"] == 2
+        assert latest["reason"] == "ops typo"
+        assert latest["bin_decrements"] == [{"bin_id": bid, "quantity": 2}]
+
+    def test_emits_receipt_cancelled_event(
+        self, client, auth_headers, seed_data,
+    ):
+        bid = seed_data["staging_bin_id"]
+        rid = _receive(client, auth_headers, po_id=1, item_id=1, qty=2, bin_id=bid)
+        admin = _admin_headers(client)
+        client.post(
+            f"/api/admin/receipts/{rid}/unreceive",
+            json={},
+            headers=admin,
+        )
+        events = _event_rows(rid, "receipt.cancelled")
+        assert len(events) == 1
+        payload = events[0]["payload"]
+        assert payload["lines"][0]["quantity_reversed"] == 2
+        # Validates against the registered v1 schema.
+        validator = get_validator("receipt.cancelled", 1)
+        errors = list(validator.iter_errors(payload))
+        assert errors == [], errors
+
+
+# ---------------------------------------------------------------------------
+# Bin-walk: even after putaway moves the goods, unreceive lands
+# ---------------------------------------------------------------------------
+
+
+class TestUnreceiveBinWalk:
+    def test_reverses_from_putaway_bin_when_receipt_bin_emptied(
+        self, client, auth_headers, seed_data,
+    ):
+        recv_bid = seed_data["staging_bin_id"]
+        # Receive into staging, then move every unit to a pickable bin
+        # (simulates the warehouse putting away before noticing the
+        # double-scan). Unreceive should still land by walking the
+        # warehouse pool.
+        rid = _receive(client, auth_headers, po_id=1, item_id=1, qty=5, bin_id=recv_bid)
+        putaway_bid = 4  # A-01-02 in apartment-lab seed (warehouse 1)
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        # Zero every other warehouse-1 bin so the walk has only the
+        # putaway bin to choose from. The apartment-lab seed pre-stocks
+        # item 1 in bin 3, which would otherwise be picked first.
+        cur.execute(
+            "UPDATE inventory SET quantity_on_hand = 0 "
+            " WHERE item_id = 1 AND bin_id <> %s",
+            (putaway_bid,),
+        )
+        cur.execute(
+            "INSERT INTO inventory (item_id, bin_id, warehouse_id, "
+            "                       quantity_on_hand, quantity_allocated) "
+            "VALUES (1, %s, 1, 5, 0) "
+            "ON CONFLICT (item_id, bin_id, lot_number) DO UPDATE "
+            "SET quantity_on_hand = 5, quantity_allocated = 0",
+            (putaway_bid,),
+        )
+        cur.close()
+
+        admin = _admin_headers(client)
+        resp = client.post(
+            f"/api/admin/receipts/{rid}/unreceive", json={}, headers=admin,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        decremented_bins = {d["bin_id"]: d["quantity"] for d in body["bin_decrements"]}
+        # Original receipt bin had no stock left, so the walk falls
+        # through to the putaway bin and decrements all 5 there.
+        assert decremented_bins == {putaway_bid: 5}
+        assert _read_inv(1, putaway_bid)["quantity_on_hand"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Guards: insufficient available, not_found
+# ---------------------------------------------------------------------------
+
+
+class TestUnreceiveGuards:
+    def test_insufficient_available_returns_409(
+        self, client, auth_headers, seed_data,
+    ):
+        bid = seed_data["staging_bin_id"]
+        rid = _receive(client, auth_headers, po_id=1, item_id=1, qty=3, bin_id=bid)
+        # Drain inventory to simulate the goods having been picked /
+        # shipped on a separate SO since the receipt landed. Zero
+        # every bin EXCEPT the receipt bin (which keeps 1 unit) so
+        # the warehouse-pool total is exactly 1 -- short of the 3
+        # required for the unreceive.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE inventory SET quantity_on_hand = 0 "
+            " WHERE item_id = 1 AND bin_id <> %s",
+            (bid,),
+        )
+        cur.execute(
+            "UPDATE inventory SET quantity_on_hand = 1 "
+            " WHERE item_id = 1 AND bin_id = %s",
+            (bid,),
+        )
+        cur.close()
+
+        admin = _admin_headers(client)
+        resp = client.post(
+            f"/api/admin/receipts/{rid}/unreceive", json={}, headers=admin,
+        )
+        assert resp.status_code == 409, resp.get_json()
+        body = resp.get_json()
+        assert body["kind"] == "insufficient_available"
+        assert body["warehouse_available"] == 1
+        assert body["receipt_quantity"] == 3
+
+        # Atomic rollback: receipt still exists, PO line untouched.
+        assert _receipt_exists(rid)
+        po_line_id = _po_line_id_for(1, 1)
+        assert _read_pol(po_line_id)["quantity_received"] == 3
+
+    def test_receipt_not_found_returns_404(self, client, auth_headers):
+        admin = _admin_headers(client)
+        resp = client.post(
+            "/api/admin/receipts/99999999/unreceive", json={}, headers=admin,
+        )
+        assert resp.status_code == 404
+        assert resp.get_json()["kind"] == "not_found"
+
+    def test_double_unreceive_returns_404_on_second(
+        self, client, auth_headers, seed_data,
+    ):
+        bid = seed_data["staging_bin_id"]
+        rid = _receive(client, auth_headers, po_id=1, item_id=1, qty=2, bin_id=bid)
+        admin = _admin_headers(client)
+        first = client.post(
+            f"/api/admin/receipts/{rid}/unreceive", json={}, headers=admin,
+        )
+        assert first.status_code == 200
+        second = client.post(
+            f"/api/admin/receipts/{rid}/unreceive", json={}, headers=admin,
+        )
+        assert second.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PO status: re-open RECEIVED PO when a line drops below ordered
+# ---------------------------------------------------------------------------
+
+
+class TestUnreceivePoStatusRecompute:
+    def test_reopens_received_po(self, client, auth_headers, seed_data):
+        bid = seed_data["staging_bin_id"]
+        # Receive every line in full -- PO flips to RECEIVED.
+        items = [
+            {"item_id": 1, "quantity": 100, "bin_id": bid},
+            {"item_id": 2, "quantity": 100, "bin_id": bid},
+            {"item_id": 3, "quantity": 100, "bin_id": bid},
+            {"item_id": 4, "quantity": 100, "bin_id": bid},
+            {"item_id": 5, "quantity": 50, "bin_id": bid},
+            {"item_id": 6, "quantity": 20, "bin_id": bid},
+            {"item_id": 7, "quantity": 200, "bin_id": bid},
+            {"item_id": 8, "quantity": 30, "bin_id": bid},
+            {"item_id": 9, "quantity": 40, "bin_id": bid},
+            {"item_id": 10, "quantity": 60, "bin_id": bid},
+        ]
+        resp = client.post(
+            "/api/receiving/receive",
+            json={"po_id": 1, "items": items},
+            headers=auth_headers,
+        )
+        assert resp.get_json()["po_status"] == "RECEIVED"
+        assert _read_po_status(1) == "RECEIVED"
+
+        # Pick any one receipt and undo it -- PO must demote.
+        admin = _admin_headers(client)
+        first_rid = resp.get_json()["receipt_ids"][0]
+        unrecv = client.post(
+            f"/api/admin/receipts/{first_rid}/unreceive", json={},
+            headers=admin,
+        )
+        assert unrecv.status_code == 200, unrecv.get_json()
+        assert unrecv.get_json()["po_status"] == "PARTIAL"
+        assert _read_po_status(1) == "PARTIAL"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestUnreceiveValidation:
+    def test_reason_too_long_returns_422(
+        self, client, auth_headers, seed_data,
+    ):
+        bid = seed_data["staging_bin_id"]
+        rid = _receive(client, auth_headers, po_id=1, item_id=1, qty=1, bin_id=bid)
+        admin = _admin_headers(client)
+        resp = client.post(
+            f"/api/admin/receipts/{rid}/unreceive",
+            json={"reason": "x" * 501},
+            headers=admin,
+        )
+        assert resp.status_code == 422
+
+    def test_reason_wrong_type_returns_422(
+        self, client, auth_headers, seed_data,
+    ):
+        bid = seed_data["staging_bin_id"]
+        rid = _receive(client, auth_headers, po_id=1, item_id=1, qty=1, bin_id=bid)
+        admin = _admin_headers(client)
+        resp = client.post(
+            f"/api/admin/receipts/{rid}/unreceive",
+            json={"reason": 42},
+            headers=admin,
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Admin unreceive (reverse a PO receipt)

The double-scan fix: an admin can reverse a single PO receipt from the web, even after the goods have been put away.

- **`record_unreceive` service**: reverses one receipt in a single transaction -- decrements the PO line, recomputes PO status (re-OPENing a RECEIVED PO when a line drops below ordered), hard-deletes the `item_receipts` row, writes an `ACTION_RECEIVE_CANCEL` audit row (`details.source='admin_unreceive'`), and emits `receipt.cancelled/1`. Inventory backs out of the warehouse pool (preferring the receipt's original bin, then any other bin holding the item with available stock) so the reversal lands even after putaway moved the goods. Refuses with `insufficient_available` when the warehouse total is below the receipt qty (the goods were picked/shipped; the operator handles that gap via an adjustment).
- **Endpoints**: `GET /admin/purchase-orders/<id>/receipts` (receipt history) and `POST /admin/receipts/<id>/unreceive` (optional `{"reason"}`), both gated by the existing `receiving` page key.
- **Event**: `receipt.cancelled/1` registered, mirroring `receipt.completed` with `quantity_reversed` + `cancelled_at`, so a downstream ERP/warehouse consumer decrements its inbound count in step.
- **Admin UI**: receipt history per PO line + a per-row Unreceive control with a reason prompt in the Receiving modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
