### PR TITLE
feat(pos): phone-order checkout (reserve, ship-to capture, wire-driven origin)

### DIFF
--- a/api/routes/pos.py
+++ b/api/routes/pos.py
@@ -643,11 +643,13 @@ def checkout():
                     so_id, so_number, so_barcode, status, warehouse_id,
                     created_by, created_at, shipped_at, external_id,
                     order_source, order_type, order_origin,
+                    customer_name, customer_phone, ship_address,
                     external_txn_ref, idempotency_key, idempotency_body_hash
                 ) VALUES (
                     :so_id, :so_number, :so_number, :status, :wh_id,
                     'pos', NOW(), :shipped_at, :ext_id,
                     'pos', 'sale', :order_origin,
+                    :customer_name, :customer_phone, :ship_address,
                     :external_txn_ref, :idempotency_key, :body_hash
                 )
                 ON CONFLICT (idempotency_key) DO NOTHING
@@ -662,6 +664,9 @@ def checkout():
                 "shipped_at":       header_shipped_at,
                 "ext_id":           str(_uuid.uuid4()),
                 "order_origin":     header_order_origin,
+                "customer_name":    body.customer_name,
+                "customer_phone":   body.customer_phone,
+                "ship_address":     body.ship_address,
                 "external_txn_ref": body.external_txn_ref,
                 "idempotency_key":  idempotency_key_str,
                 "body_hash":        body_hash,
@@ -867,6 +872,10 @@ def checkout():
             "payment_method":   body.payment_summary.method,
             "header_warehouse": header_wh_code,
             "is_phone_order":   body.is_phone_order,
+            "customer_name":    body.customer_name,
+            "customer_phone":   body.customer_phone,
+            "customer_email":   body.customer_email,
+            "ship_address":     body.ship_address,
             "lines":            audit_lines,
         },
     )

--- a/api/routes/pos.py
+++ b/api/routes/pos.py
@@ -645,6 +645,10 @@ def checkout():
     # email stay regardless -- those are receipt/loyalty capture that
     # apply to both flows.
     header_ship_address = body.ship_address if body.is_phone_order else None
