### PR TITLE
chore: deploy hardening (nginx template, baked mappings, gunicorn timeout)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Repo-root .dockerignore. Keeps the api/ image build context lean even when
+# the Dockerfile is invoked from the repo root (needed so api/Dockerfile can
+# COPY db/mappings/ alongside the api source). Without this, the Docker
+# daemon would also send admin/node_modules, .git, docs/, etc. to the
+# builder -- slow on local builds and wasted bandwidth on `az acr build`.
+**/.git
+**/.gitignore
+**/.DS_Store
+**/__pycache__
+**/*.pyc
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+**/node_modules
+**/dist
+**/build
+**/.next
+
+# Top-level dirs not needed by api or its bake-in mappings
+admin/
+mobile/
+proxy/
+tools/
+docs/
+.github/
+
+# Top-level docs/files
+*.md
+mkdocs.yml
+LICENSE
+NOTICE
+docker-compose*.yml
+package*.json
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ Thumbs.db
 
 # Docker
 pgdata/
+# docker-compose.override.yml is a developer-local override that Compose
+# auto-merges. Keep it out of source control so local build-context tweaks
+# (e.g. pointing the api build at the repo root so its Dockerfile can COPY
+# db/mappings/) stay out of the tracked docker-compose.yml.
+docker-compose.override.yml
 
 # Build outputs
 dist/

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -14,11 +14,21 @@ FROM nginx:1.27-alpine
 # the "nginx" user and listens on port 80. We override the server block
 # to listen on 8080 (allows running the master as non-root) and drop
 # privileges everywhere.
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+#
+# Server-block config is delivered as a template; nginx's
+# /docker-entrypoint.d/20-envsubst-on-templates.sh substitutes ${VAR}
+# placeholders at container start and writes the result into
+# /etc/nginx/conf.d/. Default API_UPSTREAM keeps docker-compose deploys
+# working unchanged; override per-environment (e.g. ACA: sentry-api:5000).
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=builder /app/dist /usr/share/nginx/html
-# Ensure nginx can write runtime state to /var/run and /var/cache/nginx
-# as the unprivileged user.
-RUN chown -R nginx:nginx /var/cache/nginx /usr/share/nginx/html \
+
+ENV API_UPSTREAM_URL=http://api:5000
+ENV API_UPSTREAM_HOST=api:5000
+
+# Ensure nginx can write runtime state to /var/cache/nginx and rewrite
+# /etc/nginx/conf.d/ from the template, all as the unprivileged user.
+RUN chown -R nginx:nginx /var/cache/nginx /usr/share/nginx/html /etc/nginx/conf.d /etc/nginx/templates \
     && chmod -R 755 /usr/share/nginx/html \
     && sed -i -E -e 's|^pid[[:space:]]+/[^;]+;|pid /tmp/nginx.pid;|' \
                  -e '/^user /d' \

--- a/admin/nginx.conf.template
+++ b/admin/nginx.conf.template
@@ -1,7 +1,19 @@
 # Nginx server block for the Sentry WMS admin SPA.
-# Serves built static assets and proxies /api requests to the Flask API
-# so the browser sees a single same-origin surface (no CORS needed for
-# admin-origin calls).
+#
+# Templated form: nginx 1.27 alpine's /docker-entrypoint.d/20-envsubst-on-templates.sh
+# substitutes ${API_UPSTREAM_URL} and ${API_UPSTREAM_HOST} (and any other ${VAR})
+# at container start, writing the resolved file to /etc/nginx/conf.d/default.conf.
+#
+# Plain $foo (without braces) is NOT substituted, so nginx variables like
+# $scheme, $host, $admin_hsts_header pass through untouched.
+#
+# Two env vars (with sane Dockerfile defaults for docker-compose):
+#   API_UPSTREAM_URL   -- full proxy_pass target including scheme
+#                        (e.g. http://api:5000 for compose; https://<fqdn> for ACA)
+#   API_UPSTREAM_HOST  -- value of the Host header sent to the upstream
+#                        (e.g. api:5000 for compose; <fqdn> for ACA -- Azure
+#                        Container Apps' edge gateway routes by Host header,
+#                        so this MUST match the target app's FQDN there)
 
 # V-111: HSTS. Emitted only when the connection was TLS-terminated --
 # either by nginx directly ($scheme = https) or by an upstream reverse
