### PR TITLE
feat(dashboard): operations dashboard -- Received + Marketplace Health

### DIFF
--- a/admin/src/pages/Dashboard.jsx
+++ b/admin/src/pages/Dashboard.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { api } from '../api.js';
+import { formatDateOnly } from '../utils/date.js';
 import { useWarehouse } from '../warehouse.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 import Modal from '../components/Modal.jsx';
@@ -8,14 +9,14 @@ import Modal from '../components/Modal.jsx';
 // productivity for the warehouse-scoped per-user metrics, and
 // /api/v1/dashboard/preferences for the per-user chart_order +
 // default_range + default_view. Single-file pattern matches
-// SalesOrders.jsx + TransferOrders.jsx; the directory layout in
-// plan section 5.4 was deferred for codebase uniformity.
+// SalesOrders.jsx + TransferOrders.jsx; the single-file layout was
+// kept for codebase uniformity.
 
 const COLOR_TOP = '#8e2715';   // Sentry red (top performer per card)
 const COLOR_OTHER = '#c4722a'; // Copper (every other user)
 
 const EVENT_LABELS = {
-  // Picking is measured in distinct orders, not units.
+  // picking is measured in distinct orders, not units.
   picking:       { title: 'Picking',      unit: 'orders' },
   packing:       { title: 'Packing',      unit: 'units' },
   shipped:       { title: 'Shipped',      unit: 'orders' },
@@ -164,8 +165,49 @@ function ProductivityTable({ payload }) {
   );
 }
 