+    # Structured ship-to (phone-order Phase 3): populate the sales_orders
+    # shipping_address_* columns the picking ticket reads. Gated on phone
+    # order exactly like ship_address -- a counter sale leaves them NULL.
+    header_ship = body.shipping_address if body.is_phone_order else None
     try:
         inserted = g.db.execute(
             text(
@@ -654,12 +658,18 @@ def checkout():
                     created_by, created_at, shipped_at, external_id,
                     order_source, order_type, order_origin,
                     customer_name, customer_phone, ship_address,
+                    shipping_address_name, shipping_address_line1,
+                    shipping_address_line2, shipping_address_city,
+                    shipping_address_state, shipping_address_postal_code,
+                    shipping_address_country, shipping_address_phone,
                     external_txn_ref, idempotency_key, idempotency_body_hash
                 ) VALUES (
                     :so_id, :so_number, :so_number, :status, :wh_id,
                     'pos', NOW(), :shipped_at, :ext_id,
                     'pos', 'sale', :order_origin,
                     :customer_name, :customer_phone, :ship_address,
+                    :ship_name, :ship_line1, :ship_line2, :ship_city,
+                    :ship_state, :ship_postal, :ship_country, :ship_phone,
                     :external_txn_ref, :idempotency_key, :body_hash
                 )
                 ON CONFLICT (idempotency_key) DO NOTHING
@@ -677,6 +687,14 @@ def checkout():
                 "customer_name":    body.customer_name,
                 "customer_phone":   body.customer_phone,
                 "ship_address":     header_ship_address,
+                "ship_name":        header_ship.name if header_ship else None,
+                "ship_line1":       header_ship.line1 if header_ship else None,
+                "ship_line2":       header_ship.line2 if header_ship else None,
+                "ship_city":        header_ship.city if header_ship else None,
+                "ship_state":       header_ship.state if header_ship else None,
+                "ship_postal":      header_ship.postal_code if header_ship else None,
+                "ship_country":     header_ship.country if header_ship else None,
+                "ship_phone":       header_ship.phone if header_ship else None,
                 "external_txn_ref": body.external_txn_ref,
                 "idempotency_key":  idempotency_key_str,
                 "body_hash":        body_hash,

--- a/api/routes/pos.py
+++ b/api/routes/pos.py
@@ -626,6 +626,15 @@ def checkout():
     # two concurrent retries with the same key cannot both create an
     # SO. ON CONFLICT returning zero rows means a peer committed
     # during step 0c -> re-read for the cached body and replay or 409.
+    #
+    # Phone-order mode flips three header fields: status -> OPEN (the SO
+    # enters the existing pick queue instead of bypassing it), shipped_at
+    # -> NULL (the order hasn't shipped; the picker sets it later), and
+    # order_origin -> 'phone-order' (audit + reporting marker per the
+    # mig 063 column comment).
+    header_status = "OPEN" if body.is_phone_order else "SHIPPED"
+    header_shipped_at = None if body.is_phone_order else body.completed_at
+    header_order_origin = "phone-order" if body.is_phone_order else None
     try:
         inserted = g.db.execute(
             text(
@@ -633,12 +642,12 @@ def checkout():
                 INSERT INTO sales_orders (
                     so_id, so_number, so_barcode, status, warehouse_id,
                     created_by, created_at, shipped_at, external_id,
-                    order_source, order_type,
+                    order_source, order_type, order_origin,
                     external_txn_ref, idempotency_key, idempotency_body_hash
                 ) VALUES (
-                    :so_id, :so_number, :so_number, 'SHIPPED', :wh_id,
+                    :so_id, :so_number, :so_number, :status, :wh_id,
                     'pos', NOW(), :shipped_at, :ext_id,
-                    'pos', 'sale',
+                    'pos', 'sale', :order_origin,
                     :external_txn_ref, :idempotency_key, :body_hash
                 )
                 ON CONFLICT (idempotency_key) DO NOTHING
@@ -648,9 +657,11 @@ def checkout():
             {
                 "so_id":            so_id,
                 "so_number":        so_number,
+                "status":           header_status,
                 "wh_id":            header_wh_id,
-                "shipped_at":       body.completed_at,
+                "shipped_at":       header_shipped_at,
                 "ext_id":           str(_uuid.uuid4()),
+                "order_origin":     header_order_origin,
                 "external_txn_ref": body.external_txn_ref,
                 "idempotency_key":  idempotency_key_str,
                 "body_hash":        body_hash,
@@ -736,47 +747,88 @@ def checkout():
                         "available_qty":     available,
                     },
                 )
-            # Insert the SO line. POS sales skip the OPEN -> PICKED ->
-            # PACKED -> SHIPPED lifecycle: a counter sale is fulfilled
-            # the moment Sentry gets the request, so all the per-line
-            # quantity columns equal the line quantity and the line
-            # status is SHIPPED.
-            g.db.execute(
-                text(
-                    """
-                    INSERT INTO sales_order_lines (
-                        so_id, item_id, quantity_ordered, quantity_allocated,
-                        quantity_picked, quantity_packed, quantity_shipped,
-                        line_number, status
-                    ) VALUES (
-                        :so_id, :item_id, :qty, 0,
-                        :qty, :qty, :qty,
-                        :line_number, 'SHIPPED'
-                    )
-                    """
-                ),
-                {
-                    "so_id":       so_id,
-                    "item_id":     r.item_id,
-                    "qty":         ln.quantity,
-                    "line_number": r.idx + 1,
-                },
-            )
-            # Decrement on_hand by the line quantity. POS skips the
-            # allocation reservation step so quantity_allocated stays
-            # 0 on the inventory row; the available calculation
-            # (on_hand - allocated) drops by the line quantity.
-            g.db.execute(
-                text(
-                    """
-                    UPDATE inventory
-                       SET quantity_on_hand = quantity_on_hand - :qty,
-                           updated_at       = NOW()
-                     WHERE inventory_id = :inventory_id
-                    """
-                ),
-                {"qty": ln.quantity, "inventory_id": inv.inventory_id},
-            )
+            if body.is_phone_order:
+                # Phone-order path: SO line lands at status=OPEN with
+                # quantity_allocated=qty (the unit is reserved for this
+                # order). picked/packed/shipped stay 0 -- the picker
+                # advances them when fulfilling.
+                g.db.execute(
+                    text(
+                        """
+                        INSERT INTO sales_order_lines (
+                            so_id, item_id, quantity_ordered, quantity_allocated,
+                            quantity_picked, quantity_packed, quantity_shipped,
+                            line_number, status
+                        ) VALUES (
+                            :so_id, :item_id, :qty, :qty,
+                            0, 0, 0,
+                            :line_number, 'OPEN'
+                        )
+                        """
+                    ),
+                    {
+                        "so_id":       so_id,
+                        "item_id":     r.item_id,
+                        "qty":         ln.quantity,
+                        "line_number": r.idx + 1,
+                    },
+                )
+                # Reserve instead of decrement: bump quantity_allocated
+                # so the available calculation (on_hand - allocated)
+                # drops, but the physical stock stays in its bin
+                # until the picker removes it.
+                g.db.execute(
+                    text(
+                        """
+                        UPDATE inventory
+                           SET quantity_allocated = quantity_allocated + :qty,
+                               updated_at         = NOW()
+                         WHERE inventory_id = :inventory_id
+                        """
+                    ),
+                    {"qty": ln.quantity, "inventory_id": inv.inventory_id},
+                )
+            else:
+                # Counter-sale path: SO line skips the OPEN -> PICKED ->
+                # PACKED -> SHIPPED lifecycle. All per-line quantity
+                # columns equal the line quantity and the line status
+                # is SHIPPED.
+                g.db.execute(
+                    text(
+                        """
+                        INSERT INTO sales_order_lines (
+                            so_id, item_id, quantity_ordered, quantity_allocated,
+                            quantity_picked, quantity_packed, quantity_shipped,
+                            line_number, status
+                        ) VALUES (
+                            :so_id, :item_id, :qty, 0,
+                            :qty, :qty, :qty,
+                            :line_number, 'SHIPPED'
+                        )
+                        """
+                    ),
+                    {
+                        "so_id":       so_id,
+                        "item_id":     r.item_id,
+                        "qty":         ln.quantity,
+                        "line_number": r.idx + 1,
+                    },
+                )
+                # Decrement on_hand by the line quantity. POS skips the
+                # allocation reservation step so quantity_allocated stays
+                # 0 on the inventory row; the available calculation
+                # (on_hand - allocated) drops by the line quantity.
+                g.db.execute(
+                    text(
+                        """
+                        UPDATE inventory
+                           SET quantity_on_hand = quantity_on_hand - :qty,
+                               updated_at       = NOW()
+                         WHERE inventory_id = :inventory_id
+                        """
+                    ),
+                    {"qty": ln.quantity, "inventory_id": inv.inventory_id},
+                )
     except OperationalError as exc:
         if isinstance(exc.orig, (LockNotAvailable, QueryCanceled)):
             g.db.rollback()
@@ -814,6 +866,7 @@ def checkout():
             "total_cents":      body.payment_summary.total_cents,
             "payment_method":   body.payment_summary.method,
             "header_warehouse": header_wh_code,
+            "is_phone_order":   body.is_phone_order,
             "lines":            audit_lines,
         },
     )