@@ -40,18 +52,24 @@ server {
         return 404;
     }
 
-    # Proxy API traffic to the Flask container. This keeps the admin
-    # origin (http://host:8080) and API origin unified, sidestepping
-    # CORS for admin-initiated requests.
+    # Proxy API traffic to the Flask container. URL + Host filled at
+    # container start by envsubst (see comments at top).
     location /api/ {
-        proxy_pass http://api:5000;
+        proxy_pass ${API_UPSTREAM_URL};
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host ${API_UPSTREAM_HOST};
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 120s;
         proxy_send_timeout 120s;
+
+        # When the upstream is HTTPS (e.g. ACA HTTPS-only ingress), nginx
+        # needs SNI to negotiate TLS against a virtual-host-routed gateway.
+        # These are no-ops for an http:// upstream.
+        proxy_ssl_server_name on;
+        proxy_ssl_name ${API_UPSTREAM_HOST};
     }
 
     # Hashed build assets can be cached aggressively.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -15,10 +15,20 @@ RUN apt-get update \
 
 WORKDIR /app
 
-COPY requirements.txt .
+# Build context is the repo root (so we can COPY db/mappings alongside
+# the api source). The repo-root .dockerignore strips admin/, mobile/,
+# docs/, .git, etc. so the context stays small.
+COPY api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY api/ .
+
+# Bake mapping documents (db/mappings/<source>.yaml) into the image so
+# Pipe B inbound has its schema available at /app/db/mappings without a
+# runtime volume mount. SENTRY_INBOUND_MAPPINGS_DIR=/app/db/mappings in
+# managed-platform deploys (ACA, K8s); docker-compose keeps using its
+# ./db:/db volume mount and points the env var at /db/mappings instead.
+COPY db/mappings /app/db/mappings
 
 # v1.4.2 #73: bake the source version into the image so the app can detect
 # an upgrade-without-rebuild at startup (code pulled but image not rebuilt

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -40,4 +40,8 @@ USER appuser
 
 EXPOSE 5000
 
-CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:create_app()"]
+# --timeout 60: gunicorn's default 30s worker timeout cuts off the
+# slowest PO inbound payloads (wide product-line counts) before the
+# upsert + line-table write completes. 60s gives the canonical write
+# path headroom without masking a runaway query.
+CMD ["gunicorn", "-w", "4", "--timeout", "60", "-b", "0.0.0.0:5000", "app:create_app()"]

--- a/api/tests/test_security_config.py
+++ b/api/tests/test_security_config.py
@@ -1,7 +1,8 @@
 """Infrastructure-level security regression tests.
 
-These tests assert properties of static config files (Dockerfile, nginx.conf,
-docker-compose.yml, .env.example, SECURITY.md, seed SQL) so that fixes to
+These tests assert properties of static config files (Dockerfile,
+nginx.conf.template, docker-compose.yml, .env.example, SECURITY.md, seed SQL)
+so that fixes to
 CRITICAL security findings cannot silently regress.
 
 Each test references the V-id from the Phase 6 audit report.
@@ -155,12 +156,12 @@ class TestV003_AdminDockerfileProduction:
     def test_nginx_config_blocks_vite_dev_paths(self):
         # Any legacy scanner probing Vite's /@fs/, /@id/, /@vite/, or HMR
         # endpoints should get 404 from nginx.
-        nginx_conf = _read("admin/nginx.conf")
+        nginx_conf = _read("admin/nginx.conf.template")
         for pattern in ("@fs", "@id", "@vite", "__vite_hmr"):
             assert pattern in nginx_conf, f"nginx.conf must reference {pattern}"
 
     def test_nginx_spa_fallback_present(self):
-        nginx_conf = _read("admin/nginx.conf")
+        nginx_conf = _read("admin/nginx.conf.template")
         assert "try_files $uri" in nginx_conf
         assert "/index.html" in nginx_conf
 
@@ -218,7 +219,7 @@ class TestV111_AdminNginxHsts:
     LAN deployments run cleartext and HSTS would brick them."""
 
     def test_nginx_adds_hsts_header(self):
