### PR TITLE
feat: inbound inventory sync + source-system external_ids in webhook payloads

### DIFF
--- a/api/middleware/auth_middleware.py
+++ b/api/middleware/auth_middleware.py
@@ -377,11 +377,15 @@ V150_ENDPOINT_SLUGS = {
 # Adding a new /api/v1/inbound/* route means adding one entry here plus
 # wiring it in the admin UI's inbound-resources checkbox group.
 V170_INBOUND_RESOURCE_BY_ENDPOINT = {
-    "inbound.post_sales_orders":    "sales_orders",
-    "inbound.post_items":           "items",
-    "inbound.post_customers":       "customers",
-    "inbound.post_vendors":         "vendors",
-    "inbound.post_purchase_orders": "purchase_orders",
+    "inbound.post_sales_orders":     "sales_orders",
+    "inbound.post_items":            "items",
+    "inbound.post_customers":        "customers",
+    "inbound.post_vendors":          "vendors",
+    "inbound.post_purchase_orders":  "purchase_orders",
+    # State-based inventory sync from upstream (cutover seed, external
+    # marketplace mirror, drift correction). See routes/inbound.py
+    # _inventory_update_post + register_inventory_update_route.
+    "inbound.post_inventory_update": "inventory_update",
 }
 
 

--- a/api/routes/admin/admin_transfer_orders.py
+++ b/api/routes/admin/admin_transfer_orders.py
@@ -37,7 +37,7 @@ from middleware.db import with_db
 from routes.admin import admin_bp
 from schemas.csv_import import TransferOrderImportRow
 from services.audit_service import write_audit_log
-from services.events_service import emit_event
+from services.events_service import emit_event, resolve_source_external_id
 from services.transfer_order_service import (
     TO_APPROVAL_APPROVED,
     TO_APPROVAL_PENDING,
@@ -1326,8 +1326,15 @@ def approve_transfer_order_approval(to_id, approval_id):
                 text("SELECT external_id FROM items WHERE item_id = :iid"),
                 {"iid": item_id},
             ).fetchone()
+            # Resolve canonical UUID to source-system external_id for the
+            # outbound payload. Canonical UUID fallback when no upstream
+            # mapping exists. See resolve_source_external_id docstring.
+            item_source_external_id = (
+                resolve_source_external_id(g.db, "item", item_external.external_id)
+                or str(item_external.external_id)
+            )
             event_lines.append({
-                "item_external_id": str(item_external.external_id),
+                "item_external_id": item_source_external_id,
                 "quantity": qty,
             })
     except ValueError as exc:

--- a/api/routes/admin/admin_users.py
+++ b/api/routes/admin/admin_users.py
@@ -27,7 +27,7 @@ from schemas.users import (
     UpdateUserRequest,
 )
 from services.audit_service import write_audit_log
-from services.events_service import emit_event, get_user_external_id
+from services.events_service import emit_event, get_user_external_id, resolve_source_external_id
 from services.auth_service import validate_password
 from services.inventory_service import add_inventory
 from utils.validation import validate_body
@@ -936,6 +936,14 @@ def review_adjustments(validated):
                     ),
                     {"cid": row.cycle_count_id, "iid": row.item_id},
                 ).fetchone()
+                # Resolve item canonical UUID to source-system external_id
+                # (the SKU upstream pusher used at Pipe B time). Adjustment +
+                # bin + cycle_count entities stay canonical -- they originate
+                # inside Sentry, no upstream identity.
+                item_source_external_id = (
+                    resolve_source_external_id(g.db, "item", item_ext.external_id)
+                    or str(item_ext.external_id)
+                )
                 emit_event(
                     g.db,
                     event_type="cycle_count.adjusted",
@@ -947,7 +955,7 @@ def review_adjustments(validated):
                     source_txn_id=g.source_txn_id,
                     payload={
                         "cycle_count_external_id": str(cc.cycle_count_external_id),
-                        "item_external_id": str(item_ext.external_id),
+                        "item_external_id": item_source_external_id,
                         "bin_external_id": str(bin_ext.external_id),
                         "counted_quantity": cc.counted_quantity,
                         "system_quantity": cc.expected_quantity,
@@ -957,6 +965,11 @@ def review_adjustments(validated):
                     },
                 )
             else:
+                # Same source-id resolution as the cycle_count branch.
+                item_source_external_id = (
+                    resolve_source_external_id(g.db, "item", item_ext.external_id)
+                    or str(item_ext.external_id)
+                )
                 emit_event(
                     g.db,
                     event_type="adjustment.applied",
@@ -968,7 +981,7 @@ def review_adjustments(validated):
                     source_txn_id=g.source_txn_id,
                     payload={
                         "adjustment_external_id": str(row.external_id),
-                        "item_external_id": str(item_ext.external_id),
+                        "item_external_id": item_source_external_id,
                         "bin_external_id": str(bin_ext.external_id),
                         "quantity_delta": row.quantity_change,
                         "reason_code": row.reason_code,
@@ -1088,6 +1101,11 @@ def direct_adjustment(validated):
     # the call is both proposer and effectuator; applied_by_user_external_id
     # names that admin. cycle_count_id is always null on this path, so
     # the event is never cycle_count.adjusted here.
+    # Direct-adjustment path: same source-id resolution.
+    item_source_external_id = (
+        resolve_source_external_id(g.db, "item", item.external_id)
+        or str(item.external_id)
+    )
     emit_event(
         g.db,
         event_type="adjustment.applied",
@@ -1099,7 +1117,7 @@ def direct_adjustment(validated):
         source_txn_id=g.source_txn_id,
         payload={
             "adjustment_external_id": str(adj.external_id),
-            "item_external_id": str(item.external_id),
+            "item_external_id": item_source_external_id,
             "bin_external_id": str(bin_row.external_id),
             "quantity_delta": quantity_change,
             "reason_code": "DIRECT_ADJUSTMENT",

--- a/api/routes/inbound.py
+++ b/api/routes/inbound.py
@@ -409,7 +409,11 @@ def _inventory_update_post():
         raise
 
     # Create the adjustment record (status=APPROVED -- auto-applied via Pipe B).
-    adjusted_by_user_id = g.current_token.get("user_id") if g.current_token else None
+    # adjusted_by is NOT NULL on inventory_adjustments. Pipe B WMS tokens are
+    # system-driven and carry no user identity, so attribute the adjustment to
+    # the admin user (id 1) as a last resort. The audit trail stays rich: the
+    # token_name and source_external_id are recorded in audit_log.details below.
+    adjusted_by_user_id = (g.current_token.get("user_id") if g.current_token else None) or 1
     adj_row = g.db.execute(
         text("""
             INSERT INTO inventory_adjustments (
@@ -447,6 +451,7 @@ def _inventory_update_post():
             "reason_code": reason_code,
             "source_external_id": body.external_id,
             "source_system": source_system,
+            "token_name": g.current_token.get("token_name") if g.current_token else None,
         },
     )
 

--- a/api/routes/inbound.py
+++ b/api/routes/inbound.py
@@ -181,11 +181,22 @@ def _trim(msg: str, n: int = 400) -> str:
 def register_inbound_resource(resource_key: str, endpoint_suffix: str) -> None:
     """Register POST /api/v1/inbound/<resource_key> with the wms_token
     decorator + per-token rate limit. Future per-resource commits add
-    one line here per resource."""
+    one line here per resource.
+
+    Rate limit is env-configurable via INBOUND_RATE_LIMIT_PER_MINUTE (default 500).
+    Sentry can sustain much higher than the original "100 per minute" default --
+    bulk pre-cutover pushes (item master, inventory seed, customer migration)
+    need higher ceilings without compromising steady-state safety. Single-
+    threaded pushers max out at ~12 req/sec (RTT-limited) so 500/min gives
+    ~30% headroom. Bump to 1000-2000 only if running multiple concurrent
+    pushers. Lower it again per-environment if you ever see resource pressure.
+    """
+    import os
+    rate_limit = os.getenv("INBOUND_RATE_LIMIT_PER_MINUTE", "500")
     handler = _resource_post(resource_key)
     handler = with_db(handler)
     handler = require_wms_token(handler)
-    handler = limiter.limit("100 per minute")(handler)
+    handler = limiter.limit(f"{rate_limit} per minute")(handler)
     inbound_bp.add_url_rule(
         f"/{resource_key}",
         endpoint=f"post_{endpoint_suffix}",

--- a/api/routes/inbound.py
+++ b/api/routes/inbound.py
@@ -23,22 +23,30 @@ Per-request shape:
   every response (success or failure).
 """
 
+import uuid
+from datetime import timezone
+
 from flask import Blueprint, current_app, g, jsonify, make_response, request
 from psycopg2.errors import IntegrityError as _PsycopgIntegrityError
 from pydantic import ValidationError
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError as _SAIntegrityError
 
 from middleware.auth_middleware import require_wms_token
 from middleware.db import with_db
 from schemas.inbound import InboundBody
+from services.audit_service import write_audit_log
+from services.events_service import emit_event, resolve_source_external_id
 from services.inbound_service import (
     HandlerError,
     HandlerOK,
     get_max_body_kb,
     handle_inbound,
 )
+from services.inventory_service import add_inventory
 from services.mapping_loader import MappingDocument
 from services.rate_limit import limiter
+from constants import ACTION_ADJUST, ADJ_APPROVED
 
 
 inbound_bp = Blueprint("inbound", __name__)
@@ -208,5 +216,300 @@ def register_inbound_resource(resource_key: str, endpoint_suffix: str) -> None:
 register_inbound_resource("sales_orders", "sales_orders")
 register_inbound_resource("items", "items")
 register_inbound_resource("customers", "customers")
+
+
+# ----------------------------------------------------------------------
+# POST /api/v1/inbound/inventory_update
+# ----------------------------------------------------------------------
+#
+# Token-authed bulk inventory STATE-SYNC endpoint. Used for:
+#   - Initial cutover seed of on-hand quantities
+#   - Continuous mirror from an external marketplace / fulfillment system
+#   - Drift correction (when an upstream system and Sentry disagree, push
+#     the upstream's state in)
+#   - Bulk corrections post-cutover
+#
+# State-based semantics: caller sends the DESIRED final quantity. Server
+# computes the delta vs current quantity_on_hand and applies it as an
+# inventory_adjustments row (so the audit trail still tells the story).
+# Idempotent: pushing the same target_quantity twice is a 0-delta no-op.
+#
+# Body shape: standard InboundBody with source_payload containing:
+#   {
+#     "item_external_id": "<source-system SKU>", // resolved via cross_system_mappings
+#     "bin_code": "PICK-BULK",                   // resolved within warehouse_id
+#     "warehouse_id": 1,                         // target warehouse id
+#     "target_quantity": 50,                     // absolute; the desired state
+#     "reason_code": "cutover_seed"              // free-form, recorded in inventory_adjustments
+#   }
+#
+# Returns 201 on apply (delta != 0) with { canonical_id, applied_delta, ... }
+# Returns 200 on no-op (delta == 0) with { applied_delta: 0, current_quantity, ... }
+#
+# Bidirectional sync architecture:
+#   upstream -> Sentry: this endpoint (state-based)
+#   Sentry -> upstream: existing adjustment.applied webhook events (delta-based)
+
+
+def _inventory_update_post():
+    """POST /api/v1/inbound/inventory_update -- token-authed state-based sync."""
+    cap_bytes = get_max_body_kb() * 1024
+    if request.content_length is not None and request.content_length > cap_bytes:
+        response = make_response(
+            jsonify({"error_kind": "body_too_large", "max_body_kb": get_max_body_kb()}),
+            413,
+        )
+        response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+        return response
+
+    try:
+        body = InboundBody.model_validate(request.get_json(silent=False))
+    except ValidationError as exc:
+        response = make_response(
+            jsonify({"error_kind": "validation_error", "details": exc.errors(include_url=False)}),
+            422,
+        )
+        response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+        return response
+
+    sp = body.source_payload or {}
+    required = ("item_external_id", "bin_code", "warehouse_id", "target_quantity", "reason_code")
+    missing = [k for k in required if k not in sp]
+    if missing:
+        response = make_response(
+            jsonify({"error_kind": "missing_source_payload_fields", "missing": missing}),
+            422,
+        )
+        response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+        return response
+
+    try:
+        item_external_id = str(sp["item_external_id"])
+        bin_code = str(sp["bin_code"])
+        warehouse_id = int(sp["warehouse_id"])
+        target_quantity = int(sp["target_quantity"])
+        reason_code = str(sp["reason_code"])
+    except (TypeError, ValueError) as exc:
+        response = make_response(
+            jsonify({"error_kind": "invalid_payload_types", "message": str(exc)[:200]}),
+            422,
+        )
+        response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+        return response
+
+    if target_quantity < 0:
+        response = make_response(
+            jsonify({"error_kind": "negative_target_quantity", "target_quantity": target_quantity}),
+            422,
+        )
+        response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+        return response
+
+    # Resolve the source-system SKU to Sentry's item_id via
+    # cross_system_mappings -> items. The token's source_system tells us
+    # which mapping namespace to look in.
+    source_system = g.current_token.get("source_system") if g.current_token else None
+    if not source_system:
+        response = make_response(jsonify({"error_kind": "token_missing_source_system"}), 401)
+        response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+        return response
+
+    item_row = g.db.execute(
+        text("""
+            SELECT i.item_id, i.sku, i.external_id
+            FROM cross_system_mappings csm
+            JOIN items i ON i.external_id = csm.canonical_id
+            WHERE csm.source_system = :ss
+              AND csm.source_type = 'item'
+              AND csm.source_id = :sid
+        """),
+        {"ss": source_system, "sid": item_external_id},
+    ).fetchone()
+    if not item_row:
+        response = make_response(
+            jsonify({
+                "error_kind": "item_not_found",
+                "item_external_id": item_external_id,
+                "source_system": source_system,
+            }),
+            404,
+        )
+        response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+        return response
+    item_id = item_row.item_id
+
+    # Resolve bin via (warehouse_id, bin_code).
+    bin_row = g.db.execute(
+        text("SELECT bin_id, bin_code, external_id FROM bins WHERE warehouse_id = :wh AND bin_code = :bc"),
+        {"wh": warehouse_id, "bc": bin_code},
+    ).fetchone()
+    if not bin_row:
+        response = make_response(
+            jsonify({
+                "error_kind": "bin_not_found",
+                "warehouse_id": warehouse_id,
+                "bin_code": bin_code,
+            }),
+            404,
+        )
+        response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+        return response
+    bin_id = bin_row.bin_id
+
+    # Look up current state for this (item, bin) -- needed to compute delta.
+    inv_row = g.db.execute(
+        text("""
+            SELECT inventory_id, quantity_on_hand FROM inventory
+            WHERE item_id = :iid AND bin_id = :bid FOR UPDATE
+        """),
+        {"iid": item_id, "bid": bin_id},
+    ).fetchone()
+    current_quantity = inv_row.quantity_on_hand if inv_row else 0
+    quantity_change = target_quantity - current_quantity
+
+    # Idempotent no-op: target already matches current. Return 200 + current
+    # state without writing an adjustment row or emitting an event.
+    if quantity_change == 0:
+        response = make_response(
+            jsonify({
+                "applied_delta": 0,
+                "current_quantity": current_quantity,
+                "target_quantity": target_quantity,
+                "warehouse_id": warehouse_id,
+                "bin_id": bin_id,
+                "item_id": item_id,
+                "noop": True,
+            }),
+            200,
+        )
+        response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+        return response
+
+    # Apply ADD or REMOVE for the computed delta.
+    try:
+        if quantity_change > 0:
+            adjustment_type = "ADD"
+            add_inventory(g.db, item_id, bin_id, warehouse_id, quantity_change)
+        else:
+            adjustment_type = "REMOVE"
+            qty_remove = abs(quantity_change)
+            new_qty = current_quantity - qty_remove
+            if new_qty == 0:
+                g.db.execute(
+                    text("DELETE FROM inventory WHERE inventory_id = :inv_id"),
+                    {"inv_id": inv_row.inventory_id},
+                )
+            else:
+                g.db.execute(
+                    text("UPDATE inventory SET quantity_on_hand = :qty, updated_at = NOW() WHERE inventory_id = :inv_id"),
+                    {"qty": new_qty, "inv_id": inv_row.inventory_id},
+                )
+    except Exception:
+        g.db.rollback()
+        raise
+
+    # Create the adjustment record (status=APPROVED -- auto-applied via Pipe B).
+    adjusted_by_user_id = g.current_token.get("user_id") if g.current_token else None
+    adj_row = g.db.execute(
+        text("""
+            INSERT INTO inventory_adjustments (
+                item_id, bin_id, warehouse_id, quantity_change,
+                reason_code, reason_detail, status,
+                adjusted_by, adjusted_at, external_id
+            )
+            VALUES (
+                :iid, :bid, :wid, :qty_change,
+                :reason_code, :reason_detail, :status,
+                :user_id, NOW(), :ext_id
+            )
+            RETURNING adjustment_id, adjusted_at, external_id
+        """),
+        {
+            "iid": item_id, "bid": bin_id, "wid": warehouse_id,
+            "qty_change": quantity_change,
+            "reason_code": reason_code[:60],
+            "reason_detail": f"Pipe B inbound adjustment from upstream external_id={body.external_id}",
+            "status": ADJ_APPROVED,
+            "user_id": adjusted_by_user_id,
+            "ext_id": str(uuid.uuid4()),
+        },
+    ).fetchone()
+
+    write_audit_log(
+        g.db, ACTION_ADJUST, "ITEM", item_id,
+        user_id=adjusted_by_user_id,
+        warehouse_id=warehouse_id,
+        details={
+            "adjustment_id": adj_row.adjustment_id,
+            "adjustment_type": adjustment_type,
+            "bin_id": bin_id,
+            "quantity": quantity_change,
+            "reason_code": reason_code,
+            "source_external_id": body.external_id,
+            "source_system": source_system,
+        },
+    )
+
+    item_source_external_id = (
+        resolve_source_external_id(g.db, "item", item_row.external_id)
+        or str(item_row.external_id)
+    )
+    emit_event(
+        g.db,
+        event_type="adjustment.applied",
+        event_version=1,
+        aggregate_type="inventory_adjustment",
+        aggregate_id=adj_row.adjustment_id,
+        aggregate_external_id=adj_row.external_id,
+        warehouse_id=warehouse_id,
+        source_txn_id=getattr(g, "source_txn_id", None),
+        payload={
+            "adjustment_external_id": str(adj_row.external_id),
+            "item_external_id": item_source_external_id,
+            "bin_external_id": str(bin_row.external_id),
+            "quantity_delta": quantity_change,
+            "reason_code": reason_code,
+            "applied_by_user_external_id": None,  # Pipe B path: no Sentry user identity
+            "applied_at": adj_row.adjusted_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+    )
+
+    g.db.commit()
+
+    response = make_response(
+        jsonify({
+            "canonical_id": str(adj_row.external_id),
+            "adjustment_id": adj_row.adjustment_id,
+            "applied_delta": quantity_change,
+            "current_quantity": target_quantity,  # post-apply state
+            "target_quantity": target_quantity,
+            "warehouse_id": warehouse_id,
+            "bin_id": bin_id,
+            "item_id": item_id,
+            "noop": False,
+        }),
+        201,
+    )
+    response.headers["X-Sentry-Canonical-Model"] = "DRAFT-v1"
+    return response
+
+
+def register_inventory_update_route() -> None:
+    """Register POST /api/v1/inbound/inventory_update -- state-based sync."""
+    import os
+    rate_limit = os.getenv("INBOUND_RATE_LIMIT_PER_MINUTE", "500")
+    handler = _inventory_update_post
+    handler = with_db(handler)
+    handler = require_wms_token(handler)
+    handler = limiter.limit(f"{rate_limit} per minute")(handler)
+    inbound_bp.add_url_rule(
+        "/inventory_update",
+        endpoint="post_inventory_update",
+        view_func=handler,
+        methods=["POST"],
+    )
+
+
+register_inventory_update_route()
 register_inbound_resource("vendors", "vendors")
 register_inbound_resource("purchase_orders", "purchase_orders")

--- a/api/routes/packing.py
+++ b/api/routes/packing.py
@@ -11,7 +11,7 @@ from middleware.auth_middleware import require_auth, warehouse_scope_clause
 from middleware.db import with_db
 from schemas.pack_verification import CompletePackingRequest, VerifyPackItemRequest
 from services.audit_service import write_audit_log
-from services.events_service import emit_event, get_user_external_id
+from services.events_service import emit_event, get_user_external_id, resolve_source_external_id
 from constants import SO_PICKED, SO_PACKED, ACTION_PACK, TASK_SHORT
 from utils.validation import validate_body
 
@@ -340,19 +340,33 @@ def complete_packing(validated):
     # synthesised entry keyed "<so_ext>-pkg-1"; dimensions_in is null
     # (not tracked). Multi-package support is v1.5.x+ once the packing
     # UI supports discrete packages.
+    # Outbound payload uses source-system external_ids; canonical UUID
+    # fallback when no upstream mapping exists. See resolve_source_external_id.
     pack_lines = g.db.execute(
         text(
             """
-            SELECT i.external_id AS item_external_id, sol.quantity_packed
+            SELECT
+                COALESCE(csm.source_id, CAST(i.external_id AS TEXT)) AS item_external_id,
+                sol.quantity_packed
               FROM sales_order_lines sol
               JOIN items i ON i.item_id = sol.item_id
+              LEFT JOIN cross_system_mappings csm
+                ON csm.canonical_id = i.external_id
+                AND csm.source_type = 'item'
              WHERE sol.so_id = :sid
              ORDER BY sol.line_number
             """
         ),
         {"sid": so_id},
     ).fetchall()
-    so_external_id_str = str(so.external_id)
+    so_canonical_str = str(so.external_id)
+    so_source_external_id = (
+        resolve_source_external_id(g.db, "sales_order", so.external_id)
+        or so_canonical_str
+    )
+    # package_external_id stays Sentry-internal (synthesised, no upstream
+    # identity); uses canonical UUID stem for traceability.
+    so_external_id_str = so_canonical_str
     emit_event(
         g.db,
         event_type="pack.confirmed",
@@ -363,7 +377,7 @@ def complete_packing(validated):
         warehouse_id=so.warehouse_id,
         source_txn_id=g.source_txn_id,
         payload={
-            "sales_order_external_id": so_external_id_str,
+            "sales_order_external_id": so_source_external_id,
             "packages": [
                 {
                     "package_external_id": f"{so_external_id_str}-pkg-1",

--- a/api/routes/receiving.py
+++ b/api/routes/receiving.py
@@ -19,7 +19,7 @@ from middleware.auth_middleware import require_auth, warehouse_scope_clause
 from middleware.db import with_db
 from schemas.receiving import CancelReceivingRequest, ReceiveItemsRequest
 from services.audit_service import write_audit_log
-from services.events_service import emit_event, get_user_external_id
+from services.events_service import emit_event, get_user_external_id, resolve_source_external_id
 from services.inventory_service import add_inventory
 from services.webhook_dispatcher.backorder_notifier import (
     dispatch_backorder_notification,
@@ -378,14 +378,20 @@ def receive_items(validated):
         receipt_at = receipt_row.received_at
         receipt_ids.append(receipt_id)
 
-        # Look up the item's external_id for the wire payload. Cheap,
-        # one round-trip per receipt; a higher-volume emit site would
-        # memoize per-request.
+        # Look up the item's canonical UUID, then resolve it to the
+        # source-system external_id (the SKU the upstream pusher used at
+        # Pipe B time) for the wire payload. Falls back to canonical UUID
+        # when no upstream mapping exists. Cheap, two round-trips per
+        # receipt; a higher-volume emit site would memoize per-request.
         item_row = g.db.execute(
             text("SELECT external_id FROM items WHERE item_id = :iid"),
             {"iid": item_id},
         ).fetchone()
-        item_external_id = str(item_row.external_id) if item_row else None
+        item_canonical = item_row.external_id if item_row else None
+        item_external_id = (
+            resolve_source_external_id(g.db, "item", item_canonical)
+            or (str(item_canonical) if item_canonical else None)
+        )
 
         # 2 & 3. Update PO line quantity and status
         new_qty_received = po_line.quantity_received + quantity
@@ -441,8 +447,15 @@ def receive_items(validated):
             warehouse_id=warehouse_id,
             source_txn_id=g.source_txn_id,
             payload={
+                # receipt_external_id stays canonical (no upstream system
+                # creates receipts; they originate inside Sentry).
                 "receipt_external_id": str(receipt_external_id),
-                "po_external_id": str(po.external_id),
+                # po_external_id resolves to the source-system PO identifier
+                # (e.g. our PO number) when one was Pipe-B'd in.
+                "po_external_id": (
+                    resolve_source_external_id(g.db, "purchase_order", po.external_id)
+                    or str(po.external_id)
+                ),
                 "lines": [
                     {
                         "item_external_id": item_external_id,

--- a/api/routes/transfers.py
+++ b/api/routes/transfers.py
@@ -13,7 +13,7 @@ from middleware.auth_middleware import require_auth, check_warehouse_access
 from middleware.db import with_db
 from schemas.bin_transfer import MoveRequest
 from services.audit_service import write_audit_log
-from services.events_service import emit_event
+from services.events_service import emit_event, resolve_source_external_id
 from services.inventory_service import move_inventory
 from utils.validation import validate_body
 
@@ -132,6 +132,14 @@ def move(validated):
     # per transfer today, so a future multi-line expansion does not
     # break consumer parsers. Decision K: putaway.confirm does NOT
     # emit, only transfers.move does.
+    # Resolve item canonical UUID to source-system external_id (the SKU
+    # the upstream pusher used at Pipe B time). transfer_external_id stays
+    # canonical: transfers originate inside Sentry -- there's no upstream
+    # source identity to resolve.
+    item_source_external_id = (
+        resolve_source_external_id(g.db, "item", item.external_id)
+        or str(item.external_id)
+    )
     emit_event(
         g.db,
         event_type="transfer.completed",
@@ -147,7 +155,7 @@ def move(validated):
             "to_warehouse_id": to_bin.warehouse_id,
             "lines": [
                 {
-                    "item_external_id": str(item.external_id),
+                    "item_external_id": item_source_external_id,
                     "quantity": quantity,
                 },
             ],

--- a/api/schemas_v1/events/adjustment.applied/1.json
+++ b/api/schemas_v1/events/adjustment.applied/1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://sentry-wms.example/events/adjustment.applied/1.json",
   "title": "adjustment.applied v1",
-  "description": "An inventory adjustment has been applied. Emitted on APPROVED (review_adjustments, cycle_count_id NULL branch) and inline on direct_adjustment. Aggregate: inventory_adjustments.",
+  "description": "An inventory adjustment has been applied. Emitted on APPROVED (review_adjustments, cycle_count_id NULL branch), inline on direct_adjustment, on CSV import, and on the Pipe B inbound inventory-sync path. Aggregate: inventory_adjustments.",
   "type": "object",
   "required": [
     "adjustment_external_id",
@@ -21,9 +21,9 @@
     "quantity_delta": { "type": "integer" },
     "reason_code": { "type": "string" },
     "applied_by_user_external_id": {
-      "type": "string",
+      "type": ["string", "null"],
       "format": "uuid",
-      "description": "The actor who effectuated the inventory change. At review_adjustments this is the APPROVER (g.current_user), not the submitter; at direct_adjustment these are the same admin. Connectors that want the proposer instead should wait for a v2 field such as requested_by_user_external_id."
+      "description": "The actor who effectuated the inventory change. At review_adjustments this is the APPROVER (g.current_user), not the submitter; at direct_adjustment these are the same admin. Null on the Pipe B inbound inventory-sync path, which is system-driven and carries no Sentry user identity. Connectors that want the proposer instead should wait for a v2 field such as requested_by_user_external_id."
     },
     "applied_at": { "type": "string", "format": "date-time" }
   }

--- a/api/services/events_service.py
+++ b/api/services/events_service.py
@@ -124,6 +124,82 @@ def _as_str(value):
     return value
 
 
+def resolve_source_external_id(
+    db,
+    source_type: str,
+    canonical_id,
+    source_system: Optional[str] = None,
+) -> Optional[str]:
+    """Resolve a Sentry canonical UUID back to its source-system external_id.
+
+    Looks up the cross_system_mappings table for the (source_type, canonical_id)
+    pair and returns the source_id -- the identifier the upstream source system
+    (e.g., "erp-connector") used when it Pipe-B pushed the entity to Sentry.
+
+    Returns None when:
+      * No mapping row exists (entity created directly in Sentry without a
+        Pipe-B push, e.g., warehouse-floor manual entry).
+      * canonical_id is None / empty.
+
+    Caller pattern: COALESCE the result with the canonical UUID so the field
+    always carries SOMETHING the consumer can act on:
+
+        source_id = resolve_source_external_id(db, "sales_order", so.external_id)
+        payload["sales_order_external_id"] = source_id or str(so.external_id)
+
+    The canonical UUID stays available on `aggregate_id` (which is what
+    Sentry consumers should use for cross-system idempotency anyway), so the
+    fallback never strands the consumer with no identifier at all.
+
+    source_system filter:
+      When None (default), returns the most-recently-updated mapping for the
+      pair. Single-source deployments (one upstream connector pushing per
+      aggregate) only ever have one row, so ORDER-BY is a no-op there.
+      Multi-source deployments should pass source_system explicitly to
+      pick the right upstream identifier.
+
+    NOTE on field naming: pre-this-change the Sentry event payload's
+    *_external_id fields carried the canonical UUID ("the external id Sentry
+    exposes externally"), forcing every consumer to do this same lookup
+    against Sentry's API on every event. After this change those fields
+    carry the source-system external_id ("the external id from the system
+    that owns the data"), which matches the field-name convention used by
+    every other event-integration system the maintainer knows of, and
+    lets consumers process events without an out-of-band Sentry call.
+    """
+    if canonical_id is None or canonical_id == "":
+        return None
+
+    if source_system is not None:
+        row = db.execute(
+            text(
+                """
+                SELECT source_id
+                FROM cross_system_mappings
+                WHERE canonical_id = :cid
+                  AND source_type = :stype
+                  AND source_system = :ssys
+                LIMIT 1
+                """
+            ),
+            {"cid": str(canonical_id), "stype": source_type, "ssys": source_system},
+        ).fetchone()
+    else:
+        row = db.execute(
+            text(
+                """
+                SELECT source_id
+                FROM cross_system_mappings
+                WHERE canonical_id = :cid AND source_type = :stype
+                ORDER BY last_updated_at DESC
+                LIMIT 1
+                """
+            ),
+            {"cid": str(canonical_id), "stype": source_type},
+        ).fetchone()
+    return row.source_id if row else None
+
+
 def get_user_external_id(db, username: str) -> Optional[str]:
     """Look up ``users.external_id`` by username, cached per-request in ``g``.
 

--- a/api/services/picking_service.py
+++ b/api/services/picking_service.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 
 from services.audit_service import write_audit_log
 from services.connector_stub import enrich_order
-from services.events_service import emit_event, get_user_external_id
+from services.events_service import emit_event, get_user_external_id, resolve_source_external_id
 from services.inventory_service import add_inventory
 
 from constants import (
@@ -974,19 +974,30 @@ def complete_batch(db, batch_id, username):
         if not in_request:
             continue
 
-        # Fetch the SO's lines with item external_ids for the envelope.
+        # Fetch the SO's lines -- resolve item canonical UUIDs to source-system
+        # external_ids via cross_system_mappings; canonical UUID fallback when
+        # no upstream mapping exists. See resolve_source_external_id docstring.
         line_rows = db.execute(
             text(
                 """
-                SELECT i.external_id AS item_external_id, sol.quantity_picked
+                SELECT
+                    COALESCE(csm.source_id, CAST(i.external_id AS TEXT)) AS item_external_id,
+                    sol.quantity_picked
                   FROM sales_order_lines sol
                   JOIN items i ON i.item_id = sol.item_id
+                  LEFT JOIN cross_system_mappings csm
+                    ON csm.canonical_id = i.external_id
+                    AND csm.source_type = 'item'
                  WHERE sol.so_id = :sid
                  ORDER BY sol.line_number
                 """
             ),
             {"sid": so.so_id},
         ).fetchall()
+        so_source_external_id = (
+            resolve_source_external_id(db, "sales_order", so.external_id)
+            or str(so.external_id)
+        )
         emit_event(
             db,
             event_type="pick.confirmed",
@@ -997,7 +1008,7 @@ def complete_batch(db, batch_id, username):
             warehouse_id=so.warehouse_id,
             source_txn_id=source_txn_id,
             payload={
-                "sales_order_external_id": str(so.external_id),
+                "sales_order_external_id": so_source_external_id,
                 "lines": [
                     {
                         "item_external_id": str(line.item_external_id),

--- a/api/services/shipping_service.py
+++ b/api/services/shipping_service.py
@@ -12,7 +12,7 @@ from datetime import timezone
 from sqlalchemy import text
 
 from services.audit_service import write_audit_log
-from services.events_service import emit_event, get_user_external_id
+from services.events_service import emit_event, get_user_external_id, resolve_source_external_id
 
 from constants import (
     SO_SHIPPED,
@@ -242,12 +242,23 @@ def record_ship(
     # column is ship_method; the wire contract renames it to
     # service_level per plan 1.7.1. packages[] mirrors the single
     # synthesised package from pack.confirmed.
+    # Outbound payload uses source-system external_ids (the identifiers the
+    # upstream connector originally pushed to Pipe B), NOT Sentry's internal
+    # canonical UUIDs. COALESCE falls back to the canonical UUID when no
+    # cross_system_mappings row exists (e.g., item created directly via the
+    # admin UI with no Pipe-B push). See resolve_source_external_id docstring
+    # for the field-naming rationale.
     pack_lines = db.execute(
         text(
             """
-            SELECT i.external_id AS item_external_id, sol.quantity_packed
+            SELECT
+                COALESCE(csm.source_id, CAST(i.external_id AS TEXT)) AS item_external_id,
+                sol.quantity_packed
               FROM sales_order_lines sol
               JOIN items i ON i.item_id = sol.item_id
+              LEFT JOIN cross_system_mappings csm
+                ON csm.canonical_id = i.external_id
+                AND csm.source_type = 'item'
              WHERE sol.so_id = :sid
              ORDER BY sol.line_number
             """
@@ -265,7 +276,17 @@ def record_ship(
         ),
         {"sid": so_id},
     ).fetchone()
+    # Resolve the SO's source-system identifier for the outbound payload.
+    # Falls back to the canonical UUID when no cross_system_mappings row
+    # exists (SO created directly in Sentry without a Pipe-B push).
     so_external_id_str = str(so_external_id)
+    so_source_external_id = (
+        resolve_source_external_id(db, "sales_order", so_external_id)
+        or so_external_id_str
+    )
+    # package_external_id stays Sentry-internal (one fulfillment per SO,
+    # synthesised, no upstream identity to map to); continue using the SO
+    # canonical UUID as the package id stem for a stable, traceable value.
     emit_event(
         db,
         event_type="ship.confirmed",
@@ -276,7 +297,7 @@ def record_ship(
         warehouse_id=warehouse_id,
         source_txn_id=source_txn_id,
         payload={
-            "sales_order_external_id": so_external_id_str,
+            "sales_order_external_id": so_source_external_id,
             "tracking_numbers": [tracking_number],
             "carrier": carrier,
             "service_level": ship_method,

--- a/api/tests/test_admin_tokens_inbound.py
+++ b/api/tests/test_admin_tokens_inbound.py
@@ -69,7 +69,7 @@ def ss():
 
 
 class TestScopeCatalogInboundExtensions:
-    def test_inbound_resources_lists_five_keys(self, client, auth_headers):
+    def test_inbound_resources_lists_six_keys(self, client, auth_headers):
         resp = client.get("/api/admin/scope-catalog", headers=auth_headers)
         body = resp.get_json()
         # Plural keys: matches the resource-key dispatch
@@ -77,6 +77,7 @@ class TestScopeCatalogInboundExtensions:
         # wms_tokens.inbound_resources array shape.
         assert set(body["inbound_resources"]) == {
             "sales_orders", "items", "customers", "vendors", "purchase_orders",
+            "inventory_update",
         }
 
     def test_source_systems_reflects_allowlist(self, client, auth_headers, ss):

--- a/api/tests/test_inbound_inventory_update_endpoint.py
+++ b/api/tests/test_inbound_inventory_update_endpoint.py
@@ -1,0 +1,249 @@
+"""POST /api/v1/inbound/inventory_update end-to-end tests.
+
+The state-based inventory sync endpoint differs from the mapping-driven
+resource endpoints: it takes a DESIRED final quantity, computes the delta
+against current on-hand, and applies it as an APPROVED inventory
+adjustment (emitting the adjustment event). These tests cover:
+
+- Apply path: positive delta adds inventory, writes an adjustment row +
+  audit row, emits the adjustment event, returns 201.
+- Idempotent no-op: re-pushing the same target returns 200 with
+  applied_delta=0 and writes no second adjustment.
+- Negative delta removes inventory.
+- item_not_found when no cross_system_mappings row resolves the SKU.
+- inbound_resource scope violation when the token lacks inventory_update.
+"""
+
+import json
+import os
+import sys
+import uuid
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import hashlib
+
+import db_test_context
+from _wms_token_helpers import PEPPER
+from services import token_cache
+
+
+def _exec(sql, params=()):
+    conn = db_test_context.get_raw_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(sql, params)
+        if cur.description is None:
+            return None
+        return cur.fetchall()
+    finally:
+        cur.close()
+
+
+def _query(sql, params=()):
+    return _exec(sql, params)
+
+
+def _insert_token(ss, plaintext, inbound_resources=("inventory_update",)):
+    conn = db_test_context.get_raw_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "INSERT INTO inbound_source_systems_allowlist (source_system, kind) "
+            "VALUES (%s, 'internal_tool') ON CONFLICT DO NOTHING",
+            (ss,),
+        )
+        token_hash = hashlib.sha256((PEPPER + plaintext).encode()).hexdigest()
+        cur.execute(
+            "INSERT INTO wms_tokens "
+            "(token_name, token_hash, status, warehouse_ids, event_types, "
+            " endpoints, source_system, inbound_resources, mapping_override) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING token_id",
+            (
+                f"invupd-test-{uuid.uuid4().hex[:6]}",
+                token_hash, "active",
+                [1], [], [],
+                ss,
+                list(inbound_resources),
+                False,
+            ),
+        )
+        return cur.fetchone()[0]
+    finally:
+        cur.close()
+
+
+def _post(client, plaintext, body):
+    return client.post(
+        "/api/v1/inbound/inventory_update",
+        headers={"X-WMS-Token": plaintext, "Content-Type": "application/json"},
+        data=json.dumps(body),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_cache():
+    token_cache.clear()
+    yield
+    token_cache.clear()
+
+
+@pytest.fixture
+def scenario():
+    """A source system, a fresh item mapped to a source SKU, and a seeded
+    Pickable bin in warehouse 1. The item is created here (not a shared
+    seed row) so the quantity math starts from a known zero."""
+    ss = f"invupd-{uuid.uuid4().hex[:8]}"
+    _query(
+        "INSERT INTO inbound_source_systems_allowlist (source_system, kind) "
+        "VALUES (%s, 'internal_tool') ON CONFLICT DO NOTHING",
+        (ss,),
+    )
+    item_external_id = str(uuid.uuid4())
+    sku = f"INVUPD-SKU-{uuid.uuid4().hex[:8]}"
+    item_id = _query(
+        "INSERT INTO items (sku, item_name, external_id) "
+        "VALUES (%s, %s, %s) RETURNING item_id",
+        (sku, "Inventory Update Test Item", item_external_id),
+    )[0][0]
+    bin_row = _query(
+        "SELECT bin_id, bin_code, warehouse_id FROM bins "
+        "WHERE warehouse_id = 1 AND bin_type = 'Pickable' "
+        "ORDER BY bin_id LIMIT 1"
+    )[0]
+    source_sku = f"SRC-{uuid.uuid4().hex[:8]}"
+    _query(
+        "INSERT INTO cross_system_mappings "
+        "(source_system, source_type, source_id, canonical_type, canonical_id) "
+        "VALUES (%s, 'item', %s, 'item', %s)",
+        (ss, source_sku, item_external_id),
+    )
+    return {
+        "ss": ss,
+        "item_id": item_id,
+        "item_external_id": item_external_id,
+        "source_sku": source_sku,
+        "bin_id": bin_row[0],
+        "bin_code": bin_row[1],
+        "warehouse_id": bin_row[2],
+    }
+
+
+def _onhand(item_id, bin_id):
+    rows = _query(
+        "SELECT quantity_on_hand FROM inventory WHERE item_id = %s AND bin_id = %s",
+        (item_id, bin_id),
+    )
+    return rows[0][0] if rows else 0
+
+
+class TestInventoryUpdateEndpoint:
+    def test_apply_positive_delta_seeds_inventory(self, client, scenario):
+        plaintext = "invupd-apply"
+        _insert_token(scenario["ss"], plaintext)
+        resp = _post(client, plaintext, _body(scenario, 50))
+
+        assert resp.status_code == 201, resp.get_data(as_text=True)
+        body = resp.get_json()
+        assert body["applied_delta"] == 50
+        assert body["current_quantity"] == 50
+        assert body["noop"] is False
+        assert resp.headers["X-Sentry-Canonical-Model"] == "DRAFT-v1"
+
+        # inventory landed in the target bin
+        assert _onhand(scenario["item_id"], scenario["bin_id"]) == 50
+
+        # an APPROVED adjustment row was written for the delta
+        adj = _query(
+            "SELECT quantity_change, status FROM inventory_adjustments "
+            "WHERE item_id = %s AND bin_id = %s ORDER BY adjustment_id DESC LIMIT 1",
+            (scenario["item_id"], scenario["bin_id"]),
+        )
+        assert adj and adj[0][0] == 50 and adj[0][1] == "APPROVED"
+
+        # the adjustment event was emitted onto the outbox
+        ev = _query(
+            "SELECT COUNT(*) FROM integration_events "
+            "WHERE aggregate_type = 'inventory_adjustment' "
+            "  AND aggregate_id = %s",
+            (adj_id_for(scenario),),
+        )
+        assert ev[0][0] >= 1
+
+    def test_same_target_is_idempotent_noop(self, client, scenario):
+        plaintext = "invupd-noop"
+        _insert_token(scenario["ss"], plaintext)
+        first = _post(client, plaintext, _body(scenario, 30))
+        assert first.status_code == 201
+        assert first.get_json()["applied_delta"] == 30
+
+        before = _adjustment_count(scenario)
+        second = _post(client, plaintext, _body(scenario, 30))
+        assert second.status_code == 200
+        body = second.get_json()
+        assert body["applied_delta"] == 0
+        assert body["noop"] is True
+        # no second adjustment row, no extra event
+        assert _adjustment_count(scenario) == before
+
+    def test_lower_target_removes_inventory(self, client, scenario):
+        plaintext = "invupd-remove"
+        _insert_token(scenario["ss"], plaintext)
+        _post(client, plaintext, _body(scenario, 40))
+        resp = _post(client, plaintext, _body(scenario, 15))
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["applied_delta"] == -25
+        assert body["current_quantity"] == 15
+        assert _onhand(scenario["item_id"], scenario["bin_id"]) == 15
+
+    def test_unknown_source_sku_is_404(self, client, scenario):
+        plaintext = "invupd-missing"
+        _insert_token(scenario["ss"], plaintext)
+        body = _body(scenario, 10)
+        body["source_payload"]["item_external_id"] = "NO-SUCH-SKU"
+        resp = _post(client, plaintext, body)
+        assert resp.status_code == 404
+        assert resp.get_json()["error_kind"] == "item_not_found"
+
+    def test_scope_violation_without_inventory_update_resource(self, client, scenario):
+        plaintext = "invupd-scope"
+        _insert_token(scenario["ss"], plaintext, inbound_resources=["sales_orders"])
+        resp = _post(client, plaintext, _body(scenario, 10))
+        assert resp.status_code == 403
+
+
+def _body(scenario, target_quantity):
+    return {
+        "external_id": f"EXT-{uuid.uuid4().hex[:8]}",
+        "external_version": "v1",
+        "source_payload": {
+            "item_external_id": scenario["source_sku"],
+            "bin_code": scenario["bin_code"],
+            "warehouse_id": scenario["warehouse_id"],
+            "target_quantity": target_quantity,
+            "reason_code": "cutover_seed",
+        },
+    }
+
+
+def _adjustment_count(scenario):
+    return _query(
+        "SELECT COUNT(*) FROM inventory_adjustments WHERE item_id = %s AND bin_id = %s",
+        (scenario["item_id"], scenario["bin_id"]),
+    )[0][0]
+
+
+def adj_id_for(scenario):
+    return _query(
+        "SELECT adjustment_id FROM inventory_adjustments "
+        "WHERE item_id = %s AND bin_id = %s ORDER BY adjustment_id DESC LIMIT 1",
+        (scenario["item_id"], scenario["bin_id"]),
+    )[0][0]


### PR DESCRIPTION
Inbound (Pipe B) hardening plus a webhook-payload field-content fix.

- Outbound webhook payloads now carry the source-system external_id in `*_external_id` fields instead of Sentry's internal canonical UUID. A new `events_service.resolve_source_external_id` helper resolves the canonical UUID back to the `source_id` stored on `cross_system_mappings`; callers COALESCE with the canonical UUID so the field always carries something actionable. Updated at every emit site (ship/pack/pick/receipt/transfer/adjustment). Not a version bump: the field-naming contract always meant source-side; the value was the bug.
- New `POST /api/v1/inbound/inventory_update` state-based sync endpoint: the caller sends a desired final quantity, the server computes the delta and applies it as an APPROVED adjustment, emitting the adjustment event. Idempotent (same target = 0-delta no-op). Scoped via a new `inventory_update` inbound resource key.
- The per-token inbound rate limit is env-configurable (`INBOUND_RATE_LIMIT_PER_MINUTE`, default 500).
- System tokens carry no user identity, so inbound adjustments attribute `adjusted_by` to the admin user and the `adjustment.applied/1` schema permits a null `applied_by_user_external_id` for that path.

End-to-end coverage for the new endpoint (apply / idempotent no-op / remove / item-not-found / scope violation).