### PR TITLE
feat(orders): pre-allocate inventory for admin-created sales orders

### DIFF
--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -581,6 +581,33 @@ export default function SalesOrders() {
     }
   }
 
+  // Inline stepper for a line's standing reservation. Rarely needed -- the
+  // picking flow normalizes reservations itself -- but lets an operator nudge
+  // quantity_allocated by hand. The server clamps to [picked, ordered] and
+  // reconciles inventory; we just reflect the value it returns.
+  async function adjustLineAllocation(line, delta) {
+    setLineErrors((e) => ({ ...e, [line.so_line_id]: '' }));
+    const res = await api.patch(
+      `/admin/sales-orders/${editing.so_id}/lines/${line.so_line_id}/allocation`,
+      { delta },
+    );
+    if (res?.ok) {
+      const data = await res.json();
+      setEditLines((ls) => ls.map((l) =>
+        l.so_line_id === line.so_line_id
+          ? { ...l, quantity_allocated: data.quantity_allocated }
+          : l,
+      ));
+    } else {
+      let data = null;
+      try { data = await res?.json(); } catch { /* non-JSON body */ }
+      setLineErrors((e) => ({
+        ...e,
+        [line.so_line_id]: formatApiError(data, 'Failed to adjust allocation'),
+      }));
+    }
+  }
+
   function requestRemoveLine(line) {
     if ((line.quantity_allocated || 0) > 0) {
       setReleaseConfirm({ intent: 'delete', line });
@@ -1241,7 +1268,29 @@ export default function SalesOrders() {
                               </div>
                             )}
                           </td>
-                          <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_allocated || 0}</td>
+                          <td style={{ textAlign: 'right' }}>
+                            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                              <button
+                                type="button"
+                                className="btn btn-sm"
+                                style={{ padding: '0 6px' }}
+                                disabled={!lineEditable || (l.quantity_allocated || 0) <= (l.quantity_picked || 0)}
+                                onClick={() => adjustLineAllocation(l, -1)}
+                                title="Release one reserved unit"
+                                aria-label="Decrease allocated"
+                              >-</button>
+                              <span className="mono" style={{ minWidth: 20, textAlign: 'center' }}>{l.quantity_allocated || 0}</span>
+                              <button
+                                type="button"
+                                className="btn btn-sm"
+                                style={{ padding: '0 6px' }}
+                                disabled={!lineEditable || (l.quantity_allocated || 0) >= (l.quantity_ordered || 0)}
+                                onClick={() => adjustLineAllocation(l, 1)}
+                                title="Reserve one more unit"
+                                aria-label="Increase allocated"
+                              >+</button>
+                            </span>
+                          </td>
                           <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_picked || 0}</td>
                           <td className="mono" style={{ textAlign: 'right' }}>{l.quantity_shipped || 0}</td>
                           <td style={{ textAlign: 'right' }}>

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -58,6 +58,7 @@ from schemas.sales_orders import (
     PartialFulfillRequest,
     RevertSalesOrderStatusRequest,
     UpdateSalesOrderAddressRequest,
+    UpdateLineAllocationRequest,
     UpdateSalesOrderLineRequest,
     UpdateSalesOrderMemoRequest,
     UpdateSalesOrderRequest,
@@ -1544,6 +1545,136 @@ def update_sales_order_memo(so_id, validated):
     )
     g.db.commit()
     return jsonify({"so_id": so_id, "memo": new_memo})