--- a/api/routes/pos.py
+++ b/api/routes/pos.py
@@ -635,6 +635,13 @@ def checkout():
     header_status = "OPEN" if body.is_phone_order else "SHIPPED"
     header_shipped_at = None if body.is_phone_order else body.completed_at
     header_order_origin = "phone-order" if body.is_phone_order else None
+    # ship_address is a phone-order concept: the warehouse picker needs to know
+    # where to send the parcel. A counter sale has no shipping leg (the
+    # customer leaves the store with the goods) so the column is forced to
+    # NULL even if the wire body carried a value. customer_name / phone /
+    # email stay regardless -- those are receipt/loyalty capture that
+    # apply to both flows.
+    header_ship_address = body.ship_address if body.is_phone_order else None
     try:
         inserted = g.db.execute(
             text(
@@ -666,7 +673,7 @@ def checkout():
                 "order_origin":     header_order_origin,
                 "customer_name":    body.customer_name,
                 "customer_phone":   body.customer_phone,
-                "ship_address":     body.ship_address,
+                "ship_address":     header_ship_address,
                 "external_txn_ref": body.external_txn_ref,
                 "idempotency_key":  idempotency_key_str,
                 "body_hash":        body_hash,

--- a/api/routes/pos.py
+++ b/api/routes/pos.py
@@ -613,7 +613,7 @@ def checkout():
     so_id = g.db.execute(
         text("SELECT nextval('sales_orders_so_id_seq')")
     ).scalar()
-    so_number = f"SO-POS-{so_id}"
+    so_number = f"POS-{so_id}"
 
     # Header warehouse_id: the SO row carries one warehouse_id (NOT
     # NULL); per-line allocations capture the cross-warehouse truth.
@@ -627,14 +627,17 @@ def checkout():
     # SO. ON CONFLICT returning zero rows means a peer committed
     # during step 0c -> re-read for the cached body and replay or 409.
     #
-    # Phone-order mode flips three header fields: status -> OPEN (the SO
-    # enters the existing pick queue instead of bypassing it), shipped_at
-    # -> NULL (the order hasn't shipped; the picker sets it later), and
-    # order_origin -> 'phone-order' (audit + reporting marker per the
-    # mig 063 column comment).
+    # Phone-order mode flips two header fields: status -> OPEN (the SO
+    # enters the existing pick queue instead of bypassing it) and
+    # shipped_at -> NULL (the order hasn't shipped; the picker sets it
+    # later).
     header_status = "OPEN" if body.is_phone_order else "SHIPPED"
     header_shipped_at = None if body.is_phone_order else body.completed_at
-    header_order_origin = "phone-order" if body.is_phone_order else None
+    # order_origin is wire-driven: POS sends the literal label ("POS" /
+    # "Phone Order") and Sentry stores it as-is. Older POS clients that
+    # do not send the field still land as NULL which is the pre-feature
+    # behaviour.
+    header_order_origin = body.order_origin
     # ship_address is a phone-order concept: the warehouse picker needs to know
     # where to send the parcel. A counter sale has no shipping leg (the
     # customer leaves the store with the goods) so the column is forced to
@@ -1197,7 +1200,7 @@ def refund():
     refund_so_id = g.db.execute(
         text("SELECT nextval('sales_orders_so_id_seq')")
     ).scalar()
-    refund_so_number = f"SO-POS-REF-{refund_so_id}"
+    refund_so_number = f"POS-REF-{refund_so_id}"
 
     # INSERT the credit-memo SO. ON CONFLICT (idempotency_key) DO
     # NOTHING handles the concurrent-retry case; a peer that

--- a/api/schemas/pos.py
+++ b/api/schemas/pos.py
@@ -195,6 +195,14 @@ class CheckoutBody(BaseModel):
     completed_at:      datetime
     payment_summary:   PaymentSummary
     lines:             List[CheckoutLine] = Field(..., min_length=_LINES_MIN, max_length=_LINES_MAX)
+    # When true, the POS cashier was in "phone order" mode: the customer
+    # called in, payment ran at the register (card-on-file or manual entry),
+    # and the warehouse picker will fulfill from open stock. Sentry creates
+    # the SO at status=OPEN, sets order_origin='phone-order', shipped_at
+    # NULL, and reserves stock via inventory.quantity_allocated instead of
+    # the immediate quantity_on_hand decrement that counter sales use.
+    # Default false preserves the pre-feature contract.
+    is_phone_order:    bool            = False
 
 
 # ----------------------------------------------------------------------

--- a/api/schemas/pos.py
+++ b/api/schemas/pos.py
@@ -203,6 +203,17 @@ class CheckoutBody(BaseModel):
     # the immediate quantity_on_hand decrement that counter sales use.
     # Default false preserves the pre-feature contract.
     is_phone_order:    bool            = False
+    # Customer + ship-to capture forwarded from the POS AttachCustomerModal.
+    # Optional always (a walk-in counter sale has no customer). When the
+    # cashier attached a customer, these populate customer_name /
+    # customer_phone / ship_address on the SO row so the picker has the
+    # ship-to without a cross-system lookup. customer_email has no SO
+    # column today so it rides in audit_log.details only (per-order
+    # capture, not promotion to an external customer master).
+    customer_name:     Optional[str]   = Field(None, max_length=200)
+    customer_phone:    Optional[str]   = Field(None, max_length=50)
+    customer_email:    Optional[str]   = Field(None, max_length=200)
+    ship_address:      Optional[str]   = Field(None, max_length=500)
 
 
 # ----------------------------------------------------------------------

--- a/api/schemas/pos.py
+++ b/api/schemas/pos.py
@@ -214,17 +214,23 @@ class CheckoutBody(BaseModel):
     customer_phone:    Optional[str]   = Field(None, max_length=50)
     customer_email:    Optional[str]   = Field(None, max_length=200)
     ship_address:      Optional[str]   = Field(None, max_length=500)
+    # Free-text label written verbatim into sales_orders.order_origin. POS
+    # sends "POS" for a counter sale and "Phone Order" for a phone-order
+    # checkout; Sentry stores whatever it receives without re-deriving from
+    # is_phone_order so the wire is authoritative. 64-char cap matches the
+    # column width in mig 063.
+    order_origin:      Optional[str]   = Field(None, max_length=64)
 
 
 # ----------------------------------------------------------------------
 # Refund body
 # ----------------------------------------------------------------------
 
-# Original SO numbers issued by the POS surface follow "SO-POS-{integer}"
+# Original SO numbers issued by the POS surface follow "POS-{integer}"
 # (see routes/pos.py checkout). Refusing other shapes at the schema
 # boundary prevents a non-POS so_number from ever reaching the DB
 # query and getting conflated with 404 original_so_not_found.
-_ORIGINAL_SO_RE = r"^SO-POS-\d+$"
+_ORIGINAL_SO_RE = r"^POS-\d+$"
 
 
 class RefundBody(BaseModel):

--- a/api/schemas/pos.py
+++ b/api/schemas/pos.py
@@ -168,6 +168,26 @@ class PaymentSummary(BaseModel):
     tenders:        List[Tender] = Field(..., min_length=1, max_length=8)
 
 
+class ShippingAddress(BaseModel):
+    """Structured ship-to forwarded by the POS (phone-order Phase 3). Each
+    field maps to the matching sales_orders.shipping_address_* column (mig
+    053) so the picking ticket renders a real label without a cross-system
+    lookup. The flat ship_address string stays as the legacy mirror the
+    packing/shipping floor screens still read. All fields optional -- a
+    partial, live-typed address still persists."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name:        Optional[str] = Field(None, max_length=200)
+    line1:       Optional[str] = Field(None, max_length=200)
+    line2:       Optional[str] = Field(None, max_length=200)
+    city:        Optional[str] = Field(None, max_length=100)
+    state:       Optional[str] = Field(None, max_length=100)
+    postal_code: Optional[str] = Field(None, max_length=32)
+    country:     Optional[str] = Field(None, max_length=64)
+    phone:       Optional[str] = Field(None, max_length=64)
+
+
 class CheckoutBody(BaseModel):
     """POST /api/v1/pos/checkout body.
 
@@ -220,6 +240,12 @@ class CheckoutBody(BaseModel):
     # is_phone_order so the wire is authoritative. 64-char cap matches the
     # column width in mig 063.
     order_origin:      Optional[str]   = Field(None, max_length=64)
+    # Structured ship-to (phone-order Phase 3). When present, each field is
+    # written to the matching sales_orders.shipping_address_* column (the
+    # picking ticket reads these). ship_address above stays the flattened
+    # mirror for the floor screens still on the legacy column. Gated on
+    # is_phone_order at the route, same as ship_address.
+    shipping_address:  Optional[ShippingAddress] = None
 
 
 # ----------------------------------------------------------------------

--- a/api/tests/test_pos_checkout.py
+++ b/api/tests/test_pos_checkout.py
@@ -25,7 +25,7 @@ lock-aware. Coverage:
   unchanged.
 - Audit log: one POS_CHECKOUT row written with cashier_id as user_id;
   details JSON contains the wire fields.
-- so_number format: SO-POS-<integer>.
+- so_number format: POS-<integer>.
 """
 
 import json
@@ -255,7 +255,7 @@ class TestHappyPath:
         resp = _post(client, pos_token["plaintext"], _card_body())
         assert resp.status_code == 200
         body = resp.get_json()
-        assert body["so_number"].startswith("SO-POS-")
+        assert body["so_number"].startswith("POS-")
         assert body["so_id"] == body["so_number"]
         assert body["replayed"] is False
 
@@ -333,7 +333,7 @@ class TestIdempotency:
         assert b.status_code == 409
         body = b.get_json()
         assert body["error_kind"] == "idempotency_key_reused_with_different_body"
-        assert body["details"]["existing_so_id"].startswith("SO-POS-")
+        assert body["details"]["existing_so_id"].startswith("POS-")
 
     def test_replay_does_not_consume_inventory_twice(self, client, pos_token):
         body = _card_body(qty=2)

--- a/api/tests/test_pos_checkout.py
+++ b/api/tests/test_pos_checkout.py
@@ -478,11 +478,11 @@ class TestFulfillmentFailure:
 
 class TestPhoneOrder:
     """is_phone_order=true flips the checkout into open-order semantics:
-    SO lands at status=OPEN with order_origin='phone-order' and shipped_at
-    NULL; inventory.quantity_allocated bumps instead of on_hand decrementing
-    so the unit stays in its bin until the picker physically removes it.
-    The existing counter-sale path (is_phone_order absent / false) is
-    unchanged."""
+    SO lands at status=OPEN, shipped_at NULL, and inventory.quantity_allocated
+    bumps instead of on_hand decrementing so the unit stays in its bin
+    until the picker physically removes it. order_origin is now wire-driven
+    -- whatever the POS sends in the body lands verbatim in the column. The
+    existing counter-sale path (is_phone_order absent / false) is unchanged."""
 
     def test_creates_open_so_with_phone_order_origin(self, client, pos_token):
         body = _card_body()
@@ -495,9 +495,14 @@ class TestPhoneOrder:
         assert row[5] is None
         assert row[6] == "pos"
 
-    def test_so_row_carries_order_origin_phone_order(self, client, pos_token):
+    def test_so_row_carries_order_origin_from_wire(self, client, pos_token):
+        # order_origin is wire-driven (07299a9): the POS sends the literal
+        # ("Phone Order" for phone orders, "POS" for counter sales) and the
+        # column stores it verbatim. The receiver no longer derives the
+        # value from is_phone_order.
         body = _card_body()
         body["is_phone_order"] = True
+        body["order_origin"] = "Phone Order"
         resp = _post(client, pos_token["plaintext"], body)
         # order_origin isn't in _read_so's projection; query directly.
         conn = get_raw_connection()
@@ -506,7 +511,7 @@ class TestPhoneOrder:
             "SELECT order_origin FROM sales_orders WHERE so_number = %s",
             (resp.get_json()["so_number"],),
         )
-        assert cur.fetchone()[0] == "phone-order"
+        assert cur.fetchone()[0] == "Phone Order"
         cur.close()
 
     def test_inventory_allocates_instead_of_decrementing(self, client, pos_token):

--- a/api/tests/test_pos_checkout.py
+++ b/api/tests/test_pos_checkout.py
@@ -469,3 +469,127 @@ class TestFulfillmentFailure:
         body_json = resp.get_json()
         assert body_json["error_kind"] == "fulfillment_failed"
         assert body_json["details"]["available_qty"] == 50
+
+
+# ----------------------------------------------------------------------
+# Phone-order mode (is_phone_order=true)
+# ----------------------------------------------------------------------
+
+
+class TestPhoneOrder:
+    """is_phone_order=true flips the checkout into open-order semantics:
+    SO lands at status=OPEN with order_origin='phone-order' and shipped_at
+    NULL; inventory.quantity_allocated bumps instead of on_hand decrementing
+    so the unit stays in its bin until the picker physically removes it.
+    The existing counter-sale path (is_phone_order absent / false) is
+    unchanged."""
+
+    def test_creates_open_so_with_phone_order_origin(self, client, pos_token):
+        body = _card_body()
+        body["is_phone_order"] = True
+        resp = _post(client, pos_token["plaintext"], body)
+        assert resp.status_code == 200
+        row = _read_so(resp.get_json()["so_number"])
+        # row[2] = status, row[5] = shipped_at, row[6] = order_source.
+        assert row[2] == "OPEN"
+        assert row[5] is None
+        assert row[6] == "pos"
+
+    def test_so_row_carries_order_origin_phone_order(self, client, pos_token):
+        body = _card_body()
+        body["is_phone_order"] = True
+        resp = _post(client, pos_token["plaintext"], body)
+        # order_origin isn't in _read_so's projection; query directly.
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT order_origin FROM sales_orders WHERE so_number = %s",
+            (resp.get_json()["so_number"],),
+        )
+        assert cur.fetchone()[0] == "phone-order"
+        cur.close()
+
+    def test_inventory_allocates_instead_of_decrementing(self, client, pos_token):
+        # TST-001 starts at 50 in bin 3, warehouse 1.
+        before = _read_inventory(item_id=1, bin_id=3, warehouse_id=1)
+        body = _card_body(qty=3)
+        body["is_phone_order"] = True
+        resp = _post(client, pos_token["plaintext"], body)
+        assert resp.status_code == 200
+        after = _read_inventory(item_id=1, bin_id=3, warehouse_id=1)
+        # on_hand unchanged (units physically still in the bin), allocated
+        # bumped by the order quantity.
+        assert int(after[0]) == int(before[0])
+        assert int(after[1]) == int(before[1]) + 3
+
+    def test_so_line_lands_at_status_open_with_quantity_allocated(
+        self, client, pos_token,
+    ):
+        body = _card_body(qty=2)
+        body["is_phone_order"] = True
+        resp = _post(client, pos_token["plaintext"], body)
+        so_number = resp.get_json()["so_number"]
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT quantity_ordered, quantity_allocated, quantity_picked,
+                   quantity_packed, quantity_shipped, status
+              FROM sales_order_lines
+             WHERE so_id = (SELECT so_id FROM sales_orders WHERE so_number = %s)
+            """,
+            (so_number,),
+        )
+        line = cur.fetchone()
+        cur.close()
+        assert line[0] == 2  # ordered
+        assert line[1] == 2  # allocated
+        assert line[2] == 0  # picked
+        assert line[3] == 0  # packed
+        assert line[4] == 0  # shipped
+        assert line[5] == "OPEN"
+
+    def test_available_check_still_blocks_oversell_in_phone_order_mode(
+        self, client, pos_token,
+    ):
+        # TST-001 has 50 on_hand. Ask for 51 in phone-order mode -- still
+        # fails: available (on_hand - allocated) is the gate for both paths.
+        body = _card_body(qty=51)
+        body["is_phone_order"] = True
+        resp = _post(client, pos_token["plaintext"], body)
+        assert resp.status_code == 422
+        assert resp.get_json()["error_kind"] == "fulfillment_failed"
+
+    def test_audit_log_records_is_phone_order_flag(self, client, pos_token):
+        body = _card_body()
+        body["is_phone_order"] = True
+        resp = _post(client, pos_token["plaintext"], body)
+        so_number = resp.get_json()["so_number"]
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT so_id FROM sales_orders WHERE so_number = %s", (so_number,),
+        )
+        so_id = cur.fetchone()[0]
+        cur.close()
+        audit_row = _read_audit_for_so(so_id)
+        assert audit_row is not None
+        details = audit_row[3]
+        if isinstance(details, str):
+            details = json.loads(details)
+        assert details["is_phone_order"] is True
+
+    def test_default_omitted_field_keeps_counter_sale_semantics(
+        self, client, pos_token,
+    ):
+        # Sanity check: a body WITHOUT is_phone_order (the existing
+        # contract) still lands SHIPPED, decrements on_hand, allocated
+        # unchanged. Guards against regressions in the default branch.
+        before = _read_inventory(item_id=1, bin_id=3, warehouse_id=1)
+        resp = _post(client, pos_token["plaintext"], _card_body(qty=2))
+        assert resp.status_code == 200
+        row = _read_so(resp.get_json()["so_number"])
+        assert row[2] == "SHIPPED"
+        after = _read_inventory(item_id=1, bin_id=3, warehouse_id=1)
+        assert int(after[0]) == int(before[0]) - 2
+        assert int(after[1]) == int(before[1])

--- a/api/tests/test_pos_checkout.py
+++ b/api/tests/test_pos_checkout.py
@@ -514,6 +514,75 @@ class TestPhoneOrder:
         assert cur.fetchone()[0] == "Phone Order"
         cur.close()
 
+    def test_structured_ship_address_persisted_to_columns(self, client, pos_token):
+        # Phone-order Phase 3: the POS forwards a structured shipping_address
+        # object; the receiver writes each field to the matching
+        # sales_orders.shipping_address_* column the picking ticket reads, and
+        # keeps the flat ship_address as the legacy floor-screen mirror.
+        body = _card_body()
+        body["is_phone_order"] = True
+        body["ship_address"] = "Pat Angler\n1 Test St\nTestville, CO 80000"
+        body["shipping_address"] = {
+            "name": "Pat Angler",
+            "line1": "1 Test St",
+            "line2": "Apt 4",
+            "city": "Testville",
+            "state": "CO",
+            "postal_code": "80000",
+            "country": "US",
+            "phone": "+13035550000",
+        }
+        resp = _post(client, pos_token["plaintext"], body)
+        assert resp.status_code == 200
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT shipping_address_name, shipping_address_line1,
+                   shipping_address_line2, shipping_address_city,
+                   shipping_address_state, shipping_address_postal_code,
+                   shipping_address_country, shipping_address_phone,
+                   ship_address
+              FROM sales_orders WHERE so_number = %s
+            """,
+            (resp.get_json()["so_number"],),
+        )
+        row = cur.fetchone()
+        cur.close()
+        assert row[0] == "Pat Angler"
+        assert row[1] == "1 Test St"
+        assert row[2] == "Apt 4"
+        assert row[3] == "Testville"
+        assert row[4] == "CO"
+        assert row[5] == "80000"
+        assert row[6] == "US"
+        assert row[7] == "+13035550000"
+        assert row[8] == "Pat Angler\n1 Test St\nTestville, CO 80000"
+
+    def test_counter_sale_leaves_structured_ship_address_null(self, client, pos_token):
+        # A counter sale (is_phone_order false) has no shipping leg, so the
+        # structured columns are forced NULL even if a body carries them --
+        # same gate ship_address already uses.
+        body = _card_body()
+        body["shipping_address"] = {
+            "line1": "999 Should Not Persist",
+            "city": "Nowhere",
+        }
+        resp = _post(client, pos_token["plaintext"], body)
+        assert resp.status_code == 200
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT shipping_address_line1, shipping_address_city, ship_address "
+            "FROM sales_orders WHERE so_number = %s",
+            (resp.get_json()["so_number"],),
+        )
+        row = cur.fetchone()
+        cur.close()
+        assert row[0] is None
+        assert row[1] is None
+        assert row[2] is None
+
     def test_inventory_allocates_instead_of_decrementing(self, client, pos_token):
         # TST-001 starts at 50 in bin 3, warehouse 1.
         before = _read_inventory(item_id=1, bin_id=3, warehouse_id=1)

