### PR TITLE
fix(pos-refund): cancel the original SO on a full refund

### DIFF
--- a/api/routes/pos.py
+++ b/api/routes/pos.py
@@ -32,6 +32,7 @@ Path / query parameter validation:
 import json
 import re
 import uuid as _uuid
+from decimal import Decimal
 
 from flask import Blueprint, g, jsonify, make_response, request
 from psycopg2.errors import LockNotAvailable, QueryCanceled
@@ -649,6 +650,17 @@ def checkout():
     # shipping_address_* columns the picking ticket reads. Gated on phone
     # order exactly like ship_address -- a counter sale leaves them NULL.
     header_ship = body.shipping_address if body.is_phone_order else None
+    # Money columns (NUMERIC(12,2) dollars). The POS owns the arithmetic and
+    # sends integer cents; convert at the boundary. order_total is now persisted
+    # on every POS SO (previously left NULL, with totals only in audit_log);
+    # customer_shipping_paid carries the rep-entered freight charge (0 on a
+    # counter sale, since the POS only sends shipping on phone orders). Decimal
+    # avoids the float artefact that 995/100 would otherwise introduce.
+    header_shipping_paid = Decimal(body.payment_summary.shipping_cents) / 100
+    header_order_total = Decimal(body.payment_summary.total_cents) / 100
+    # Ship method is a phone-order fulfillment field (the pick ticket reads it);
+    # a counter sale has no shipping leg, so force NULL like ship_address.
+    header_ship_method = body.ship_method if body.is_phone_order else None
     try:
         inserted = g.db.execute(
             text(
@@ -662,6 +674,7 @@ def checkout():
                     shipping_address_line2, shipping_address_city,
                     shipping_address_state, shipping_address_postal_code,
                     shipping_address_country, shipping_address_phone,
+                    order_total, customer_shipping_paid, ship_method,
                     external_txn_ref, idempotency_key, idempotency_body_hash
                 ) VALUES (
                     :so_id, :so_number, :so_number, :status, :wh_id,
@@ -670,6 +683,7 @@ def checkout():
                     :customer_name, :customer_phone, :ship_address,
                     :ship_name, :ship_line1, :ship_line2, :ship_city,
                     :ship_state, :ship_postal, :ship_country, :ship_phone,
+                    :order_total, :shipping_paid, :ship_method,
                     :external_txn_ref, :idempotency_key, :body_hash
                 )
                 ON CONFLICT (idempotency_key) DO NOTHING
@@ -695,6 +709,9 @@ def checkout():
                 "ship_postal":      header_ship.postal_code if header_ship else None,
                 "ship_country":     header_ship.country if header_ship else None,
                 "ship_phone":       header_ship.phone if header_ship else None,
+                "order_total":      header_order_total,
+                "shipping_paid":    header_shipping_paid,
+                "ship_method":      header_ship_method,
                 "external_txn_ref": body.external_txn_ref,
                 "idempotency_key":  idempotency_key_str,
                 "body_hash":        body_hash,
@@ -896,6 +913,7 @@ def checkout():
             "external_txn_ref": body.external_txn_ref,
             "terminal_id":      body.terminal_id,
             "so_number":        so_number,
+            "shipping_cents":   body.payment_summary.shipping_cents,
             "total_cents":      body.payment_summary.total_cents,
             "payment_method":   body.payment_summary.method,
             "header_warehouse": header_wh_code,
@@ -904,6 +922,7 @@ def checkout():
             "customer_phone":   body.customer_phone,
             "customer_email":   body.customer_email,
             "ship_address":     body.ship_address,
+            "ship_method":      header_ship_method,
             "lines":            audit_lines,
         },
     )
@@ -1220,6 +1239,15 @@ def refund():
     ).scalar()
     refund_so_number = f"POS-REF-{refund_so_id}"
 