+// Dashboard is a thin tab shell. The original productivity view became
+// one of three tabs; the other two (Received Today, Shipping Health)
+// live in this file as siblings so
+// they share the warehouse context + page header. Tab selection is
+// local-only state (no URL persistence yet -- can be added once
+// stakeholders show they want shareable deep links).
 export default function Dashboard() {
   const { warehouseId } = useWarehouse();
+  const [tab, setTab] = useState('productivity');
+  return (
+    <div>
+      <PageHeader title="Dashboard" />
+      <div className="data-tabs" style={{ marginBottom: 16 }}>
+        <button
+          type="button"
+          className={`data-tab${tab === 'productivity' ? ' active' : ''}`}
+          onClick={() => setTab('productivity')}
+        >
+          Productivity
+        </button>
+        <button
+          type="button"
+          className={`data-tab${tab === 'received' ? ' active' : ''}`}
+          onClick={() => setTab('received')}
+        >
+          Received
+        </button>
+        <button
+          type="button"
+          className={`data-tab${tab === 'shipping' ? ' active' : ''}`}
+          onClick={() => setTab('shipping')}
+        >
+          Marketplace Health
+        </button>
+      </div>
+      {tab === 'productivity' && <ProductivityView warehouseId={warehouseId} />}
+      {tab === 'received' && <ReceivedTodayView warehouseId={warehouseId} />}
+      {tab === 'shipping' && <ShippingHealthView warehouseId={warehouseId} />}
+    </div>
+  );
+}
+
+function ProductivityView({ warehouseId }) {
   const [payload, setPayload] = useState(null);
   const [error, setError] = useState('');
   const [preferences, setPreferences] = useState({
@@ -206,8 +248,8 @@ export default function Dashboard() {
     const qp = new URLSearchParams({
       start: range.start, end: range.end, warehouse_id: String(warehouseId),
     });
-    // P6.1: productivity is ADMIN-only upstream; a USER hitting the
-    // home page should not see "Forbidden" inline. Silent the popup
+    // productivity is ADMIN-only; a USER hitting the home page should
+    // not see "Forbidden" inline. Silent the popup
     // and on 403 just clear the payload so the widget shows nothing.
     const res = await api.get(
       `/v1/dashboard/productivity?${qp}`,
@@ -258,8 +300,6 @@ export default function Dashboard() {
 
   return (
     <div>
-      <PageHeader title="Productivity" />
-
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16, flexWrap: 'wrap' }}>
         <div style={{ display: 'flex', gap: 4 }}>
           {RANGE_PRESETS.map((p) => (
@@ -462,3 +502,419 @@ const styles = {
   th: { padding: '6px 8px', fontSize: 11, color: 'var(--text-secondary)', fontWeight: 600 },
   td: { padding: '6px 8px' },
 };
+
+
+// Shared date-range picker for the Received + Shipping Health tabs.
+// Mirrors the Productivity tab's RANGE_PRESETS controls so the three
+// views read as a coherent set; the parent owns rangePreset +
+// customStart / customEnd state so the dashboard can persist a
+// single range choice across tab switches if we want that later.
+function RangeControls({
+  rangePreset, setRangePreset,
+  customStart, setCustomStart, customEnd, setCustomEnd,
+  loading, onRefresh, trailingChildren,
+}) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 12,
+      marginBottom: 16, flexWrap: 'wrap',
+    }}>
+      <div style={{ display: 'flex', gap: 4 }}>
+        {RANGE_PRESETS.map((p) => (
+          <button
+            key={p.key}
+            className={`btn btn-sm${rangePreset === p.key ? ' btn-primary' : ''}`}
+            onClick={() => setRangePreset(p.key)}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+      {rangePreset === 'custom' && (
+        <>
+          <input
+            type="date"
+            className="form-input"
+            style={{ width: 150 }}
+            value={customStart}
+            onChange={(e) => setCustomStart(e.target.value)}
+          />
+          <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>to</span>
+          <input
+            type="date"
+            className="form-input"
+            style={{ width: 150 }}
+            value={customEnd}
+            onChange={(e) => setCustomEnd(e.target.value)}
+          />
+        </>
+      )}
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: 4, alignItems: 'center' }}>
+        {trailingChildren}
+        <button className="btn btn-sm" onClick={onRefresh} disabled={loading}>
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+
+// ── Received ───────────────────────────────────────────────────────────────
+
+function ReceivedTodayView({ warehouseId }) {
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [rangePreset, setRangePreset] = useState('today');
+  const [customStart, setCustomStart] = useState('');
+  const [customEnd, setCustomEnd] = useState('');
+
+  useEffect(() => {
+    if (!warehouseId) return;
+    if (rangePreset === 'custom' && (!customStart || !customEnd)) return;
+    load();
+  }, [warehouseId, rangePreset, customStart, customEnd]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function load() {
+    const range = rangeForPreset(rangePreset, customStart, customEnd);
+    if (!range.start || !range.end) return;
+    setLoading(true);
+    const qp = new URLSearchParams({
+      warehouse_id: String(warehouseId),
+      start: range.start, end: range.end,
+    });
+    const res = await api.get(
+      `/v1/dashboard/received?${qp}`,
+      { silentPermissionDenied: true },
+    );
+    setLoading(false);
+    if (!res?.ok) return;
+    const data = await res.json();
+    setRows(data.pos || []);
+  }
+
+  const totalUnits = rows.reduce((acc, r) => acc + (r.units_received || 0), 0);
+  const totalLines = rows.reduce((acc, r) => acc + (r.lines_received || 0), 0);
+  const distinctReceivers = new Set(rows.flatMap((r) => r.receivers || []));
+
+  return (
+    <div>
+      <RangeControls
+        rangePreset={rangePreset} setRangePreset={setRangePreset}
+        customStart={customStart} setCustomStart={setCustomStart}
+        customEnd={customEnd} setCustomEnd={setCustomEnd}
+        loading={loading} onRefresh={load}
+      />
+      <div style={{
+        display: 'flex', gap: 16, marginBottom: 16, fontSize: 13,
+        color: 'var(--text-secondary)', flexWrap: 'wrap', alignItems: 'center',
+      }}>
+        <span><strong style={{ color: 'var(--text)' }}>{rows.length}</strong> POs received</span>
+        <span><strong style={{ color: 'var(--text)' }}>{totalLines}</strong> lines</span>
+        <span><strong style={{ color: 'var(--text)' }}>{totalUnits}</strong> units</span>
+        <span><strong style={{ color: 'var(--text)' }}>{distinctReceivers.size}</strong> receivers active</span>
+      </div>
+
+      {!loading && rows.length === 0 && (
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+          No POs received units in this range.
+        </p>
+      )}
+
+      {rows.length > 0 && (
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>PO #</th>
+              <th>Vendor</th>
+              <th>Status</th>
+              <th style={{ textAlign: 'right' }}>Lines</th>
+              <th style={{ textAlign: 'right' }}>Units</th>
+              <th>Receiver(s)</th>
+              <th>Last received</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.po_id}>
+                <td className="mono">{r.po_number}</td>
+                <td>{r.vendor_name || '-'}</td>
+                <td>{r.status}</td>
+                <td className="mono" style={{ textAlign: 'right' }}>{r.lines_received}</td>
+                <td className="mono" style={{ textAlign: 'right' }}>{r.units_received}</td>
+                <td>{(r.receivers || []).join(', ') || '-'}</td>
+                <td className="mono" style={{ fontSize: 12 }}>
+                  {r.last_received_at ? new Date(r.last_received_at).toLocaleTimeString() : '-'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+
+// -- Marketplace Health ---------------------------------------------------
+//
+// The signal the desk reads first: how many orders need to ship today
+// per marketplace (Amazon / eBay / BigCommerce / Phone Orders). Above
+// the bubbles, a one-line summary of total orders received per
+// marketplace today gives context for the bubble counts. Channel
+// identity is sales_orders.order_origin (free-text label written by
+// the inbound mapping); the backend pins the set to four DB values
+// and the UI translates them to display labels here.
+
+function ShippingHealthView({ warehouseId }) {
+  const [data, setData] = useState({ by_source: [] });
+  const [loading, setLoading] = useState(false);
+  const [rangePreset, setRangePreset] = useState('today');
+  const [customStart, setCustomStart] = useState('');
+  const [customEnd, setCustomEnd] = useState('');
+  const [focused, setFocused] = useState(null);
+
+  useEffect(() => {
+    if (!warehouseId) return;
+    if (rangePreset === 'custom' && (!customStart || !customEnd)) return;
+    load();
+  }, [warehouseId, rangePreset, customStart, customEnd]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function load() {
+    const range = rangeForPreset(rangePreset, customStart, customEnd);
+    if (!range.start || !range.end) return;
+    setLoading(true);
+    const qp = new URLSearchParams({
+      warehouse_id: String(warehouseId),
+      start: range.start, end: range.end,
+    });
+    const res = await api.get(
+      `/v1/dashboard/shipping-health?${qp}`,
+      { silentPermissionDenied: true },
+    );
+    setLoading(false);
+    if (!res?.ok) return;
+    setData(await res.json());
+  }
+
+  const rows = data.by_source || [];
+
+  return (
+    <div>
+      <RangeControls
+        rangePreset={rangePreset} setRangePreset={setRangePreset}
+        customStart={customStart} setCustomStart={setCustomStart}
+        customEnd={customEnd} setCustomEnd={setCustomEnd}
+        loading={loading} onRefresh={load}
+      />
+
+      <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 12px 0' }}>
+        Marketplace Breakdown
+      </h3>
+
+      {rows.length === 0 && !loading && (
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+          No marketplace channels are configured. Add one per channel under
+          Settings &gt; Marketplace Health to see its health bubble here.
+        </p>
+      )}
+
+      {/* Top section: per-marketplace Received + Shipped totals
+          for the selected range. Same auto-fit wrap pattern as the
+          bubbles below so the layout stays consistent on narrow
+          windows. */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+        gap: 12,
+        marginBottom: 16,
+      }}>
+        {rows.map((r) => (
+          <MarketplaceTotalsCard key={r.order_origin} row={r} />
+        ))}
+      </div>
+
+      <div style={{
+        marginBottom: 16,
+        borderTop: '3px solid var(--border-dark)',
+      }} />
+
+      <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 12px 0' }}>
+        Orders that need to ship today
+      </h3>
+
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+        gap: 12,
+        marginBottom: 24,
+      }}>
+        {rows.map((r) => (
+          <ShipTodayBubble
+            key={r.order_origin}
+            row={r}
+            onClick={() => setFocused(r)}
+          />
+        ))}
+      </div>
+
+      {focused && (
+        <Modal
+          title={`${focused.label} - orders that need to ship today`}
+          onClose={() => setFocused(null)}
+          size="wide"
+          footer={
+            <button className="btn btn-primary" onClick={() => setFocused(null)}>
+              Close
+            </button>
+          }
+        >
+          {(focused.orders || []).length === 0 ? (
+            <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+              No orders to show.
+            </p>
+          ) : (
+            <table className="lines-table">
+              <thead>
+                <tr>
+                  <th>SO #</th>
+                  <th>Customer</th>
+                  <th>Status</th>
+                  <th>Ship by</th>
+                </tr>
+              </thead>
+              <tbody>
+                {focused.orders.map((o) => (
+                  <tr key={o.so_id}>
+                    <td className="mono">{o.so_number}</td>
+                    <td>{o.customer_name || '-'}</td>
+                    <td>{o.status}</td>
+                    <td className="mono" style={{ fontSize: 12, color: 'var(--accent)' }}>
+                      {o.ship_by_date ? formatDateOnly(o.ship_by_date) : '-'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+// Top-section card: per-marketplace Orders Received + Orders Shipped
+// totals for the selected range. Two big stats side-by-side. The desk
+// reads this for channel-mix context; the action signal lives in the
+// bubble row below.
+function MarketplaceTotalsCard({ row }) {
+  return (
+    <div className="card" style={{ padding: 16 }}>
+      <div style={{
+        marginBottom: 12, paddingBottom: 8,
+        borderBottom: '1px solid var(--border)',
+        textAlign: 'center',
+      }}>
+        <span style={{ fontSize: 16, fontWeight: 600 }}>
+          {row.label}
+        </span>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{
+            fontSize: 28, fontWeight: 700,
+            fontFamily: 'var(--mono, monospace)',
+            color: 'var(--text)',
+            lineHeight: 1,
+          }}>
+            {row.orders_received || 0}
+          </div>
+          <div style={{
+            fontSize: 11, marginTop: 4,
+            color: 'var(--text-secondary)',
+            textTransform: 'uppercase', letterSpacing: 0.4,
+          }}>
+            Orders Received
+          </div>
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <div style={{
+            fontSize: 28, fontWeight: 700,
+            fontFamily: 'var(--mono, monospace)',
+            color: 'var(--text)',
+            lineHeight: 1,
+          }}>
+            {row.orders_shipped || 0}
+          </div>
+          <div style={{
+            fontSize: 11, marginTop: 4,
+            color: 'var(--text-secondary)',
+            textTransform: 'uppercase', letterSpacing: 0.4,
+          }}>
+            Orders Shipped
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// One channel bubble. Shows the number of orders past ship_by_date
+// today (or due today) that have not shipped or been cancelled -- the
+// number the desk acts on. Click a non-zero bubble to open the SO
+// list; zero renders as a green check, non-interactive.
+function ShipTodayBubble({ row, onClick }) {
+  const needToShip = row.need_to_ship_today || 0;
+  const sharedStyle = {
+    padding: 20,
+    display: 'flex', flexDirection: 'column', alignItems: 'center',
+    gap: 8,
+    border: needToShip > 0
+      ? '2px solid var(--accent)'
+      : '1px solid var(--border-dark)',
+    background: 'var(--white)',
+    fontFamily: 'inherit',
+    textAlign: 'center',
+  };
+  const label = (
+    <span style={{ fontSize: 14, fontWeight: 600 }}>
+      {row.label}
+    </span>
+  );
+  if (needToShip > 0) {
+    return (
+      <button
+        type="button"
+        className="card"
+        onClick={onClick}
+        style={{ ...sharedStyle, cursor: 'pointer' }}
+        title="Show the SO list behind this count"
+      >
+        {label}
+        <span style={{
+          fontSize: 44, fontWeight: 700,
+          fontFamily: 'var(--mono, monospace)',
+          color: 'var(--accent)',
+          lineHeight: 1,
+        }}>
+          {needToShip}
+        </span>
+      </button>
+    );
+  }
+  return (
+    <div className="card" style={sharedStyle}>
+      {label}
+      <span
+        style={{
+          fontSize: 44, lineHeight: 1, fontWeight: 700,
+          color: '#1f9d55',
+        }}
+        aria-label="caught up"
+        title="No orders need to ship for this channel"
+      >
+        &#10003;
+      </span>
+    </div>
+  );
+}

--- a/admin/src/pages/Settings.jsx
+++ b/admin/src/pages/Settings.jsx
@@ -57,6 +57,7 @@ export default function Settings() {
       api.get('/admin/settings/picking_ticket_returns_text'),
       api.get('/admin/settings/pos_activity_enabled'),
       api.get('/admin/settings/fraud_review_billing_shipping'),
+      api.get('/admin/settings/dashboard_bubble_origins'),
     ]).then(async (responses) => {
       const initial = {};
       for (const res of responses) {
@@ -84,6 +85,10 @@ export default function Settings() {
       // Billing != shipping fraud heuristic is opt-in: off by default so
       // a fresh install never parks orders in FRAUD_REVIEW automatically.
       if (!('fraud_review_billing_shipping' in initial)) initial.fraud_review_billing_shipping = 'false';
+      // Marketplace Health bubble set: a JSON array of {origin, label}. Empty
+      // by default so the dashboard surfaces no channels until an operator
+      // adds them; the dashboard endpoint reads the same key.
+      if (!('dashboard_bubble_origins' in initial)) initial.dashboard_bubble_origins = '[]';
       setSavedSettings({ ...initial });
       setDraftSettings({ ...initial });
     });
@@ -106,6 +111,38 @@ export default function Settings() {
   function updateDraft(key, value) {
     setDraftSettings((prev) => ({ ...prev, [key]: value }));
     setSettingsSuccess('');
+  }
+
+  // Marketplace Health bubble set is stored as a JSON string in
+  // draftSettings.dashboard_bubble_origins; parse / mutate / re-serialize
+  // around the flat string the settings store keeps.
+  function bubbleRows() {
+    try {
+      const parsed = JSON.parse(draftSettings.dashboard_bubble_origins || '[]');
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function setBubbleRows(rows) {
+    updateDraft('dashboard_bubble_origins', JSON.stringify(rows));
+  }
+
+  function updateBubble(i, field, value) {
+    const rows = bubbleRows();
+    rows[i] = { ...rows[i], [field]: value };
+    setBubbleRows(rows);
+  }
+
+  function addBubble() {
+    setBubbleRows([...bubbleRows(), { origin: '', label: '' }]);
+  }
+
+  function removeBubble(i) {
+    const rows = bubbleRows();
+    rows.splice(i, 1);
+    setBubbleRows(rows);
   }
 
   async function saveSettings() {
@@ -440,6 +477,44 @@ export default function Settings() {
           </label>
         </div>
         <p className="settings-note">One built-in heuristic for the Outbound &gt; Fraud queue: when on, an inbound order whose billing and shipping addresses diverge (street / city / state / postal, both sides populated) lands in FRAUD_REVIEW and is held out of picking until a CSR clears it. Off by default. A CSR can always flag or clear an order manually regardless of this setting.</p>
+      </div>
+
+      <div className="settings-section">
+        <h3>Marketplace Health</h3>
+        <p className="settings-note">
+          Channels shown on the Dashboard &gt; Marketplace Health view. Origin is
+          matched verbatim against each sales order's <code>order_origin</code>
+          value (the label the inbound channel mapping writes, or
+          &quot;Phone Order&quot; for POS phone orders); Label is the display name
+          on the bubble. With no channels configured the view shows nothing -- add
+          one row per channel you want a health bubble for.
+        </p>
+        {bubbleRows().map((b, i) => (
+          <div key={i} style={{ display: 'flex', gap: 8, padding: '4px 0', maxWidth: 560, alignItems: 'center' }}>
+            <input
+              className="form-input"
+              style={{ flex: 1 }}
+              value={b.origin || ''}
+              onChange={(e) => updateBubble(i, 'origin', e.target.value)}
+              placeholder="order_origin value (e.g. AMAZON)"
+            />
+            <input
+              className="form-input"
+              style={{ flex: 1 }}
+              value={b.label || ''}
+              onChange={(e) => updateBubble(i, 'label', e.target.value)}
+              placeholder="Display label (e.g. Amazon)"
+            />
+            <button type="button" className="btn btn-secondary" onClick={() => removeBubble(i)}>
+              Remove
+            </button>
+          </div>
+        ))}
+        <div style={{ padding: '8px 0' }}>
+          <button type="button" className="btn btn-secondary" onClick={addBubble}>
+            Add channel
+          </button>
+        </div>
       </div>
 
       {/* Picking Ticket branding */}

--- a/api/routes/dashboard.py
+++ b/api/routes/dashboard.py
@@ -1,16 +1,20 @@
-"""Productivity dashboard API (v1.8.0 #297).
+"""Operations dashboard API (v1.8.0 #297).
 
-Three endpoints:
+Endpoints:
 
-- GET  /api/v1/dashboard/productivity   per-user metrics for a date range
-- GET  /api/v1/dashboard/preferences    user's chart_order + defaults
-- PUT  /api/v1/dashboard/preferences    upsert preferences row
+- GET  /api/v1/dashboard/productivity     per-user metrics for a date range
+- GET  /api/v1/dashboard/preferences      user's chart_order + defaults
+- PUT  /api/v1/dashboard/preferences      upsert preferences row
+- GET  /api/v1/dashboard/received         per-PO receipts for a date range
+- GET  /api/v1/dashboard/shipping-health  per-channel outbound health
 
 Auth: cookie + ADMIN role for productivity (operators with admin
 visibility); preferences are per-user with the user_id derived
-from g.current_user (never from the request body).
+from g.current_user (never from the request body). received and
+shipping-health require a logged-in admin session.
 """
 
+import json
 from datetime import date, timedelta
 from typing import List, Optional
 
@@ -252,3 +256,280 @@ def put_preferences():
         {"uid": user_id},
     ).fetchone()
     return jsonify(_row_to_dict(row))
+
+
+# ============================================================
+# Shared range parsing
+# ============================================================
+
+
+def _parse_dashboard_range():
+    """Parse the shared start/end query params (inclusive YYYY-MM-DD dates,
+    defaulting to today). Returns (start_date, end_date, error_response);
+    on success error_response is None. Callers add one day to end for the
+    half-open SQL window."""
+    start_str = request.args.get("start") or date.today().isoformat()
+    end_str = request.args.get("end") or date.today().isoformat()
+    try:
+        start_dt = date.fromisoformat(start_str)
+        end_dt = date.fromisoformat(end_str)
+    except ValueError:
+        return None, None, (jsonify({"error": "start/end must be YYYY-MM-DD"}), 422)
+    if end_dt < start_dt:
+        return None, None, (jsonify({"error": "end must be on or after start"}), 422)
+    return start_dt, end_dt, None
+
+
+# ============================================================
+# Received (per-PO receipts for a date range)
+# ============================================================
+
+
+@dashboard_bp.route("/received", methods=["GET"])
+@require_auth
+@with_db
+def received():
+    """Per-PO receipts for a date range.
+
+    Aggregates audit_log RECEIVE rows in [start, end] (inclusive dates,
+    treated as half-open [start, end+1day) in SQL for clean index scans).
+    Per PO the response carries the PO header, what was received in range
+    (units + distinct line items + receivers), and when the most recent
+    line landed. start / end default to CURRENT_DATE; warehouse_id is
+    required.
+    """
+    warehouse_id = request.args.get("warehouse_id", type=int)
+    if not warehouse_id:
+        return jsonify({"error": "warehouse_id is required"}), 422
+    start_dt, end_dt, err = _parse_dashboard_range()
+    if err is not None:
+        return err
+    end_exclusive = end_dt + timedelta(days=1)
+
+    rows = g.db.execute(
+        text(
+            """
+            SELECT al.entity_id AS po_id,
+                   po.po_number,
+                   po.vendor_name,
+                   po.status,
+                   SUM(COALESCE((al.details->>'quantity')::int, 0)) AS units_received,
+                   COUNT(DISTINCT (al.details->>'item_id')::int) AS lines_received,
+                   COUNT(*) AS receive_events,
+                   ARRAY_AGG(DISTINCT al.user_id) AS receivers,
+                   MAX(al.created_at) AS last_received_at
+              FROM audit_log al
+              JOIN purchase_orders po ON po.po_id = al.entity_id
+             WHERE al.action_type = 'RECEIVE'
+               AND al.entity_type = 'PO'
+               AND al.warehouse_id = :wid
+               AND al.created_at >= :start
+               AND al.created_at < :end
+             GROUP BY al.entity_id, po.po_number, po.vendor_name, po.status
+             ORDER BY MAX(al.created_at) DESC
+            """
+        ),
+        {"wid": warehouse_id, "start": start_dt, "end": end_exclusive},
+    ).fetchall()
+
+    return jsonify({
+        "warehouse_id": warehouse_id,
+        "range": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
+        "pos": [
+            {
+                "po_id": r.po_id,
+                "po_number": r.po_number,
+                "vendor_name": r.vendor_name,
+                "status": r.status,
+                "units_received": int(r.units_received or 0),
+                "lines_received": int(r.lines_received or 0),
+                "receive_events": int(r.receive_events or 0),
+                "receivers": list(r.receivers or []),
+                "last_received_at": (
+                    r.last_received_at.isoformat() if r.last_received_at else None
+                ),
+            }
+            for r in rows
+        ],
+    })
+
+
+# ============================================================
+# Shipping Health (Marketplace Health)
+# ============================================================
+
+
+_DASHBOARD_BUBBLE_ORIGINS_KEY = "dashboard_bubble_origins"
+
+
+def _bubble_origins(db):
+    """The admin-defined Marketplace Health bubble set.
+
+    order_origin is a free-text sales_orders column: the inbound mapping
+    writes whatever label the upstream channel uses, and the POS
+    phone-order flow writes the literal "Phone Order". Rather than hardcode
+    a channel list, the bubble set is configured per deployment in
+    app_settings.dashboard_bubble_origins -- a JSON array of
+    {"origin": <order_origin value>, "label": <display name>}. An admin
+    adds one entry per channel they want a health bubble for. Unset, empty,
+    or malformed yields no bubbles: this dashboard never surfaces channels
+    implicitly from the data, so a fresh install shows nothing until an
+    operator opts a channel in. origin values are matched verbatim.
+    """
+    row = db.execute(
+        text("SELECT value FROM app_settings WHERE key = :k"),
+        {"k": _DASHBOARD_BUBBLE_ORIGINS_KEY},
+    ).fetchone()
+    if not row or not row.value:
+        return []
+    try:
+        parsed = json.loads(row.value)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    out = []
+    seen = set()
+    for entry in parsed:
+        if not isinstance(entry, dict):
+            continue
+        origin = entry.get("origin")
+        if not isinstance(origin, str) or not origin or origin in seen:
+            continue
+        seen.add(origin)
+        label = entry.get("label")
+        out.append({
+            "origin": origin,
+            "label": label if isinstance(label, str) and label else origin,
+        })
+    return out
+
+
+@dashboard_bp.route("/shipping-health", methods=["GET"])
+@require_auth
+@with_db
+def shipping_health():
+    """Per-order-origin outbound health for the Marketplace Health view.
+
+    Returns one row per configured channel carrying:
+      * orders_received    (created_at within [start, end])
+      * orders_shipped     (status SHIPPED, shipped_at within range)
+      * need_to_ship_today (ship_by_date <= today, still open) -- always
+                           current-state, since the desk only acts on
+                           today's backlog
+      * orders             up to 200 SOs behind the ship-today count, so a
+                           click on the bubble renders the drill-down
+                           without a second round-trip
+
+    The configured channel set is materialised as a CTE and LEFT JOINed so
+    every bubble renders even when its count is zero (a green check is
+    information, not an empty grid). With no channels configured the
+    response is ``by_source: []``. start / end default to CURRENT_DATE;
+    warehouse_id is required; received / shipped honour the range. A
+    SHIPPED, CANCELLED (refunds cancel the original), or FRAUD_REVIEW order
+    is out of the ship-today pool.
+    """
+    warehouse_id = request.args.get("warehouse_id", type=int)
+    if not warehouse_id:
+        return jsonify({"error": "warehouse_id is required"}), 422
+    start_dt, end_dt, err = _parse_dashboard_range()
+    if err is not None:
+        return err
+    end_exclusive = end_dt + timedelta(days=1)
+
+    bubbles = _bubble_origins(g.db)
+    if not bubbles:
+        return jsonify({
+            "warehouse_id": warehouse_id,
+            "range": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
+            "by_source": [],
+        })
+    origins = [b["origin"] for b in bubbles]
+    label_by_origin = {b["origin"]: b["label"] for b in bubbles}
+
+    rows = g.db.execute(
+        text(
+            """
+            WITH origins AS (
+                SELECT UNNEST(CAST(:origins AS text[])) AS order_origin
+            )
+            SELECT o.order_origin,
+                   COUNT(so.so_id) FILTER (
+                       WHERE so.created_at >= :start
+                         AND so.created_at < :end
+                   ) AS orders_received,
+                   COUNT(so.so_id) FILTER (
+                       WHERE so.status = 'SHIPPED'
+                         AND so.shipped_at >= :start
+                         AND so.shipped_at < :end
+                   ) AS orders_shipped,
+                   COUNT(so.so_id) FILTER (
+                       WHERE so.ship_by_date IS NOT NULL
+                         AND so.ship_by_date <= CURRENT_DATE
+                         AND so.status NOT IN ('SHIPPED', 'CANCELLED', 'FRAUD_REVIEW')
+                   ) AS need_to_ship_today
+              FROM origins o
+              LEFT JOIN sales_orders so
+                ON so.order_origin = o.order_origin
+               AND so.warehouse_id = :wid
+             GROUP BY o.order_origin
+             ORDER BY o.order_origin
+            """
+        ),
+        {
+            "wid": warehouse_id,
+            "start": start_dt,
+            "end": end_exclusive,
+            "origins": origins,
+        },
+    ).fetchall()
+
+    # Drill-down: the SO list behind every non-zero need_to_ship_today
+    # bubble. Capped per-origin in Python (the count is bounded to
+    # len(origins) x 200, so a plain order-and-truncate beats ROW_NUMBER()
+    # partition work). Earliest ship_by_date first so the desk sees the
+    # oldest debt at the top of the modal.
+    detail_rows = g.db.execute(
+        text(
+            """
+            SELECT so.order_origin, so.so_id, so.so_number,
+                   so.customer_name, so.status, so.ship_by_date
+              FROM sales_orders so
+             WHERE so.warehouse_id = :wid
+               AND so.order_origin = ANY(CAST(:origins AS text[]))
+               AND so.ship_by_date IS NOT NULL
+               AND so.ship_by_date <= CURRENT_DATE
+               AND so.status NOT IN ('SHIPPED', 'CANCELLED', 'FRAUD_REVIEW')
+             ORDER BY so.ship_by_date ASC, so.so_id ASC
+            """
+        ),
+        {"wid": warehouse_id, "origins": origins},
+    ).fetchall()
+    orders_by_origin = {o: [] for o in origins}
+    for r in detail_rows:
+        bucket = orders_by_origin.get(r.order_origin)
+        if bucket is None or len(bucket) >= 200:
+            continue
+        bucket.append({
+            "so_id": r.so_id,
+            "so_number": r.so_number,
+            "customer_name": r.customer_name,
+            "status": r.status,
+            "ship_by_date": r.ship_by_date.isoformat() if r.ship_by_date else None,
+        })
+
+    return jsonify({
+        "warehouse_id": warehouse_id,
+        "range": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
+        "by_source": [
+            {
+                "order_origin": r.order_origin,
+                "label": label_by_origin.get(r.order_origin, r.order_origin),
+                "orders_received": int(r.orders_received or 0),
+                "orders_shipped": int(r.orders_shipped or 0),
+                "need_to_ship_today": int(r.need_to_ship_today or 0),
+                "orders": orders_by_origin.get(r.order_origin, []),
+            }
+            for r in rows
+        ],
+    })

--- a/api/tests/test_dashboard_operations.py
+++ b/api/tests/test_dashboard_operations.py
@@ -1,0 +1,214 @@
+"""Operations dashboard: /received and /shipping-health.
+
+Covers:
+- /api/v1/dashboard/shipping-health:
+    bubble set is admin-defined via app_settings.dashboard_bubble_origins;
+    no setting -> by_source: [] (nothing implicit from data);
+    a configured channel renders even at zero count (LEFT JOIN);
+    orders_received / orders_shipped honor the range; need_to_ship_today
+    is current-state and excludes SHIPPED / CANCELLED / FRAUD_REVIEW;
+    the drill-down `orders` list rides behind the ship-today count;
+    label comes from the setting, falling back to the origin value;
+    warehouse scoping; warehouse_id required -> 422; bad range -> 422.
+- /api/v1/dashboard/received:
+    per-PO aggregation of RECEIVE audit rows in range; warehouse_id
+    required -> 422.
+"""
+
+import json
+import os
+import sys
+from datetime import date, timedelta
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import db_test_context
+
+
+TODAY = date.today()
+
+
+def _exec(sql, params=()):
+    conn = db_test_context.get_raw_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(sql, params)
+        if cur.description is None:
+            return None
+        return cur.fetchall()
+    finally:
+        cur.close()
+
+
+def _set_bubbles(entries):
+    """Write app_settings.dashboard_bubble_origins. entries is a list of
+    {"origin", "label"} dicts, or None to clear the row entirely."""
+    if entries is None:
+        _exec("DELETE FROM app_settings WHERE key = 'dashboard_bubble_origins'")
+        return
+    _exec(
+        "INSERT INTO app_settings (key, value) VALUES ('dashboard_bubble_origins', %s) "
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+        (json.dumps(entries),),
+    )
+
+
+_SO_SEQ = [9000]
+
+
+def _seed_so(*, order_origin, status="OPEN", warehouse_id=1,
+             ship_by_date=None, created_at=None, shipped_at=None,
+             customer_name="ACME"):
+    """Insert a minimal sales_orders row with a unique so_number."""
+    _SO_SEQ[0] += 1
+    n = _SO_SEQ[0]
+    _exec(
+        "INSERT INTO sales_orders "
+        "  (so_number, so_barcode, external_id, status, warehouse_id, "
+        "   order_origin, customer_name, ship_by_date, created_at, shipped_at) "
+        "VALUES (%s, %s, gen_random_uuid(), %s, %s, %s, %s, %s, "
+        "        COALESCE(%s, NOW()), %s)",
+        (f"OPS-{n}", f"OPS-{n}", status, warehouse_id, order_origin,
+         customer_name, ship_by_date, created_at, shipped_at),
+    )
+    return f"OPS-{n}"
+
+
+def _get(client, auth_headers, path):
+    return client.get(path, headers=auth_headers)
+
+
+def _by_origin(payload):
+    return {row["order_origin"]: row for row in payload["by_source"]}
+
+
+@pytest.fixture(autouse=True)
+def _clean_dashboard_state():
+    # Isolate from other suites: drop our setting + any rows we seeded.
+    _set_bubbles(None)
+    _exec("DELETE FROM sales_orders WHERE so_number LIKE 'OPS-%%'")
+    yield
+    _set_bubbles(None)
+    _exec("DELETE FROM sales_orders WHERE so_number LIKE 'OPS-%%'")
+
+
+class TestShippingHealthBubbleSet:
+    def test_no_setting_returns_empty_by_source(self, client, auth_headers):
+        # Nothing configured -> the dashboard surfaces nothing implicitly.
+        _seed_so(order_origin="AMAZON", ship_by_date=TODAY)
+        resp = _get(client, auth_headers,
+                    "/api/v1/dashboard/shipping-health?warehouse_id=1")
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["by_source"] == []
+
+    def test_configured_channel_renders_at_zero(self, client, auth_headers):
+        # A configured channel with no matching orders still renders a
+        # bubble (LEFT JOIN), so the desk sees a green-check, not a gap.
+        _set_bubbles([{"origin": "EBAY", "label": "eBay"}])
+        resp = _get(client, auth_headers,
+                    "/api/v1/dashboard/shipping-health?warehouse_id=1")
+        rows = _by_origin(resp.get_json())
+        assert set(rows) == {"EBAY"}
+        assert rows["EBAY"]["label"] == "eBay"
+        assert rows["EBAY"]["orders_received"] == 0
+        assert rows["EBAY"]["need_to_ship_today"] == 0
+        assert rows["EBAY"]["orders"] == []
+
+    def test_label_falls_back_to_origin(self, client, auth_headers):
+        _set_bubbles([{"origin": "DIRECTSALE"}])  # no label
+        resp = _get(client, auth_headers,
+                    "/api/v1/dashboard/shipping-health?warehouse_id=1")
+        rows = _by_origin(resp.get_json())
+        assert rows["DIRECTSALE"]["label"] == "DIRECTSALE"
+
+    def test_malformed_setting_yields_no_bubbles(self, client, auth_headers):
+        _exec(
+            "INSERT INTO app_settings (key, value) VALUES "
+            "('dashboard_bubble_origins', 'not json') "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        )
+        resp = _get(client, auth_headers,
+                    "/api/v1/dashboard/shipping-health?warehouse_id=1")
+        assert resp.status_code == 200
+        assert resp.get_json()["by_source"] == []
+
+
+class TestShippingHealthCounts:
+    def test_need_to_ship_today_excludes_terminal_statuses(self, client, auth_headers):
+        _set_bubbles([{"origin": "AMAZON", "label": "Amazon"}])
+        # Two open orders due today -> counted; shipped / cancelled /
+        # fraud-held / future-dated are not.
+        _seed_so(order_origin="AMAZON", status="OPEN", ship_by_date=TODAY)
+        _seed_so(order_origin="AMAZON", status="PACKED", ship_by_date=TODAY)
+        _seed_so(order_origin="AMAZON", status="SHIPPED", ship_by_date=TODAY)
+        _seed_so(order_origin="AMAZON", status="CANCELLED", ship_by_date=TODAY)
+        _seed_so(order_origin="AMAZON", status="FRAUD_REVIEW", ship_by_date=TODAY)
+        _seed_so(order_origin="AMAZON", status="OPEN",
+                 ship_by_date=TODAY + timedelta(days=3))
+        resp = _get(client, auth_headers,
+                    "/api/v1/dashboard/shipping-health?warehouse_id=1")
+        rows = _by_origin(resp.get_json())
+        assert rows["AMAZON"]["need_to_ship_today"] == 2
+        # Drill-down carries the two due-today open orders, oldest first.
+        assert len(rows["AMAZON"]["orders"]) == 2
+        assert {o["status"] for o in rows["AMAZON"]["orders"]} == {"OPEN", "PACKED"}
+
+    def test_shipped_count_honors_range_and_status(self, client, auth_headers):
+        _set_bubbles([{"origin": "AMAZON", "label": "Amazon"}])
+        _seed_so(order_origin="AMAZON", status="SHIPPED", shipped_at=TODAY)
+        _seed_so(order_origin="AMAZON", status="SHIPPED",
+                 shipped_at=TODAY - timedelta(days=10))  # outside today range
+        resp = _get(client, auth_headers,
+                    "/api/v1/dashboard/shipping-health?warehouse_id=1")
+        rows = _by_origin(resp.get_json())
+        assert rows["AMAZON"]["orders_shipped"] == 1
+
+    def test_warehouse_scoping(self, client, auth_headers):
+        _set_bubbles([{"origin": "AMAZON", "label": "Amazon"}])
+        _seed_so(order_origin="AMAZON", status="OPEN", warehouse_id=1,
+                 ship_by_date=TODAY)
+        _seed_so(order_origin="AMAZON", status="OPEN", warehouse_id=2,
+                 ship_by_date=TODAY)
+        rows = _by_origin(_get(
+            client, auth_headers,
+            "/api/v1/dashboard/shipping-health?warehouse_id=1").get_json())
+        assert rows["AMAZON"]["need_to_ship_today"] == 1
+
+
+class TestShippingHealthValidation:
+    def test_warehouse_id_required(self, client, auth_headers):
+        resp = _get(client, auth_headers, "/api/v1/dashboard/shipping-health")
+        assert resp.status_code == 422
+
+    def test_bad_range(self, client, auth_headers):
+        resp = _get(
+            client, auth_headers,
+            "/api/v1/dashboard/shipping-health?warehouse_id=1"
+            "&start=2026-06-10&end=2026-06-01")
+        assert resp.status_code == 422
+
+    def test_requires_auth(self, client):
+        resp = client.get("/api/v1/dashboard/shipping-health?warehouse_id=1")
+        assert resp.status_code == 401
+
+
+class TestReceived:
+    def test_warehouse_id_required(self, client, auth_headers):
+        resp = _get(client, auth_headers, "/api/v1/dashboard/received")
+        assert resp.status_code == 422
+
+    def test_returns_pos_shape(self, client, auth_headers):
+        # No assertion on specific PO contents (seed-dependent); just the
+        # response shape + 200 so a regression in the SQL surfaces.
+        resp = _get(client, auth_headers,
+                    "/api/v1/dashboard/received?warehouse_id=1")
+        assert resp.status_code == 200, resp.get_json()
+        body = resp.get_json()
+        assert "pos" in body and isinstance(body["pos"], list)
+        assert body["warehouse_id"] == 1


### PR DESCRIPTION
Adds an operations view to the dashboard: a per-PO Received tab and a per-channel Marketplace Health tab, with the channel set admin-defined rather than hardcoded.

## What changes

- **Backend** (`api/routes/dashboard.py`): two read endpoints.
  - `GET /api/v1/dashboard/received` aggregates `audit_log` RECEIVE rows per PO for a date range (units, distinct line items, receivers, last receipt time).
  - `GET /api/v1/dashboard/shipping-health` returns per-channel outbound health (orders received, orders shipped, and a current-state need-to-ship-today count with the drill-down SO list behind it). The channel set is read from `app_settings.dashboard_bubble_origins` -- a JSON array of `{origin, label}` matched verbatim against the free-text `sales_orders.order_origin`. With nothing configured the response is an empty `by_source`; the dashboard never surfaces channels implicitly from the data.
- **Dashboard UI** (`Dashboard.jsx`): the page becomes a tab shell -- existing Productivity plus Received and Marketplace Health. The Marketplace Health view renders the endpoint's channels and labels directly (no hardcoded marketplace list), with a clickable ship-today bubble opening the SO drill-down, and a shared range picker.
- **Settings surface** (`Settings.jsx`): a Marketplace Health section to define the bubble set ({origin, label} rows) saved to `dashboard_bubble_origins`.

This branch is a re-authoring of the fork's dashboard-operations work; the hardcoded marketplace list became the settings surface, and the unrelated local-pickup view was left out. api + admin; no migration; no mobile change.

## Tests

`test_dashboard_operations.py` (new, 12 cases) covers the settings-driven bubble set (empty default, configured channels, zero-count render, label fallback, malformed setting), the count/range/scoping logic, and validation. Full api suite green; admin build + vitest (78) green.