+
+
+@admin_bp.route(
+    "/sales-orders/<int:so_id>/lines/<int:so_line_id>/allocation", methods=["PATCH"]
+)
+@require_auth
+@require_admin_or_page_permission("sales-orders")
+@validate_body(UpdateLineAllocationRequest)
+@with_db
+def adjust_sales_order_line_allocation(so_id, so_line_id, validated):
+    """Inline stepper edit of a line's standing inventory reservation.
+
+    A rarely-used manual escape hatch: the picking flow normalizes
+    reservations on its own, but an operator occasionally needs to nudge a
+    line's quantity_allocated by hand. ``delta`` is the signed step; the
+    result is clamped to [quantity_picked, quantity_ordered] and
+    inventory.quantity_allocated is reconciled by the same amount -- reserving
+    from available stock when raising, releasing back when lowering -- so the
+    line-level and inventory-level reservations stay in lockstep.
+    """
+    line = g.db.execute(
+        text(
+            "SELECT sol.so_line_id, sol.item_id, sol.quantity_ordered, "
+            "       sol.quantity_allocated, sol.quantity_picked, so.warehouse_id "
+            "  FROM sales_order_lines sol "
+            "  JOIN sales_orders so ON so.so_id = sol.so_id "
+            " WHERE sol.so_line_id = :lid AND sol.so_id = :sid "
+            " FOR UPDATE OF sol"
+        ),
+        {"lid": so_line_id, "sid": so_id},
+    ).fetchone()
+    if not line:
+        return jsonify({"error": "Sales order line not found"}), 404
+
+    current = line.quantity_allocated
+    # Never below what's already picked (those units left the shelf), never
+    # above what was ordered.
+    target = max(
+        line.quantity_picked,
+        min(line.quantity_ordered, current + validated.delta),
+    )
+    if target == current:
+        return jsonify(
+            {"unchanged": True, "so_line_id": so_line_id, "quantity_allocated": current}
+        ), 200
+
+    if target > current:
+        # Reserve the increase from available stock, fullest bin first. If the
+        # warehouse cannot cover the whole step, reserve what it can; the final
+        # value reflects what was achievable.
+        remaining = target - current
+        rows = g.db.execute(
+            text(
+                "SELECT inventory_id, (quantity_on_hand - quantity_allocated) AS available "
+                "  FROM inventory "
+                " WHERE item_id = :iid AND warehouse_id = :wh "
+                "   AND quantity_on_hand > quantity_allocated "
+                " ORDER BY available DESC, inventory_id "
+                " FOR UPDATE"
+            ),
+            {"iid": line.item_id, "wh": line.warehouse_id},
+        ).fetchall()
+        for inv in rows:
+            if remaining <= 0:
+                break
+            take = min(remaining, int(inv.available))
+            if take <= 0:
+                continue
+            g.db.execute(
+                text(
+                    "UPDATE inventory SET quantity_allocated = quantity_allocated + :q, "
+                    "       updated_at = NOW() WHERE inventory_id = :iid"
+                ),
+                {"q": take, "iid": inv.inventory_id},
+            )
+            remaining -= take
+        target -= remaining  # back off to what could actually be reserved
+    else:
+        # Release the decrease back to inventory, walking allocated rows in the
+        # warehouse-wide lock order.
+        remaining = current - target
+        rows = g.db.execute(
+            text(
+                "SELECT inventory_id, quantity_allocated FROM inventory "
+                " WHERE item_id = :iid AND warehouse_id = :wh "
+                "   AND quantity_allocated > 0 "
+                " ORDER BY inventory_id ASC FOR UPDATE"
+            ),
+            {"iid": line.item_id, "wh": line.warehouse_id},
+        ).fetchall()
+        for inv in rows:
+            if remaining <= 0:
+                break
+            dec = min(remaining, inv.quantity_allocated)
+            g.db.execute(
+                text(
+                    "UPDATE inventory SET quantity_allocated = quantity_allocated - :q, "
+                    "       updated_at = NOW() WHERE inventory_id = :iid"
+                ),
+                {"q": dec, "iid": inv.inventory_id},
+            )
+            remaining -= dec
+
+    if target == current:
+        # A raise that found no free stock: nothing moved.
+        g.db.rollback()
+        return jsonify(
+            {"unchanged": True, "so_line_id": so_line_id, "quantity_allocated": current}
+        ), 200
+
+    g.db.execute(
+        text("UPDATE sales_order_lines SET quantity_allocated = :q WHERE so_line_id = :lid"),
+        {"q": target, "lid": so_line_id},
+    )
+    write_audit_log(
+        g.db,
+        action_type=ACTION_SO_LINE_UPDATED,
+        entity_type="SO",
+        entity_id=so_id,
+        user_id=g.current_user["username"],
+        warehouse_id=line.warehouse_id,
+        details={
+            "field_changed": "quantity_allocated",
+            "so_line_id": so_line_id,
+            "old_value": current,
+            "new_value": target,
+        },
+    )
+    g.db.commit()
+    return jsonify({"so_line_id": so_line_id, "quantity_allocated": target})
 
 
 @admin_bp.route("/sales-orders/<int:so_id>/push-to-queue", methods=["POST"])

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -1175,10 +1175,72 @@ def create_sales_order(validated):
     so_id = result.fetchone()[0]
 
     for line in data["lines"]:
-        g.db.execute(
-            text("INSERT INTO sales_order_lines (so_id, item_id, quantity_ordered, line_number) VALUES (:sid, :iid, :qty, :ln)"),
+        line_result = g.db.execute(
+            text(
+                "INSERT INTO sales_order_lines "
+                "  (so_id, item_id, quantity_ordered, line_number) "
+                "VALUES (:sid, :iid, :qty, :ln) "
+                "RETURNING so_line_id"
+            ),
             {"sid": so_id, "iid": line["item_id"], "qty": line["quantity_ordered"], "ln": line.get("line_number") or 1},
         )
+        so_line_id = line_result.fetchone()[0]
+
+        # Reserve as much of the line as the warehouse can cover right
+        # now. Without this, the SO sits OPEN with quantity_allocated=0
+        # on every line until a picker batches it (hours / days), and
+        # in the meantime POS sales and concurrent inbound orders can
+        # claim the same on_hand stock -- the structural cause of
+        # oversells. Walk the (item, warehouse) inventory rows
+        # in fullest-bin-first order, bumping quantity_allocated until
+        # the line is satisfied or available stock is exhausted.
+        # Partial reservation is fine: the SO line stays OPEN with
+        # quantity_allocated < quantity_ordered and the picker handles
+        # the short later.
+        remaining = int(line["quantity_ordered"])
+        inv_rows = g.db.execute(
+            text(
+                """
+                SELECT inventory_id,
+                       (quantity_on_hand - quantity_allocated) AS available
+                  FROM inventory
+                 WHERE item_id = :iid AND warehouse_id = :wid
+                   AND quantity_on_hand > quantity_allocated
+                 ORDER BY available DESC, inventory_id
+                 FOR UPDATE
+                """
+            ),
+            {"iid": line["item_id"], "wid": data["warehouse_id"]},
+        ).fetchall()
+        allocated_for_line = 0
+        for inv in inv_rows:
+            if remaining <= 0:
+                break
+            take = min(int(inv.available), remaining)
+            if take <= 0:
+                continue
+            g.db.execute(
+                text(
+                    """
+                    UPDATE inventory
+                       SET quantity_allocated = quantity_allocated + :take,
+                           updated_at         = NOW()
+                     WHERE inventory_id = :iid
+                    """
+                ),
+                {"take": take, "iid": inv.inventory_id},
+            )
+            allocated_for_line += take
+            remaining -= take
+        if allocated_for_line > 0:
+            g.db.execute(
+                text(
+                    "UPDATE sales_order_lines "
+                    "   SET quantity_allocated = :alloc "
+                    " WHERE so_line_id = :sid"
+                ),
+                {"alloc": allocated_for_line, "sid": so_line_id},
+            )
 
     g.db.commit()
 

--- a/api/schemas/sales_orders.py
+++ b/api/schemas/sales_orders.py
@@ -174,6 +174,16 @@ class UpdateSalesOrderAddressRequest(BaseModel):
         return self
 
 
+class UpdateLineAllocationRequest(BaseModel):
+    """Inline stepper adjustment for a sales_order_line's standing inventory
+    reservation. ``delta`` is the signed step (+ reserve more, - release); the
+    handler clamps the result to [quantity_picked, quantity_ordered] and
+    reconciles inventory.quantity_allocated by the same amount. A rarely-used
+    manual knob -- the picking flow normalizes reservations on its own."""
+
+    delta: int = Field(..., ge=-1000000, le=1000000)
+
+
 class PartialFulfillLineEntry(BaseModel):
     """Partial-fulfill: per-line short input.
 

--- a/api/services/picking_service.py
+++ b/api/services/picking_service.py
@@ -112,6 +112,76 @@ def _plan_coverage(db, so_lines_by_item, warehouse_id):
     return unpickable_by_so, inv_rows_by_item
 
 
+def _normalize_so_reservations(db, so_id, warehouse_id):
+    """Release each line's standing inventory reservation down to what has
+    already been picked, so the allocation pass re-plans the line from a
+    clean slate.
+
+    A line can reach picking already reserved -- quantity_allocated up to
+    quantity_ordered while quantity_picked is still short -- from POS
+    phone-order checkout (reserve at checkout), admin reserve-at-creation
+    (the oversell guard), or a stranded prior allocation. The coverage and
+    allocation passes both key on `quantity_ordered > quantity_allocated`,
+    so a fully-reserved line produced zero pick_tasks; complete_batch's
+    silently-short guard then refused to finish the batch -- stranding the
+    order OPEN ("already in active pick batch") and poisoning every order in
+    the same batch.
+
+    Releasing the standing reservation first (inventory + line) lets the
+    unchanged allocation below reserve and task the line exactly like any
+    fresh OPEN line. There is no double-book: we release before we
+    re-reserve, all inside the caller's single transaction. The inventory
+    decrement walks the item's rows in inventory_id order (the warehouse-wide
+    lock order) and is approximate per bin -- the original reservation never
+    recorded which bin it claimed -- but the item-level total is exact and
+    the allocation pass re-reserves bin-accurately.
+    """
+    lines = db.execute(
+        text(
+            "SELECT so_line_id, item_id, quantity_allocated, quantity_picked "
+            "  FROM sales_order_lines "
+            " WHERE so_id = :sid AND quantity_allocated > quantity_picked"
+        ),
+        {"sid": so_id},
+    ).fetchall()
+    for ln in lines:
+        remaining = ln.quantity_allocated - ln.quantity_picked
+        inv_rows = db.execute(
+            text(
+                "SELECT inventory_id, quantity_allocated FROM inventory "
+                " WHERE item_id = :iid AND warehouse_id = :wh "
+                "   AND quantity_allocated > 0 "
+                " ORDER BY inventory_id ASC "
+                " FOR UPDATE"
+            ),
+            {"iid": ln.item_id, "wh": warehouse_id},
+        ).fetchall()
+        for r in inv_rows:
+            if remaining <= 0:
+                break
+            dec = min(remaining, r.quantity_allocated)
+            db.execute(
+                text(
+                    "UPDATE inventory "
+                    "   SET quantity_allocated = quantity_allocated - :d, "
+                    "       updated_at = NOW() "
+                    " WHERE inventory_id = :iid"
+                ),
+                {"d": dec, "iid": r.inventory_id},
+            )
+            remaining -= dec
+        # Drop the line's standing reservation to its picked floor; the
+        # allocation pass re-reserves quantity_ordered - quantity_picked.
+        db.execute(
+            text(
+                "UPDATE sales_order_lines "
+                "   SET quantity_allocated = quantity_picked "
+                " WHERE so_line_id = :sid"
+            ),
+            {"sid": ln.so_line_id},
+        )
+
+
 def cancel_prior_user_batches(db, username, warehouse_id):
     """No-Resume rule: a new pick session implicitly invalidates any
     in-progress session for the same operator. Walks the user's