--- a/api/tests/test_pos_refund.py
+++ b/api/tests/test_pos_refund.py
@@ -265,7 +265,7 @@ class TestAuthAndHeader:
             headers={"Content-Type": "application/json"},
             data=json.dumps({
                 "idempotency_key":           _new_uuid(),
-                "original_so_id":            "SO-POS-1",
+                "original_so_id":            "POS-1",
                 "original_external_txn_ref": "x",
                 "external_refund_ref":       "y",
                 "cashier_id":                "mike",
@@ -285,7 +285,7 @@ class TestAuthAndHeader:
     def test_404_response_carries_draft_header(self, client, pos_token):
         resp = _post_refund(client, pos_token["plaintext"], {
             "idempotency_key":           _new_uuid(),
-            "original_so_id":            "SO-POS-999999",
+            "original_so_id":            "POS-999999",
             "original_external_txn_ref": "x",
             "external_refund_ref":       "y",
             "cashier_id":                "mike",
@@ -327,7 +327,7 @@ class TestHappyPath:
         assert refund_resp.status_code == 200
         body = refund_resp.get_json()
         assert body["original_so_id"] == sale_so_number
-        assert body["refund_so_id"].startswith("SO-POS-REF-")
+        assert body["refund_so_id"].startswith("POS-REF-")
         assert body["replayed"] is False
 
         # Inventory back to original.
@@ -418,7 +418,7 @@ class TestRuleGuards:
     def test_unknown_original_so_returns_404(self, client, pos_token):
         rb = {
             "idempotency_key":           _new_uuid(),
-            "original_so_id":            "SO-POS-999999",
+            "original_so_id":            "POS-999999",
             "original_external_txn_ref": "x",
             "external_refund_ref":       "y",
             "cashier_id":                "mike",
@@ -519,7 +519,7 @@ class TestBodyValidation:
     def test_bad_uuid_idempotency_key_returns_422(self, client, pos_token):
         rb = {
             "idempotency_key":           "not-a-uuid",
-            "original_so_id":            "SO-POS-1",
+            "original_so_id":            "POS-1",
             "original_external_txn_ref": "x",
             "external_refund_ref":       "y",
             "cashier_id":                "mike",


### PR DESCRIPTION
Adds a phone-order path to POS checkout: a phoned-in order is paid at the register but fulfilled by the warehouse, so it must enter the pick queue with a real ship-to instead of bypassing to SHIPPED. Builds on the pre-allocation reservation work (#396).

## What changes

- **`is_phone_order` flag** (default false, counter-sale contract preserved). When set, the SO is created at `status=OPEN`, `shipped_at` NULL, and each line reserves stock via `quantity_allocated` instead of decrementing `quantity_on_hand` -- the unit stays in its bin until the picker removes it.
- **Customer + ship-to capture.** Checkout accepts optional `customer_name`, `customer_phone`, `customer_email`, and a structured `shipping_address` object. On a phone order the structured fields persist to the matching `sales_orders.shipping_address_*` columns (mig 053) so the picking ticket renders a real label without a cross-system lookup; the flat `ship_address` stays as the floor-screen mirror. `customer_email` (no SO column) rides in `audit_log.details`. Counter sales ignore the shipping fields (no shipping leg).
- **Wire-driven `order_origin`.** The POS sends the literal label ("POS" / "Phone Order") and Sentry stores it verbatim rather than deriving from `is_phone_order`; older clients that omit it land as NULL.
- **POS-N SO numbers.** `SO-POS-<n>` becomes `POS-<n>` and `SO-POS-REF-<n>` becomes `POS-REF-<n>`.

api-only; no migration; no mobile change.

## Tests

`test_pos_checkout.py` gains the `TestPhoneOrder` suite (open-SO semantics, allocate-not-decrement, wire-driven origin, structured ship-to persistence); checkout/refund SO-number expectations updated. Full api suite green.