+    # Credit-memo money columns (NUMERIC(12,2) dollars), stored NEGATIVE to
+    # mirror the negative-quantity credit lines below: a refund SO is a credit,
+    # so its order_total and refunded shipping reconcile as negatives in dockd
+    # and downstream consumers. The POS sends positive magnitudes in
+    # refund_summary; v1 refunds
+    # are full-order, so shipping is credited back in full with the order.
+    refund_order_total = -Decimal(body.refund_summary.total_cents) / 100
+    refund_shipping_paid = -Decimal(body.refund_summary.shipping_cents) / 100
+
     # INSERT the credit-memo SO. ON CONFLICT (idempotency_key) DO
     # NOTHING handles the concurrent-retry case; a peer that
     # committed during the warm-cache step gets re-read for replay.
@@ -1231,11 +1259,13 @@ def refund():
                     so_id, so_number, so_barcode, status, warehouse_id,
                     created_by, created_at, shipped_at, external_id,
                     order_source, order_type, parent_so_id,
+                    order_total, customer_shipping_paid,
                     external_txn_ref, idempotency_key, idempotency_body_hash
                 ) VALUES (
                     :so_id, :so_number, :so_number, 'SHIPPED', :wh_id,
                     'pos', NOW(), :shipped_at, :ext_id,
                     'pos', 'refund', :parent_so_id,
+                    :order_total, :shipping_paid,
                     :external_txn_ref, :idempotency_key, :body_hash
                 )
                 ON CONFLICT (idempotency_key) DO NOTHING
@@ -1249,6 +1279,8 @@ def refund():
                 "shipped_at":       body.completed_at,
                 "ext_id":           str(_uuid.uuid4()),
                 "parent_so_id":     original.so_id,
+                "order_total":      refund_order_total,
+                "shipping_paid":    refund_shipping_paid,
                 "external_txn_ref": body.external_refund_ref,
                 "idempotency_key":  idempotency_key_str,
                 "body_hash":        body_hash,
@@ -1397,6 +1429,7 @@ def refund():
             "original_so_id":            body.original_so_id,
             "refund_so_number":          refund_so_number,
             "terminal_id":               body.terminal_id,
+            "shipping_cents":            body.refund_summary.shipping_cents,
             "total_cents":               body.refund_summary.total_cents,
             "payment_method":            refund_method,
             "lines":                     original_lines_locations,

--- a/api/routes/pos.py
+++ b/api/routes/pos.py
@@ -1125,12 +1125,10 @@ def refund():
         g.db.rollback()
         return _err("original_so_not_found", "no POS SO found with the given id", 404)
 
-    if original.status != "SHIPPED":
-        # Wrong state. Conflate to 404 so a token cannot probe SO
-        # state by issuing successive refund attempts.
-        g.db.rollback()
-        return _err("original_so_not_found", "no POS SO found with the given id", 404)
-
+    # already_refunded is checked BEFORE the status gate below: a full refund
+    # now flips the original to CANCELLED, so a second refund attempt would
+    # otherwise trip the "must be SHIPPED" gate and 404 instead of surfacing
+    # the intended 422 already_refunded.
     if original.refunded_at is not None or original.refund_so_id is not None:
         existing_refund_so_number = None
         if original.refund_so_id is not None:
@@ -1147,6 +1145,12 @@ def refund():
             422,
             {"existing_refund_so_id": existing_refund_so_number},
         )
+
+    if original.status != "SHIPPED":
+        # Wrong state (an OPEN phone order, an SO cancelled for some other
+        # reason, etc.). Conflate to 404 so a token cannot probe SO state.
+        g.db.rollback()
+        return _err("original_so_not_found", "no POS SO found with the given id", 404)
 
     # 90-day window. Comparing the original sale's created_at against
     # NOW(). Postgres handles the interval math.
@@ -1396,13 +1400,17 @@ def refund():
             return _lock_contention()
         raise
 