@@ -204,6 +274,13 @@ def create_pick_batch(db, so_identifiers, warehouse_id, username, exclude_so_ids
 
     if not sales_orders:
         raise ValueError("No sales orders to pick (all excluded or empty input)")
+
+    # Normalize standing reservations to the picked floor first, so a line
+    # that arrived already reserved (phone-order checkout, reserve-at-creation,
+    # or a stranded prior allocation) still gets pick_tasks instead of being
+    # skipped by the quantity_ordered > quantity_allocated coverage test.
+    for so in sales_orders:
+        _normalize_so_reservations(db, so.so_id, warehouse_id)
 
     # 1.5 Coverage pre-flight. Build the item -> contributors map FIRST so
     # we can decide which SOs are unpickable BEFORE we insert any
@@ -1332,6 +1409,12 @@ def wave_create(db, so_ids, warehouse_id, username, exclude_so_ids=None):
             raise ValueError(f"SO {so.so_number} has no items")
 
         sales_orders.append(so)
+
+    # Normalize standing reservations to the picked floor before planning, so
+    # already-reserved lines get pick_tasks instead of being skipped. See
+    # _normalize_so_reservations and create_pick_batch for the rationale.
+    for so in sales_orders:
+        _normalize_so_reservations(db, so.so_id, warehouse_id)
 
     # 1.5 Coverage pre-flight. Build line_map BEFORE creating the batch row
     # so an InsufficientCoverageError leaves no half-written batch behind.

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -785,6 +785,88 @@ class TestSalesOrdersPrimaryBin:
         data = resp.get_json()
         assert data["sales_order"]["so_number"] == "SO-2026-021"
 
+    def test_create_sales_order_reserves_inventory_at_insert(self, client, auth_headers):
+        # Closes the structural oversell hole: prior to this change the SO
+        # landed OPEN with quantity_allocated=0 on every line; available
+        # qty (on_hand - allocated) didn't drop until a picker batched it.
+        # Now the create endpoint reserves on the spot.
+        before_oh = _query_val(
+            "SELECT quantity_on_hand FROM inventory "
+            " WHERE item_id = 1 AND bin_id = 3 AND warehouse_id = 1"
+        )
+        before_alloc = _query_val(
+            "SELECT quantity_allocated FROM inventory "
+            " WHERE item_id = 1 AND bin_id = 3 AND warehouse_id = 1"
+        )
+        resp = client.post(
+            "/api/admin/sales-orders",
+            json={
+                "so_number": "SO-2026-ALLOC",
+                "customer_name": "Reservation Test",
+                "warehouse_id": 1,
+                "ship_method": "GROUND",
+                "lines": [{"item_id": 1, "quantity_ordered": 4, "line_number": 1}],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        # on_hand untouched (units still physically there), allocated bumped.
+        after_oh = _query_val(
+            "SELECT quantity_on_hand FROM inventory "
+            " WHERE item_id = 1 AND bin_id = 3 AND warehouse_id = 1"
+        )
+        after_alloc = _query_val(
+            "SELECT quantity_allocated FROM inventory "
+            " WHERE item_id = 1 AND bin_id = 3 AND warehouse_id = 1"
+        )
+        assert int(after_oh) == int(before_oh)
+        assert int(after_alloc) == int(before_alloc) + 4
+        # sales_order_lines.quantity_allocated mirrors the actual reservation.
+        line_alloc = _query_val(
+            "SELECT quantity_allocated FROM sales_order_lines "
+            "  JOIN sales_orders USING (so_id) "
+            " WHERE so_number = 'SO-2026-ALLOC'"
+        )
+        assert int(line_alloc) == 4
+
+    def test_create_sales_order_partial_allocation_when_short(
+        self, client, auth_headers,
+    ):
+        # Ask for more than the warehouse has available. SO still creates
+        # (the marketplace already charged the customer), but quantity_allocated
+        # caps at what we can reserve. Line stays OPEN; picker handles
+        # the short during fulfillment.
+        before_alloc = int(_query_val(
+            "SELECT quantity_allocated FROM inventory "
+            " WHERE item_id = 1 AND bin_id = 3 AND warehouse_id = 1"
+        ))
+        before_oh = int(_query_val(
+            "SELECT quantity_on_hand FROM inventory "
+            " WHERE item_id = 1 AND bin_id = 3 AND warehouse_id = 1"
+        ))
+        available = before_oh - before_alloc
+        ordered = available + 10
+        resp = client.post(
+            "/api/admin/sales-orders",
+            json={
+                "so_number": "SO-2026-SHORT",
+                "warehouse_id": 1,
+                "lines": [{"item_id": 1, "quantity_ordered": ordered, "line_number": 1}],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        line_alloc = int(_query_val(
+            "SELECT quantity_allocated FROM sales_order_lines "
+            "  JOIN sales_orders USING (so_id) "
+            " WHERE so_number = 'SO-2026-SHORT'"
+        ))
+        assert line_alloc == available
+        status = _query_val(
+            "SELECT status FROM sales_orders WHERE so_number = 'SO-2026-SHORT'"
+        )
+        assert status == "OPEN"
+
     def test_create_sales_order_duplicate(self, client, auth_headers):
         resp = client.post("/api/admin/sales-orders", json={
             "so_number": "SO-2026-001", "warehouse_id": 1, "lines": [{"item_id": 1, "quantity_ordered": 1, "line_number": 1}]

--- a/api/tests/test_line_allocation_stepper.py
+++ b/api/tests/test_line_allocation_stepper.py
@@ -1,0 +1,140 @@
+"""Tests for the inline quantity_allocated stepper:
+PATCH /api/admin/sales-orders/<so_id>/lines/<so_line_id>/allocation.
+
+A rarely-used manual knob to nudge a line's standing reservation. Lowering
+releases inventory.quantity_allocated; raising reserves from available stock.
+The result is clamped to [quantity_picked, quantity_ordered], and the line and
+inventory reservations move in lockstep.
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_one(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row
+
+
+def _query_val(sql, params=None):
+    row = _query_one(sql, params)
+    return row[0] if row else None
+
+
+def _exec(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    cur.close()
+
+
+def _first_line():
+    """(so_line_id, item_id) of SO-2026-001's first line."""
+    row = _query_one(
+        "SELECT so_line_id, item_id FROM sales_order_lines "
+        "WHERE so_id = 1 ORDER BY so_line_id LIMIT 1"
+    )
+    return row[0], row[1]
+
+
+def _item_allocated(item_id):
+    return _query_val(
+        "SELECT COALESCE(SUM(quantity_allocated), 0) FROM inventory "
+        "WHERE item_id = %s AND warehouse_id = 1",
+        (item_id,),
+    )
+
+
+def _patch(client, auth_headers, so_line_id, delta):
+    return client.patch(
+        f"/api/admin/sales-orders/1/lines/{so_line_id}/allocation",
+        json={"delta": delta},
+        headers=auth_headers,
+    )
+
+
+class TestAllocationStepper:
+    def test_decrease_releases_inventory(self, client, auth_headers):
+        so_line_id, item_id = _first_line()
+        # Reserve one unit at the line + inventory level.
+        _exec(
+            "UPDATE sales_order_lines SET quantity_allocated = 1, quantity_picked = 0 "
+            "WHERE so_line_id = %s",
+            (so_line_id,),
+        )
+        _exec(
+            "UPDATE inventory SET quantity_allocated = quantity_allocated + 1 "
+            "WHERE inventory_id = (SELECT inventory_id FROM inventory "
+            "WHERE item_id = %s AND warehouse_id = 1 AND quantity_on_hand > 0 "
+            "ORDER BY inventory_id LIMIT 1)",
+            (item_id,),
+        )
+        inv_before = _item_allocated(item_id)
+
+        resp = _patch(client, auth_headers, so_line_id, -1)
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["quantity_allocated"] == 0
+        assert _query_val(
+            "SELECT quantity_allocated FROM sales_order_lines WHERE so_line_id = %s",
+            (so_line_id,),
+        ) == 0
+        assert _item_allocated(item_id) == inv_before - 1
+
+    def test_increase_reserves_inventory(self, client, auth_headers):
+        so_line_id, item_id = _first_line()
+        _exec(
+            "UPDATE sales_order_lines SET quantity_allocated = 0, quantity_picked = 0 "
+            "WHERE so_line_id = %s",
+            (so_line_id,),
+        )
+        inv_before = _item_allocated(item_id)
+        resp = _patch(client, auth_headers, so_line_id, 1)
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["quantity_allocated"] == 1
+        assert _item_allocated(item_id) == inv_before + 1
+
+    def test_clamp_not_below_picked(self, client, auth_headers):
+        so_line_id, _ = _first_line()
+        _exec(
+            "UPDATE sales_order_lines SET quantity_allocated = 1, quantity_picked = 1 "
+            "WHERE so_line_id = %s",
+            (so_line_id,),
+        )
+        resp = _patch(client, auth_headers, so_line_id, -5)
+        assert resp.status_code == 200
+        # Clamped at the picked floor (1); nothing moved.
+        assert _query_val(
+            "SELECT quantity_allocated FROM sales_order_lines WHERE so_line_id = %s",
+            (so_line_id,),
+        ) == 1
+
+    def test_clamp_not_above_ordered(self, client, auth_headers):
+        so_line_id, _ = _first_line()
+        ordered = _query_val(
+            "SELECT quantity_ordered FROM sales_order_lines WHERE so_line_id = %s",
+            (so_line_id,),
+        )
+        _exec(
+            "UPDATE sales_order_lines SET quantity_allocated = %s, quantity_picked = 0 "
+            "WHERE so_line_id = %s",
+            (ordered, so_line_id),
+        )
+        resp = _patch(client, auth_headers, so_line_id, 5)
+        assert resp.status_code == 200
+        assert _query_val(
+            "SELECT quantity_allocated FROM sales_order_lines WHERE so_line_id = %s",
+            (so_line_id,),
+        ) == ordered
+
+    def test_unknown_line_404(self, client, auth_headers):
+        resp = _patch(client, auth_headers, 99999999, -1)
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, client):
+        resp = client.patch(
+            "/api/admin/sales-orders/1/lines/1/allocation", json={"delta": -1}
+        )
+        assert resp.status_code == 401

--- a/api/tests/test_preallocated_pickable.py
+++ b/api/tests/test_preallocated_pickable.py
@@ -1,0 +1,195 @@
+"""Regression tests for the pre-allocated-line poison state.
+
+A sales-order line can reach picking already fully reserved -
+quantity_allocated == quantity_ordered while quantity_picked == 0 - from POS
+phone-order checkout (reserve at checkout), admin reserve-at-creation (the
+oversell guard), or a stranded prior allocation. Before the fix, the coverage
+and allocation passes keyed on `quantity_ordered > quantity_allocated`, so such
+a line got zero pick_tasks; complete_batch's silently-short guard then refused
+to finish the batch, stranding the order OPEN ("already in active pick batch")
+and poisoning every order in the same batch.
+
+picking_service._normalize_so_reservations now releases the standing
+reservation down to the picked floor before planning, so the line is tasked and
+completes like any fresh OPEN line, with no inventory double-book.
+"""
+
+from db_test_context import get_raw_connection
+
+
+def _query_one(sql, params=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(sql, params or ())
+    row = cur.fetchone()
+    cur.close()
+    return row
+
+
+def _query_val(sql, params=None):
+    row = _query_one(sql, params)
+    return row[0] if row else None
+
+
+def _so_item_ids(so_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT DISTINCT item_id FROM sales_order_lines WHERE so_id = %s", (so_id,)
+    )
+    ids = [r[0] for r in cur.fetchall()]
+    cur.close()
+    return ids
+
+
+def _total_allocated(item_ids):
+    if not item_ids:
+        return 0
+    return _query_val(
+        "SELECT COALESCE(SUM(quantity_allocated), 0) FROM inventory "
+        "WHERE item_id = ANY(%s) AND warehouse_id = 1",
+        (item_ids,),
+    )
+
+
+def _reserve_so_at_creation(so_id):
+    """Put every line of the SO into the poison shape: fully allocated at the
+    line level with quantity_picked == 0, and inventory.quantity_allocated
+    bumped to match (a real standing reservation). Returns True only if every
+    line could be fully reserved against pickable stock."""
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT so_line_id, item_id, quantity_ordered "
+        "  FROM sales_order_lines WHERE so_id = %s",
+        (so_id,),
+    )
+    lines = cur.fetchall()
+    fully_reserved = True
+    for so_line_id, item_id, qty in lines:
+        remaining = qty
+        cur.execute(
+            "SELECT inventory_id, (quantity_on_hand - quantity_allocated) AS avail "
+            "  FROM inventory "
+            " WHERE item_id = %s AND warehouse_id = 1 "
+            "   AND (quantity_on_hand - quantity_allocated) > 0 "
+            " ORDER BY avail DESC, inventory_id",
+            (item_id,),
+        )
+        for inv_id, avail in cur.fetchall():
+            if remaining <= 0:
+                break
+            take = min(remaining, avail)
+            cur.execute(
+                "UPDATE inventory SET quantity_allocated = quantity_allocated + %s "
+                "WHERE inventory_id = %s",
+                (take, inv_id),
+            )
+            remaining -= take
+        if remaining > 0:
+            fully_reserved = False
+        cur.execute(
+            "UPDATE sales_order_lines SET quantity_allocated = %s, quantity_picked = 0 "
+            "WHERE so_line_id = %s",
+            (qty, so_line_id),
+        )
+    cur.close()
+    return fully_reserved
+
+
+def _create_batch(client, auth_headers, identifiers):
+    return client.post(
+        "/api/picking/create-batch",
+        json={"so_identifiers": identifiers, "warehouse_id": 1},
+        headers=auth_headers,
+    )
+
+
+def _pick_all_tasks(client, auth_headers, batch_id):
+    while True:
+        nxt = client.get(
+            f"/api/picking/batch/{batch_id}/next", headers=auth_headers
+        ).get_json()
+        if "message" in nxt:
+            break
+        client.post(
+            "/api/picking/confirm",
+            json={
+                "pick_task_id": nxt["pick_task_id"],
+                "scanned_barcode": nxt["upc"],
+                "quantity_picked": nxt["quantity_to_pick"],
+            },
+            headers=auth_headers,
+        )
+
+
+class TestPreAllocatedCreateBatch:
+    def test_poison_precondition(self, client, auth_headers):
+        # Confirm the setup actually reproduces allocated == ordered, picked 0.
+        assert _reserve_so_at_creation(1)
+        row = _query_one(
+            "SELECT MIN(quantity_allocated - quantity_ordered), MAX(quantity_picked) "
+            "FROM sales_order_lines WHERE so_id = 1"
+        )
+        assert row[0] >= 0  # every line allocated >= ordered
+        assert row[1] == 0  # nothing picked yet
+
+    def test_pre_allocated_line_gets_pick_tasks(self, client, auth_headers):
+        _reserve_so_at_creation(1)
+        resp = _create_batch(client, auth_headers, ["SO-2026-001"])
+        assert resp.status_code == 200, resp.get_json()
+        batch_id = resp.get_json()["batch_id"]
+        # The fix: a task exists for the pre-allocated SO (was 0 before).
+        task_count = _query_val(
+            "SELECT COUNT(*) FROM pick_tasks WHERE so_id = 1 AND batch_id = %s",
+            (batch_id,),
+        )
+        assert task_count > 0
+
+    def test_pre_allocated_batch_completes(self, client, auth_headers):
+        _reserve_so_at_creation(1)
+        batch_id = _create_batch(client, auth_headers, ["SO-2026-001"]).get_json()["batch_id"]
+        _pick_all_tasks(client, auth_headers, batch_id)
+        done = client.post(
+            "/api/picking/complete-batch",
+            json={"batch_id": batch_id},
+            headers=auth_headers,
+        )
+        assert done.status_code == 200, done.get_json()
+        assert _query_val("SELECT status FROM sales_orders WHERE so_id = 1") == "PICKED"
+
+    def test_no_inventory_double_book(self, client, auth_headers):
+        item_ids = _so_item_ids(1)
+        _reserve_so_at_creation(1)
+        reserved_baseline = _total_allocated(item_ids)
+        _create_batch(client, auth_headers, ["SO-2026-001"])
+        # Release-then-reallocate nets to the same standing reservation.
+        assert _total_allocated(item_ids) == reserved_baseline
+        # And the line ends up re-reserved at its ordered quantity.
+        assert _query_val(
+            "SELECT MIN(quantity_allocated - quantity_ordered) "
+            "FROM sales_order_lines WHERE so_id = 1"
+        ) == 0
+
+
+class TestPreAllocatedWaveCreate:
+    def test_pre_allocated_wave_gets_tasks_and_completes(self, client, auth_headers):
+        _reserve_so_at_creation(1)
+        resp = client.post(
+            "/api/picking/wave-create",
+            json={"so_ids": [1], "warehouse_id": 1},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.get_json()
+        batch_id = resp.get_json()["batch_id"]
+        assert _query_val(
+            "SELECT COUNT(*) FROM pick_tasks WHERE so_id = 1 AND batch_id = %s",
+            (batch_id,),
+        ) > 0
+        _pick_all_tasks(client, auth_headers, batch_id)
+        done = client.post(
+            "/api/picking/complete-batch",
+            json={"batch_id": batch_id},
+            headers=auth_headers,
+        )
+        assert done.status_code == 200, done.get_json()


### PR DESCRIPTION
Closes the oversell window on admin-created and marketplace-inbound sales orders, and makes already-reserved lines pickable.

## What changes

- **Reserve at SO create.** `POST /admin/sales-orders` now follows each line INSERT with a greedy reservation walk: for each `(item_id, warehouse_id)` it locks the available inventory rows `FOR UPDATE`, takes from the fullest bin first, and bumps `quantity_allocated` until the line is satisfied or stock is exhausted. Previously the order sat OPEN with `quantity_allocated=0` until a picker batched it, and in that gap POS sales and concurrent inbound orders could claim the same on-hand pool. Partial reservation is allowed: a short warehouse still creates the SO and the picker handles the short at fulfillment.
- **Pick pre-reserved lines.** A line can reach picking already fully reserved (from this change, from POS phone-order checkout, or from a stranded prior allocation). The coverage and allocation passes keyed on `quantity_ordered > quantity_allocated`, so such a line got zero pick_tasks and stranded the whole batch. The picking flow now normalizes each line's standing reservation to its picked floor before planning, then re-reserves and tasks it like any fresh line. Applies to `create_pick_batch` and `wave_create`.
- **Manual allocation knob.** `PATCH /admin/sales-orders/<so_id>/lines/<so_line_id>/allocation` takes a signed delta, clamps to `[quantity_picked, quantity_ordered]`, and reconciles `inventory.quantity_allocated`. Surfaced as a minus/plus stepper on the Allocated cell of the SO line table.

No migration; no mobile change.

## Tests

New: `test_preallocated_pickable.py`, `test_line_allocation_stepper.py`, and reserve/partial-allocation cases in `test_admin.py`. Full api suite and admin vitest green.