-        nginx_conf = _read("admin/nginx.conf")
+        nginx_conf = _read("admin/nginx.conf.template")
         assert "Strict-Transport-Security" in nginx_conf, (
             "nginx.conf must emit Strict-Transport-Security over HTTPS"
         )
@@ -228,13 +229,13 @@ class TestV111_AdminNginxHsts:
         # would pass: "max-age=" appears in the conf. The real guard is that
         # the add_header uses a variable whose value comes from a map keyed
         # on $scheme / $http_x_forwarded_proto.
-        nginx_conf = _read("admin/nginx.conf")
+        nginx_conf = _read("admin/nginx.conf.template")
         assert re.search(
             r"add_header\s+Strict-Transport-Security\s+\$", nginx_conf
         ), "HSTS must be driven by a variable, not an unconditional literal"
 
     def test_nginx_hsts_gated_on_https(self):
-        nginx_conf = _read("admin/nginx.conf")
+        nginx_conf = _read("admin/nginx.conf.template")
         # Map on $scheme must have an "https" -> max-age=... entry.
         assert re.search(
             r"map\s+\$scheme\s+\$\w+\s*\{[^}]*\"https\"\s*\"max-age=",
@@ -243,7 +244,7 @@ class TestV111_AdminNginxHsts:
         ), "nginx.conf must map $scheme=https to an HSTS header value"
 
     def test_nginx_hsts_respects_x_forwarded_proto(self):
-        nginx_conf = _read("admin/nginx.conf")
+        nginx_conf = _read("admin/nginx.conf.template")
         # Must ALSO honor X-Forwarded-Proto: https from an upstream TLS
         # terminator (mirrors api/app.py).
         assert re.search(
@@ -253,7 +254,7 @@ class TestV111_AdminNginxHsts:
         ), "nginx.conf must map X-Forwarded-Proto=https to HSTS so proxied TLS terminations still trigger the header"
 
     def test_nginx_hsts_uses_one_year_includesubdomains(self):
-        nginx_conf = _read("admin/nginx.conf")
+        nginx_conf = _read("admin/nginx.conf.template")
         assert "max-age=31536000" in nginx_conf, "HSTS max-age must be 1 year"
         assert "includeSubDomains" in nginx_conf
 


### PR DESCRIPTION
Deployment-portability changes so one image set runs across docker-compose and managed container platforms (ACA, K8s) without rebuilds.

- `admin/nginx.conf` becomes `admin/nginx.conf.template`; the nginx 1.27 entrypoint substitutes `${API_UPSTREAM_URL}` / `${API_UPSTREAM_HOST}` at container start. Defaults preserve compose behavior; the Host header is separately configurable for edge gateways that route by Host.
- The api image bakes `db/mappings/` so Pipe B inbound has its source-system schemas without a runtime volume mount. The build context moves to the repo root; a repo-root `.dockerignore` keeps the context lean.
- `docker-compose.override.yml` is gitignored so local build-context tweaks stay out of the tracked compose file.
- gunicorn worker timeout raised to 60s so the slowest single-transaction PO inbound writes are not cut off at the default 30s.

The infrastructure security tests now read `nginx.conf.template`; the templating only parameterises the upstream, so every HSTS/proxy-header assertion still holds.