### PR TITLE
feat(dockd): item lookup endpoint + qty_ordered on the order payload

### DIFF
--- a/api/middleware/auth_middleware.py
+++ b/api/middleware/auth_middleware.py
@@ -405,6 +405,11 @@ _V190_DOCKD_FLASK_ENDPOINTS = frozenset({
     "dockd.get_order",
     "dockd.ship_order",
     "dockd.void_ship",
+    # Item lookup by UPC / SKU / barcode alias. Used by dockd's Bin
+    # Sticker and Item Labels (lookup mode) features. Same slug
+    # (dockd.dispatch); any existing dockd token can hit it without a
+    # re-mint.
+    "dockd.get_item",
 })
 
 

--- a/api/routes/dockd.py
+++ b/api/routes/dockd.py
@@ -239,6 +239,127 @@ def get_order(so_number):
 
 
 # ----------------------------------------------------------------------
+# GET /api/v1/dockd/items/<barcode>
+# ----------------------------------------------------------------------
+#
+# Token-authed item lookup for dockd's Bin Sticker + Item Labels
+# (lookup mode) features. The admin lookup at /api/lookup/item/<barcode>
+# uses @require_auth (cookie/JWT) and so refuses a dockd X-WMS-Token.
+# Same SQL, same response shape -- the dockd client treats them as
+# interchangeable. Warehouse scope comes from the token's warehouse_ids
+# (the wms_token decorator path), filtering locations only; the item
+# itself still 200s when it exists since the catalog row isn't
+# warehouse-scoped.
+
+_BARCODE_RE = re.compile(r"^[A-Za-z0-9_\-./]+$")
+_BARCODE_MAX_LEN = 128
+
+
+def _validate_barcode(barcode):
+    """Mirrors _validate_so_number: returns None when valid, else an
+    error response. Defense in depth on top of bind-parameter handling."""
+    if not barcode or len(barcode) > _BARCODE_MAX_LEN:
+        return _err("invalid_barcode", "barcode length out of range", 422)
+    if not _BARCODE_RE.match(barcode):
+        return _err(
+            "invalid_barcode",
+            "barcode contains disallowed characters",
+            422,
+        )
+    return None
+
+
+@dockd_bp.route("/items/<barcode>", methods=["GET"])
+@require_wms_token
+@limiter.limit("60 per minute")
+@with_db
+def get_item(barcode):
+    """Dockd item lookup by UPC, SKU, or barcode alias.
+
+    Mirrors GET /api/lookup/item/<barcode> in routes/lookup.py but is
+    auth-gated for machine-to-machine WMS tokens. Response shape is
+    identical so the dockd client consumes either endpoint without
+    branching.
+    """
+    barcode = (barcode or "").strip()
+    err = _validate_barcode(barcode)
+    if err is not None:
+        return err
+
+    item_row = g.db.execute(
+        text(
+            """
+            SELECT item_id, sku, item_name, upc, category, weight_lbs
+            FROM items
+            WHERE upc = :barcode
+               OR sku = :barcode
+               OR barcode_aliases @> CAST(:barcode_json AS jsonb)
+            LIMIT 1
+            """
+        ),
+        {"barcode": barcode, "barcode_json": f'["{barcode}"]'},
+    ).fetchone()
+
+    if not item_row:
+        return _err("not_found", f"item '{barcode}' not found", 404)
+
+    location_rows = g.db.execute(
+        text(
+            """
+            SELECT i.bin_id, b.bin_code, b.bin_type, z.zone_name,
+                   i.quantity_on_hand, i.quantity_allocated,
+                   (i.quantity_on_hand - i.quantity_allocated) AS quantity_available,
+                   i.lot_number, i.warehouse_id
+            FROM inventory i
+            JOIN bins b ON b.bin_id = i.bin_id
+            LEFT JOIN zones z ON z.zone_id = b.zone_id
+            WHERE i.item_id = :item_id
+            """
+        ),
+        {"item_id": item_row.item_id},
+    ).fetchall()
+
+    # WMS tokens are warehouse-scoped via the @require_wms_token
+    # decorator; honour that scope rather than the per-user role check
+    # the JWT route does. A token with no warehouse_ids sees no
+    # locations (defensive: matches get_order's "empty scope = no
+    # data" rule).
+    allowed_wids = set(g.current_token.get("warehouse_ids") or [])
+    if allowed_wids:
+        location_rows = [
+            r for r in location_rows if r.warehouse_id in allowed_wids
+        ]
+    else:
+        location_rows = []
+
+    return _draft_response({
+        "item": {
+            "item_id": item_row.item_id,
+            "sku": item_row.sku,
+            "item_name": item_row.item_name,
+            "upc": item_row.upc,
+            "category": item_row.category,
+            "weight_lbs": (
+                float(item_row.weight_lbs) if item_row.weight_lbs else None
+            ),
+        },
+        "locations": [
+            {
+                "bin_id": r.bin_id,
+                "bin_code": r.bin_code,
+                "bin_type": r.bin_type,
+                "zone_name": r.zone_name,
+                "quantity_on_hand": r.quantity_on_hand,
+                "quantity_allocated": r.quantity_allocated,
+                "quantity_available": r.quantity_available,
+                "lot_number": r.lot_number,
+            }
+            for r in location_rows
+        ],
+    }, 200)
+
+
+# ----------------------------------------------------------------------
 # POST /api/v1/dockd/orders/<so_number>/ship
 # ----------------------------------------------------------------------
 