-    # Mark the original SO as refunded.
+    # Mark the original SO as refunded and cancel it. v1 is full-order refund
+    # only, so a refunded sale is a cancelled sale: status -> CANCELLED so the
+    # admin/picker views stop showing it as SHIPPED. refunded_at + refund_so_id
+    # remain the audit link to the credit-memo SO.
     g.db.execute(
         text(
             """
             UPDATE sales_orders
                SET refunded_at  = NOW(),
-                   refund_so_id = :refund_so_id
+                   refund_so_id = :refund_so_id,
+                   status       = 'CANCELLED'
              WHERE so_id = :original_so_id
             """
         ),

--- a/api/schemas/pos.py
+++ b/api/schemas/pos.py
@@ -163,6 +163,11 @@ class PaymentSummary(BaseModel):
 
     method:         Literal["card", "cash"]
     subtotal_cents: int          = Field(..., ge=_CENTS_MIN, le=_CENTS_MAX)
+    # Pre-tax shipping charge (phone orders; 0 on counter sales). Persisted
+    # cents->dollars on sales_orders.customer_shipping_paid. total_cents already
+    # includes it and its tax. Default 0 keeps the counter-sale contract: an
+    # older POS that omits the field still validates and writes 0.
+    shipping_cents: int          = Field(0, ge=_CENTS_MIN, le=_CENTS_MAX)
     tax_cents:      int          = Field(..., ge=_CENTS_MIN, le=_CENTS_MAX)
     total_cents:    int          = Field(..., ge=_CENTS_MIN, le=_CENTS_MAX)
     tenders:        List[Tender] = Field(..., min_length=1, max_length=8)
@@ -246,6 +251,11 @@ class CheckoutBody(BaseModel):
     # mirror for the floor screens still on the legacy column. Gated on
     # is_phone_order at the route, same as ship_address.
     shipping_address:  Optional[ShippingAddress] = None
+    # Operator-selected ship method, written to sales_orders.ship_method (the
+    # pick ticket reads it). Gated on is_phone_order at the route like
+    # ship_address. 50-char cap matches the column. extra='forbid' above means
+    # this must be declared for the POS to send it.
+    ship_method:       Optional[str]   = Field(None, max_length=50)
 
 
 # ----------------------------------------------------------------------

--- a/api/schemas/pos.py
+++ b/api/schemas/pos.py
@@ -161,7 +161,10 @@ class PaymentSummary(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    method:         Literal["card", "cash"]
+    # "split" = part cash + part card on one sale (the tenders list carries the
+    # breakdown). Archival like the other two; the refund path matches it
+    # symmetrically (split sale -> split refund). Additive under DRAFT-v1.
+    method:         Literal["card", "cash", "split"]
     subtotal_cents: int          = Field(..., ge=_CENTS_MIN, le=_CENTS_MAX)
     # Pre-tax shipping charge (phone orders; 0 on counter sales). Persisted
     # cents->dollars on sales_orders.customer_shipping_paid. total_cents already

--- a/api/tests/test_pos_checkout.py
+++ b/api/tests/test_pos_checkout.py
@@ -32,6 +32,7 @@ import json
 import os
 import sys
 import uuid
+from decimal import Decimal
 
 os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
 os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
@@ -169,7 +170,8 @@ def _read_so(so_number):
         """
         SELECT so_id, so_number, status, warehouse_id, created_by, shipped_at,
                order_source, order_type, external_txn_ref,
-               idempotency_key, idempotency_body_hash, cached_response_body
+               idempotency_key, idempotency_body_hash, cached_response_body,
+               order_total, customer_shipping_paid, ship_method
           FROM sales_orders
          WHERE so_number = %s
         """,
@@ -275,6 +277,45 @@ class TestHappyPath:
         assert row[9] is not None  # idempotency_key set
         assert row[10] is not None  # idempotency_body_hash set
         assert row[11] is not None  # cached_response_body set
+
+    def test_so_row_persists_order_total_and_zero_shipping(self, client, pos_token):
+        # Every POS sale now persists order_total (previously NULL); a counter
+        # sale carries customer_shipping_paid = 0.00 (the POS sends no shipping).
+        resp = _post(client, pos_token["plaintext"], _card_body())
+        row = _read_so(resp.get_json()["so_number"])
+        assert row[12] == Decimal("21.61")  # order_total (2161 cents)
+        assert row[13] == Decimal("0.00")   # customer_shipping_paid
+
+    def test_phone_order_persists_customer_shipping_paid(self, client, pos_token):
+        # A phone order carries a rep-entered shipping charge; Sentry stores it
+        # (cents->dollars) on customer_shipping_paid and the full total on
+        # order_total, and archives the cents in the audit details.
+        body = _card_body()
+        body["is_phone_order"] = True
+        body["ship_method"] = "UPS Ground"
+        ps = body["payment_summary"]
+        ps["shipping_cents"] = 995
+        # total = subtotal + shipping + tax = 1999 + 995 + 162.
+        ps["total_cents"] = ps["subtotal_cents"] + 995 + ps["tax_cents"]
+        resp = _post(client, pos_token["plaintext"], body)
+        assert resp.status_code == 200
+        row = _read_so(resp.get_json()["so_number"])
+        assert row[13] == Decimal("9.95")   # customer_shipping_paid
+        assert row[12] == Decimal("31.56")  # order_total
+        assert row[14] == "UPS Ground"      # ship_method
+        audit = _read_audit_for_so(row[0])
+        assert audit[3]["shipping_cents"] == 995
+        assert audit[3]["ship_method"] == "UPS Ground"
+
+    def test_counter_sale_nulls_ship_method(self, client, pos_token):
+        # ship_method on a counter sale is forced NULL (no shipping leg), like
+        # ship_address.
+        body = _card_body()
+        body["ship_method"] = "UPS Ground"  # is_phone_order defaults False
+        resp = _post(client, pos_token["plaintext"], body)
+        assert resp.status_code == 200
+        row = _read_so(resp.get_json()["so_number"])
+        assert row[14] is None  # ship_method NULL on a counter sale
 
     def test_inventory_decremented(self, client, pos_token):
         # TST-001 starts at 50 in bin 3, warehouse 1.

--- a/api/tests/test_pos_refund.py
+++ b/api/tests/test_pos_refund.py
@@ -336,8 +336,9 @@ class TestHappyPath:
         after = _read_inventory(item_id=1, bin_id=3, warehouse_id=1)
         assert int(after[0]) == int(before[0])
 
-        # Original SO has refunded_at + refund_so_id populated.
+        # Original SO is cancelled, with refunded_at + refund_so_id populated.
         sale_row = _read_so(sale_so_number)
+        assert sale_row[2] == "CANCELLED"  # full refund cancels the original
         assert sale_row[6] is not None  # refunded_at
         assert sale_row[7] is not None  # refund_so_id
 

--- a/api/tests/test_pos_refund.py
+++ b/api/tests/test_pos_refund.py
@@ -363,13 +363,15 @@ class TestHappyPath:
         assert audit[1] == "mike"  # cashier_id
 
     def test_refund_credits_shipping_in_full(self, client, pos_token):
-        # A phone order with a $9.95 shipping charge: the sale row carries
-        # positive order_total + customer_shipping_paid; the full refund's
-        # credit-memo SO carries the negated magnitudes, and the refund audit
-        # archives the shipping cents. v1 refunds are full-order, so shipping is
-        # credited back in full.
+        # A sale with a $9.95 shipping charge: the sale row carries positive
+        # order_total + customer_shipping_paid; the full refund's credit-memo SO
+        # carries the negated magnitudes, and the refund audit archives the
+        # shipping cents. v1 refunds are full-order, so shipping is credited back
+        # in full. The receiver's shipping persistence/negation is order-type
+        # agnostic, so this uses a counter sale (SHIPPED) -- the only state the
+        # refund path accepts today; refunding an unshipped phone order (OPEN) is
+        # gated separately (see stikman28/sentry-wms#47).
         sale_body = _checkout_card_body(qty=1)
-        sale_body["is_phone_order"] = True
         ps = sale_body["payment_summary"]
         ps["shipping_cents"] = 995
         ps["total_cents"] = ps["subtotal_cents"] + 995 + ps["tax_cents"]  # 3156

--- a/api/tests/test_pos_refund.py
+++ b/api/tests/test_pos_refund.py
@@ -23,6 +23,7 @@ import json
 import os
 import sys
 import uuid
+from decimal import Decimal
 
 os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
 os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
@@ -191,7 +192,8 @@ def _read_so(so_number):
         """
         SELECT so_id, so_number, status, order_source, order_type,
                parent_so_id, refunded_at, refund_so_id,
-               external_txn_ref, idempotency_key
+               external_txn_ref, idempotency_key,
+               order_total, customer_shipping_paid
           FROM sales_orders
          WHERE so_number = %s
         """,
@@ -359,6 +361,39 @@ class TestHappyPath:
         audit = _read_audit_for_so(refund_row[0], "POS_REFUND")
         assert audit is not None
         assert audit[1] == "mike"  # cashier_id
+
+    def test_refund_credits_shipping_in_full(self, client, pos_token):
+        # A phone order with a $9.95 shipping charge: the sale row carries
+        # positive order_total + customer_shipping_paid; the full refund's
+        # credit-memo SO carries the negated magnitudes, and the refund audit
+        # archives the shipping cents. v1 refunds are full-order, so shipping is
+        # credited back in full.
+        sale_body = _checkout_card_body(qty=1)
+        sale_body["is_phone_order"] = True
+        ps = sale_body["payment_summary"]
+        ps["shipping_cents"] = 995
+        ps["total_cents"] = ps["subtotal_cents"] + 995 + ps["tax_cents"]  # 3156
+        ps["tenders"][0]["amount_cents"] = ps["total_cents"]
+        sale_resp = _post_checkout(client, pos_token["plaintext"], sale_body)
+        assert sale_resp.status_code == 200
+        sale_so_number = sale_resp.get_json()["so_number"]
+
+        sale_row = _read_so(sale_so_number)
+        assert sale_row[10] == Decimal("31.56")  # order_total
+        assert sale_row[11] == Decimal("9.95")   # customer_shipping_paid
+
+        rb = _refund_body_for(sale_body, sale_so_number)
+        refund_resp = _post_refund(client, pos_token["plaintext"], rb)
+        assert refund_resp.status_code == 200
+        refund_so_id = refund_resp.get_json()["refund_so_id"]
+
+        refund_row = _read_so(refund_so_id)
+        # Credit memo: negated magnitudes mirror the negative-quantity lines.
+        assert refund_row[10] == Decimal("-31.56")  # order_total
+        assert refund_row[11] == Decimal("-9.95")   # customer_shipping_paid
+
+        audit = _read_audit_for_so(refund_row[0], "POS_REFUND")
+        assert audit[3]["shipping_cents"] == 995
 
     def test_cash_sale_then_cash_refund(self, client, pos_token):
         sale_body = _checkout_cash_body(qty=1)


### PR DESCRIPTION
A v1 POS refund is full-order only, so a refunded sale is a cancelled sale.

## What changes

- The original SO now moves to `status=CANCELLED` on a full refund (alongside the existing `refunded_at` + `refund_so_id` link), so the admin and picker views stop showing a refunded order as SHIPPED.
- The "must be SHIPPED" state gate moves below the already-refunded check, so a second refund attempt surfaces the intended `422 already_refunded` instead of 404-ing on the now-CANCELLED status.

Stacked on #399 and #400; merges after them. api-only; no migration.

## Tests

`test_pos_refund.py` updated to expect the CANCELLED original and the reordered gate. Full api suite green.