--- a/api/routes/dockd.py
+++ b/api/routes/dockd.py
@@ -139,11 +139,18 @@ def get_order(so_number):
     if not so:
         return _err("not_found", "order not found", 404)
 
+    # qty vs qty_ordered: qty is "what's physically in the tote awaiting
+    # scan-verify" (quantity_picked). qty_ordered is the original order
+    # quantity. They diverge only when a line was short-picked or
+    # partial-fulfilled (the BO child carries the residual). Surfacing
+    # both lets dockd render "Verify N of M ordered" without the
+    # operator cross-referencing Sentry's admin UI to spot a short.
     items = g.db.execute(
         text(
             """
             SELECT i.external_id AS item_external_id, i.sku, i.item_name,
-                   i.upc, sol.quantity_picked AS qty
+                   i.upc, sol.quantity_picked AS qty,
+                   sol.quantity_ordered AS qty_ordered
               FROM sales_order_lines sol
               JOIN items i ON i.item_id = sol.item_id
              WHERE sol.so_id = :so_id
@@ -202,6 +209,7 @@ def get_order(so_number):
                 "display_name": it.item_name,
                 "upc": it.upc,
                 "qty": it.qty,
+                "qty_ordered": it.qty_ordered,
             }
             for it in items
         ],

--- a/api/services/dockd_openapi.py
+++ b/api/services/dockd_openapi.py
@@ -93,13 +93,33 @@ _ADDRESS_SCHEMA: Dict[str, Any] = {
 _GET_ORDER_ITEM_SCHEMA: Dict[str, Any] = {
     "type": "object",
     "additionalProperties": False,
-    "required": ["external_id", "sku", "display_name", "upc", "qty"],
+    "required": [
+        "external_id", "sku", "display_name", "upc", "qty", "qty_ordered",
+    ],
     "properties": {
         "external_id":  {"type": "string", "format": "uuid"},
         "sku":          {"type": "string"},
         "display_name": {"type": "string"},
         "upc":          {"type": ["string", "null"]},
-        "qty":          {"type": "integer"},
+        "qty": {
+            "type": "integer",
+            "description": (
+                "Units physically in the tote awaiting scan-verify. "
+                "Equals sales_order_lines.quantity_picked on the "
+                "Sentry side. Use this as the verify-target on dockd."
+            ),
+        },
+        "qty_ordered": {
+            "type": "integer",
+            "description": (
+                "Units the customer originally ordered. Equals "
+                "sales_order_lines.quantity_ordered on the Sentry "
+                "side. qty < qty_ordered means the line was short-"
+                "picked or partial-fulfilled; the difference will "
+                "not ship on this SO (a backorder child SO carries "
+                "the residual in the partial-fulfill case)."
+            ),
+        },
     },
 }
 

--- a/api/tests/test_dockd_get_item.py
+++ b/api/tests/test_dockd_get_item.py
@@ -1,0 +1,345 @@
+"""GET /api/v1/dockd/items/<barcode> contract.
+
+Auth-gated item lookup for dockd's Bin Sticker + Item Labels (lookup
+mode) features. Mirrors the lookup_bp shape but takes an X-WMS-Token.
+
+Coverage:
+- 200 happy path: response shape + DRAFT-v1 header + item/locations
+- 200 SKU lookup matches by sku
+- 200 UPC lookup matches by upc
+- 200 alias lookup matches by barcode_aliases @> ...
+- Warehouse scoping: locations in non-allowed warehouses are filtered
+  from the response; the item still 200s (catalog row isn't warehouse-
+  scoped)
+- 404 not_found body shape + DRAFT-v1 header
+- 422 invalid_barcode for malformed path parameter
+- 401 missing / unknown token
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from _wms_token_helpers import delete_token, insert_token
+from db_test_context import get_raw_connection
+from services import token_cache
+
+
+@pytest.fixture(autouse=True)
+def _fresh_token_cache():
+    token_cache.clear()
+    yield
+    token_cache.clear()
+
+
+@pytest.fixture()
+def dockd_token(seed_data):
+    """Pure-direction dockd station token: dockd.dispatch slug,
+    warehouse_id 1, no inbound / outbound markers."""
+    plaintext = f"dockd-item-test-{uuid.uuid4()}"
+    token_id = insert_token(
+        name="Item Lookup Station",
+        plaintext=plaintext,
+        warehouse_ids=[1],
+        event_types=[],
+        inbound_resources=[],
+        source_system=None,
+        endpoints=["dockd.dispatch"],
+    )
+    yield {"plaintext": plaintext, "token_id": token_id}
+    delete_token(token_id)
+
+
+@pytest.fixture()
+def dockd_token_other_warehouse(seed_data):
+    plaintext = f"dockd-item-test-wh99-{uuid.uuid4()}"
+    token_id = insert_token(
+        name="Other Warehouse Station",
+        plaintext=plaintext,
+        warehouse_ids=[99],
+        event_types=[],
+        inbound_resources=[],
+        source_system=None,
+        endpoints=["dockd.dispatch"],
+    )
+    yield {"plaintext": plaintext, "token_id": token_id}
+    delete_token(token_id)
+
+
+def _insert_item(sku=None, item_name="Widget", upc="0123456789012",
+                 category="general", weight_lbs=None, barcode_aliases=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    sku = sku or f"SKU-{uuid.uuid4().hex[:8]}"
+    cur.execute(
+        "INSERT INTO items "
+        "  (sku, item_name, upc, category, weight_lbs, "
+        "   barcode_aliases, external_id) "
+        "VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s) RETURNING item_id",
+        (
+            sku, item_name, upc, category, weight_lbs,
+            barcode_aliases, str(uuid.uuid4()),
+        ),
+    )
+    item_id = cur.fetchone()[0]
+    cur.close()
+    return item_id, sku
+
+
+def _set_inv(item_id, bin_id, qty_on_hand, qty_allocated=0, warehouse_id=1):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO inventory "
+        "  (item_id, bin_id, warehouse_id, quantity_on_hand, quantity_allocated) "
+        "VALUES (%s, %s, %s, %s, %s) "
+        "ON CONFLICT (item_id, bin_id, lot_number) DO UPDATE "
+        "SET quantity_on_hand = EXCLUDED.quantity_on_hand, "
+        "    quantity_allocated = EXCLUDED.quantity_allocated",
+        (item_id, bin_id, warehouse_id, qty_on_hand, qty_allocated),
+    )
+    cur.close()
+
+
+# ----------------------------------------------------------------------
+# Auth + DRAFT header
+# ----------------------------------------------------------------------
+
+
+class TestAuthAndHeader:
+    def test_missing_token_returns_401(self, client):
+        resp = client.get("/api/v1/dockd/items/SKU-X")
+        assert resp.status_code == 401
+
+    def test_unknown_token_returns_401(self, client, seed_data):
+        resp = client.get(
+            "/api/v1/dockd/items/SKU-X",
+            headers={"X-WMS-Token": "not-real"},
+        )
+        assert resp.status_code == 401
+
+    def test_happy_response_carries_draft_header(self, client, dockd_token):
+        item_id, sku = _insert_item()
+        resp = client.get(
+            f"/api/v1/dockd/items/{sku}",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.headers["X-Sentry-Canonical-Model"] == "DRAFT-v1"
+
+    def test_404_response_carries_draft_header(self, client, dockd_token):
+        resp = client.get(
+            "/api/v1/dockd/items/SKU-DOES-NOT-EXIST",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        assert resp.status_code == 404
+        assert resp.headers["X-Sentry-Canonical-Model"] == "DRAFT-v1"
+        body = resp.get_json()
+        assert body["error_kind"] == "not_found"
+
+    def test_422_response_carries_draft_header(self, client, dockd_token):
+        resp = client.get(
+            "/api/v1/dockd/items/has spaces",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        assert resp.status_code == 422
+        assert resp.headers["X-Sentry-Canonical-Model"] == "DRAFT-v1"
+        body = resp.get_json()
+        assert body["error_kind"] == "invalid_barcode"
+
+
+# ----------------------------------------------------------------------
+# Path-parameter validation
+# ----------------------------------------------------------------------
+
+
+class TestPathParameter:
+    def test_disallowed_chars_return_422(self, client, dockd_token):
+        # Single quote / semicolon are explicitly rejected -- the bind
+        # parameter handling is the real defence, but the regex is the
+        # outer wall so a SQL-injection-shaped path never gets close
+        # to the DB.
+        resp = client.get(
+            "/api/v1/dockd/items/has'chars",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        assert resp.status_code == 422
+        assert resp.get_json()["error_kind"] == "invalid_barcode"
+
+    def test_too_long_returns_422(self, client, dockd_token):
+        long_barcode = "A" * 129
+        resp = client.get(
+            f"/api/v1/dockd/items/{long_barcode}",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        assert resp.status_code == 422
+
+
+# ----------------------------------------------------------------------
+# Lookup paths: UPC, SKU, alias
+# ----------------------------------------------------------------------
+
+
+class TestLookupBy:
+    def test_upc_lookup(self, client, dockd_token):
+        upc = f"UPC{uuid.uuid4().hex[:8]}"
+        item_id, sku = _insert_item(upc=upc)
+        resp = client.get(
+            f"/api/v1/dockd/items/{upc}",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["item"]["item_id"] == item_id
+        assert body["item"]["sku"] == sku
+        assert body["item"]["upc"] == upc
+
+    def test_sku_lookup(self, client, dockd_token):
+        item_id, sku = _insert_item()
+        resp = client.get(
+            f"/api/v1/dockd/items/{sku}",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["item"]["item_id"] == item_id
+
+    def test_barcode_alias_lookup(self, client, dockd_token):
+        alias = f"ALIAS-{uuid.uuid4().hex[:8]}"
+        item_id, sku = _insert_item(
+            barcode_aliases=f'["{alias}"]',
+        )
+        resp = client.get(
+            f"/api/v1/dockd/items/{alias}",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["item"]["item_id"] == item_id
+
+
+# ----------------------------------------------------------------------
+# Response shape: item fields + locations
+# ----------------------------------------------------------------------
+
+
+class TestResponseShape:
+    def test_item_fields(self, client, dockd_token):
+        item_id, sku = _insert_item(
+            item_name="Test Widget Pro", category="widgets", weight_lbs="1.5",
+        )
+        resp = client.get(
+            f"/api/v1/dockd/items/{sku}",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        body = resp.get_json()
+        item = body["item"]
+        assert set(item.keys()) == {
+            "item_id", "sku", "item_name", "upc",
+            "category", "weight_lbs",
+        }
+        assert item["item_name"] == "Test Widget Pro"
+        assert item["category"] == "widgets"
+        # weight_lbs returns as float, not decimal/string.
+        assert item["weight_lbs"] == 1.5
+
+    def test_locations_include_inventory(self, client, dockd_token):
+        item_id, sku = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=10, qty_allocated=3)
+        _set_inv(item_id, bin_id=4, qty_on_hand=5)
+        resp = client.get(
+            f"/api/v1/dockd/items/{sku}",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        body = resp.get_json()
+        locs = {l["bin_id"]: l for l in body["locations"]}
+        assert 3 in locs
+        assert 4 in locs
+        assert locs[3]["quantity_on_hand"] == 10
+        assert locs[3]["quantity_allocated"] == 3
+        assert locs[3]["quantity_available"] == 7
+        assert set(locs[3].keys()) == {
+            "bin_id", "bin_code", "bin_type", "zone_name",
+            "quantity_on_hand", "quantity_allocated", "quantity_available",
+            "lot_number",
+        }
+
+
+# ----------------------------------------------------------------------
+# Warehouse scoping
+# ----------------------------------------------------------------------
+
+
+class TestWarehouseScope:
+    def test_item_still_200_when_locations_outside_scope(
+        self, client, dockd_token_other_warehouse,
+    ):
+        # Item exists with inventory in warehouse 1; token is scoped
+        # to warehouse 99. Item catalog row 200s, locations come back
+        # empty -- the dockd UI sees the item shape but no bins to
+        # print stickers from.
+        item_id, sku = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=10, warehouse_id=1)
+        resp = client.get(
+            f"/api/v1/dockd/items/{sku}",
+            headers={
+                "X-WMS-Token": dockd_token_other_warehouse["plaintext"],
+            },
+        )
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert body["item"]["item_id"] == item_id
+        assert body["locations"] == []
+
+    def test_locations_filtered_to_token_warehouses(self, client, dockd_token):
+        # Token is warehouse 1 only. Place stock in warehouse 1 (bin 3)
+        # AND warehouse 2 (a fabricated bin). Only the warehouse-1
+        # location should appear.
+        item_id, sku = _insert_item()
+        _set_inv(item_id, bin_id=3, qty_on_hand=10, warehouse_id=1)
+
+        # Fabricate a warehouse-2 bin (seed has the warehouse but no
+        # zones/bins).
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO zones "
+            "  (zone_name, zone_code, zone_type, warehouse_id) "
+            "VALUES (%s, %s, 'Pickable', 2) RETURNING zone_id",
+            (
+                f"Z-WH2-{uuid.uuid4().hex[:6]}",
+                f"ZWH2-{uuid.uuid4().hex[:6]}",
+            ),
+        )
+        zone_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO bins "
+            "  (zone_id, warehouse_id, bin_code, bin_barcode, external_id) "
+            "VALUES (%s, 2, %s, %s, %s) RETURNING bin_id",
+            (
+                zone_id,
+                f"WH2-{uuid.uuid4().hex[:6]}",
+                f"WH2BC-{uuid.uuid4().hex[:6]}",
+                str(uuid.uuid4()),
+            ),
+        )
+        wh2_bin = cur.fetchone()[0]
+        cur.close()
+        _set_inv(item_id, bin_id=wh2_bin, qty_on_hand=5, warehouse_id=2)
+
+        resp = client.get(
+            f"/api/v1/dockd/items/{sku}",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        body = resp.get_json()
+        bin_ids = {l["bin_id"] for l in body["locations"]}
+        assert 3 in bin_ids
+        assert wh2_bin not in bin_ids

--- a/api/tests/test_dockd_get_order.py
+++ b/api/tests/test_dockd_get_order.py
@@ -342,6 +342,8 @@ class TestHappyPath:
         assert item["display_name"] == "Widget Red Small"
         assert item["upc"] == "0123456789012"
         assert item["qty"] == 2
+        # Fully picked line: qty_ordered matches qty.
+        assert item["qty_ordered"] == 2
         assert isinstance(item["external_id"], str) and len(item["external_id"]) == 36
         assert body["order_total"] == 25.98
         assert body["customer_shipping_paid"] == 8.95
@@ -353,6 +355,29 @@ class TestHappyPath:
         assert body["carrier"] is None
         assert body["shipped_at"] is None
         assert body["station_label"] is None
+
+    def test_short_picked_line_surfaces_both_qty_and_qty_ordered(
+        self, client, dockd_token,
+    ):
+        """When a line was short-picked, qty (tote count) is less than
+        qty_ordered (original order). Both fields appear in the payload
+        so dockd can render `Verify N of M ordered` without the
+        operator cross-referencing Sentry's admin UI."""
+        item_id = _insert_item()
+        so_id, so_number = _insert_so(status="PICKED")
+        _insert_so_line(
+            so_id, item_id,
+            quantity_picked=1, quantity_ordered=2, line_number=1,
+        )
+
+        resp = client.get(
+            f"/api/v1/dockd/orders/{so_number}",
+            headers={"X-WMS-Token": dockd_token["plaintext"]},
+        )
+        assert resp.status_code == 200
+        item = resp.get_json()["items"][0]
+        assert item["qty"] == 1
+        assert item["qty_ordered"] == 2
 
     def test_packed_so_with_packing_required(self, client, dockd_token):
         item_id = _insert_item()

--- a/docs/api/dockd-openapi.yaml
+++ b/docs/api/dockd-openapi.yaml
@@ -201,6 +201,16 @@ paths:
                           format: uuid
                           type: string
                         qty:
+                          description: Units physically in the tote awaiting scan-verify.
+                            Equals sales_order_lines.quantity_picked on the Sentry
+                            side. Use this as the verify-target on dockd.
+                          type: integer
+                        qty_ordered:
+                          description: Units the customer originally ordered. Equals
+                            sales_order_lines.quantity_ordered on the Sentry side.
+                            qty < qty_ordered means the line was short-picked or partial-fulfilled;
+                            the difference will not ship on this SO (a backorder child
+                            SO carries the residual in the partial-fulfill case).
                           type: integer
                         sku:
                           type: string
@@ -214,6 +224,7 @@ paths:
                       - display_name
                       - upc
                       - qty
+                      - qty_ordered
                       type: object
                     type: array
                   marketplace:


### PR DESCRIPTION
Two dockd reads for the warehouse-floor integration.

## What changes

- **`qty_ordered` on GET order**: the dockd order payload returns `qty_ordered` alongside the existing fulfilled `qty` on each line, so a consumer sees the ordered quantity without a second lookup. The OpenAPI spec and committed `docs/api/dockd-openapi.yaml` are regenerated to match (parity test enforced).
- **`GET /api/v1/dockd/items/<barcode>`**: a token-authed item lookup that resolves an item by barcode (UPC) and returns its canonical detail plus per-location stock, scoped to the token's warehouses. Registered as a dockd inbound resource so it is gated like the other dockd reads.

api-only; no migration; no mobile change.

## Tests

New `test_dockd_get_item.py`; `test_dockd_get_order.py` extended for `qty_ordered`; the OpenAPI parity test passes against the regenerated spec. Full api suite green.