### PR TITLE
feat(po): reopen received lines on quantity edit and emit purchaseorderedit.completed

### DIFF
--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -85,6 +85,7 @@ from services.sales_order_service import (
 from services.receiving_service import (
     UnreceiveError,
     record_unreceive,
+    recompute_po_status,
 )
 from services.shipping_service import carrier_from_ship_method, record_ship
 from services.webhook_dispatcher.backorder_notifier import (
@@ -249,6 +250,44 @@ PO_STATUS_VALUES = {PO_OPEN, PO_PARTIAL, PO_RECEIVED, PO_CLOSED, PO_ARCHIVED}
 PO_EDIT_BLOCKED_STATUSES = {PO_CLOSED, PO_ARCHIVED}
 
 
+def _emit_po_edit(db, *, po_id, po_external_id, po_number, warehouse_id,
+                  status, changes, username):
+    """Emit purchaseorderedit.completed carrying the per-field diff so the
+    ERP can reverse-sync a PO edit made in Sentry -- the outbound half of
+    the both-ways PO-edit flow. Mirrors salesorderedit.completed.
+
+    No-op when ``changes`` is empty: the event schema requires at least
+    one change, and a re-PATCH that lands the same values is not an edit
+    worth shipping. purchase_order_external_id carries the source-system
+    id when one exists (cross_system_mappings), falling back to the
+    Sentry canonical UUID so the consumer always has a key to act on.
+    """
+    if not changes:
+        return
+    po_source_external_id = (
+        resolve_source_external_id(db, "purchase_order", po_external_id)
+        or str(po_external_id)
+    )
+    emit_event(
+        db,
+        event_type="purchaseorderedit.completed",
+        event_version=1,
+        aggregate_type="purchase_order",
+        aggregate_id=po_id,
+        aggregate_external_id=po_external_id,
+        warehouse_id=warehouse_id,
+        source_txn_id=g.source_txn_id,
+        payload={
+            "purchase_order_external_id": po_source_external_id,
+            "po_number": po_number,
+            "status": status,
+            "changes": changes,
+            "edited_by_user_external_id": get_user_external_id(db, username),
+            "edited_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+    )
+
+
 @admin_bp.route("/purchase-orders/<int:po_id>", methods=["PUT"])
 @require_auth
 @require_admin_or_page_permission("purchase-orders")
@@ -258,7 +297,11 @@ def update_purchase_order(po_id, validated):
     data = validated.model_dump(exclude_unset=True)
 
     po = g.db.execute(
-        text("SELECT po_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
+        text(
+            "SELECT po_id, po_number, po_barcode, vendor_name, expected_date, "
+            "notes, external_id, status, warehouse_id "
+            "FROM purchase_orders WHERE po_id = :pid"
+        ),
         {"pid": po_id},
     ).fetchone()
     if not po:
@@ -314,6 +357,33 @@ def update_purchase_order(po_id, validated):
             details={"old_status": po.status, "new_status": new_status},
         )
 
+    status_changed = new_status is not None and new_status != po.status
+    changes = [
+        {
+            "field": field,
+            "old_value": str(getattr(po, field)) if getattr(po, field) is not None else None,
+            "new_value": str(val) if val is not None else None,
+        }
+        for field, val in header_data.items()
+        if val != getattr(po, field)
+    ]
+    if status_changed:
+        changes.append({
+            "field": "status",
+            "old_value": po.status,
+            "new_value": new_status,
+        })
+    _emit_po_edit(
+        g.db,
+        po_id=po_id,
+        po_external_id=po.external_id,
+        po_number=po.po_number,
+        warehouse_id=po.warehouse_id,
+        status=new_status if status_changed else po.status,
+        changes=changes,
+        username=g.current_user["username"],
+    )
+
     g.db.commit()
 
     row = g.db.execute(
@@ -340,7 +410,7 @@ def add_purchase_order_line(po_id, validated):
     data = validated.model_dump()
 
     po = g.db.execute(
-        text("SELECT po_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
+        text("SELECT po_id, po_number, external_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
         {"pid": po_id},
     ).fetchone()
     if not po:
@@ -402,6 +472,24 @@ def add_purchase_order_line(po_id, validated):
             "quantity_ordered": data["quantity_ordered"],
         },
     )
+
+    # A new unreceived line on an already-RECEIVED PO reopens it to
+    # PARTIAL; recompute so the header reflects the added obligation.
+    new_po_status = recompute_po_status(g.db, po_id)
+    _emit_po_edit(
+        g.db,
+        po_id=po_id,
+        po_external_id=po.external_id,
+        po_number=po.po_number,
+        warehouse_id=po.warehouse_id,
+        status=new_po_status,
+        changes=[{
+            "field": f"line[{item.sku}]",
+            "old_value": None,
+            "new_value": str(data["quantity_ordered"]),
+        }],
+        username=g.current_user["username"],
+    )
     g.db.commit()
 
     return jsonify({
@@ -412,6 +500,7 @@ def add_purchase_order_line(po_id, validated):
         "quantity_ordered": data["quantity_ordered"],
         "quantity_received": 0,
         "line_number": next_ln,
+        "po_status": new_po_status,
     }), 201
 
 
@@ -424,7 +513,7 @@ def update_purchase_order_line(po_id, po_line_id, validated):
     data = validated.model_dump()
 
     po = g.db.execute(
-        text("SELECT po_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
+        text("SELECT po_id, po_number, external_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
         {"pid": po_id},
     ).fetchone()
     if not po:
@@ -463,6 +552,16 @@ def update_purchase_order_line(po_id, po_line_id, validated):
         {"qty": new_qty, "plid": po_line_id},
     )
 
+    # Re-derive the line + PO header status from the new ordered qty. This
+    # is what makes the over-receipt case work: bumping a RECEIVED line's
+    # quantity_ordered above what was received reopens it to PARTIAL (and
+    # the header with it) so the remaining unit becomes receivable again.
+    new_po_status = recompute_po_status(g.db, po_id)
+    new_line_status = g.db.execute(
+        text("SELECT status FROM purchase_order_lines WHERE po_line_id = :plid"),
+        {"plid": po_line_id},
+    ).scalar()
+
     write_audit_log(
         g.db,
         ACTION_PO_LINE_UPDATED,
@@ -476,8 +575,32 @@ def update_purchase_order_line(po_id, po_line_id, validated):
             "new_quantity_ordered": new_qty,
         },
     )
+
+    changes = []
+    if new_qty != line.quantity_ordered:
+        changes.append({
+            "field": f"line[{line.sku}].quantity_ordered",
+            "old_value": str(line.quantity_ordered),
+            "new_value": str(new_qty),
+        })
+    _emit_po_edit(
+        g.db,
+        po_id=po_id,
+        po_external_id=po.external_id,
+        po_number=po.po_number,
+        warehouse_id=po.warehouse_id,
+        status=new_po_status,
+        changes=changes,
+        username=g.current_user["username"],
+    )
+
     g.db.commit()
-    return jsonify({"po_line_id": po_line_id, "quantity_ordered": new_qty})
+    return jsonify({
+        "po_line_id": po_line_id,
+        "quantity_ordered": new_qty,
+        "line_status": new_line_status,
+        "po_status": new_po_status,
+    })
 
 
 @admin_bp.route("/purchase-orders/<int:po_id>/lines/<int:po_line_id>", methods=["DELETE"])
@@ -486,7 +609,7 @@ def update_purchase_order_line(po_id, po_line_id, validated):
 @with_db
 def delete_purchase_order_line(po_id, po_line_id):
     po = g.db.execute(
-        text("SELECT po_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
+        text("SELECT po_id, po_number, external_id, status, warehouse_id FROM purchase_orders WHERE po_id = :pid"),
         {"pid": po_id},
     ).fetchone()
     if not po:
@@ -538,8 +661,26 @@ def delete_purchase_order_line(po_id, po_line_id):
             "quantity_ordered": line.quantity_ordered,
         },
     )
+
+    # Removing a line can complete the PO (e.g. the only unreceived line
+    # is gone, leaving the rest fully received); recompute the header.
+    new_po_status = recompute_po_status(g.db, po_id)
+    _emit_po_edit(
+        g.db,
+        po_id=po_id,
+        po_external_id=po.external_id,
+        po_number=po.po_number,
+        warehouse_id=po.warehouse_id,
+        status=new_po_status,
+        changes=[{
+            "field": f"line[{line.sku}]",
+            "old_value": str(line.quantity_ordered),
+            "new_value": None,
+        }],
+        username=g.current_user["username"],
+    )
     g.db.commit()
-    return jsonify({"po_line_id": po_line_id, "deleted": True})
+    return jsonify({"po_line_id": po_line_id, "deleted": True, "po_status": new_po_status})
 
 
 @admin_bp.route("/purchase-orders/<int:po_id>/close", methods=["POST"])

--- a/api/schemas_v1/events/purchaseorderedit.completed/1.json
+++ b/api/schemas_v1/events/purchaseorderedit.completed/1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sentry-wms.example/events/purchaseorderedit.completed/1.json",
+  "title": "purchaseorderedit.completed v1",
+  "description": "A purchase order was edited through the admin edit surface: the header (PUT /api/admin/purchase-orders/<id>) or any line operation (POST/PATCH/DELETE .../lines[/<id>]). Carries the per-field diff that landed so the ERP can reverse-sync a correction made in Sentry. Aggregate: purchase_order. Header field edits use the bare field name (e.g. vendor_name, status); line edits qualify the field with the line's SKU so the consumer knows which line moved: line[SKU].quantity_ordered for a quantity change, line[SKU] for a line added (old_value null) or removed (new_value null). purchase_order_external_id carries the source-system identifier when one exists (cross_system_mappings), falling back to the Sentry canonical UUID, so it is a plain string rather than format:uuid.",
+  "type": "object",
+  "required": [
+    "purchase_order_external_id",
+    "po_number",
+    "status",
+    "changes",
+    "edited_by_user_external_id",
+    "edited_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "purchase_order_external_id": { "type": "string" },
+    "po_number": { "type": "string" },
+    "status": { "type": "string" },
+    "changes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["field", "old_value", "new_value"],
+        "additionalProperties": false,
+        "properties": {
+          "field": { "type": "string" },
+          "old_value": { "type": ["string", "null"] },
+          "new_value": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "edited_by_user_external_id": { "type": "string", "format": "uuid" },
+    "edited_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/api/services/events_schema_registry.py
+++ b/api/services/events_schema_registry.py
@@ -67,6 +67,13 @@ V150_CATALOG: Tuple[Tuple[str, int, str], ...] = (
     # previously emitted nothing. A status transition to SHIPPED on that
     # same edit additionally emits ship.confirmed (via record_ship).
     ("salesorderedit.completed", 1, "sales_order"),
+    # po-edit-reverse-sync: a purchase order was edited through the admin
+    # edit surface (header PUT or any line add/update/remove). Carries the
+    # per-field diff -- line edits qualify the field with the SKU
+    # (line[SKU].quantity_ordered) so the ERP knows which line moved and can
+    # reverse-sync a PO correction made in Sentry. The mirror of
+    # salesorderedit.completed for the inbound-PO over-receipt path.
+    ("purchaseorderedit.completed", 1, "purchase_order"),
     # post-fulfillment returns: goods received back against a return SO
     # (the <orig>-RMA goods-in). One event per item_receipts row, mirroring
     # receipt.completed; the destination warehouse_code carries the

--- a/api/services/receiving_service.py
+++ b/api/services/receiving_service.py
@@ -54,6 +54,60 @@ class UnreceiveError(Exception):
         self.context = context
 
 
+def recompute_po_status(db, po_id: int) -> str:
+    """Re-derive every line's status and the PO header status from the
+    lines' current quantity_received vs quantity_ordered, persist them,
+    and return the new header status.
+
+    Single source of truth for PO status derivation. A line is PENDING
+    when nothing is received, RECEIVED when receipts meet or exceed the
+    order, PARTIAL in between; the header is RECEIVED when every line is
+    fully received, PARTIAL when any line carries receipts, OPEN
+    otherwise. Callers invoke this after changing quantity_ordered (admin
+    line edit) or quantity_received (unreceive) so a RECEIVED line
+    reopens to PARTIAL once the order grows past what was received -- and
+    the header follows in lockstep, which is what makes an over-receipt
+    receivable again.
+    """
+    db.execute(
+        text(
+            """
+            UPDATE purchase_order_lines
+               SET status = CASE
+                       WHEN quantity_received = 0 THEN :pol_pending
+                       WHEN quantity_received >= quantity_ordered THEN :pol_received
+                       ELSE :pol_partial
+                   END
+             WHERE po_id = :pid
+            """
+        ),
+        {
+            "pid": po_id,
+            "pol_pending": POL_PENDING,
+            "pol_received": POL_RECEIVED,
+            "pol_partial": POL_PARTIAL,
+        },
+    )
+    lines = db.execute(
+        text(
+            "SELECT quantity_received, quantity_ordered "
+            "  FROM purchase_order_lines WHERE po_id = :pid"
+        ),
+        {"pid": po_id},
+    ).fetchall()
+    if lines and all(ln.quantity_received >= ln.quantity_ordered for ln in lines):
+        new_status = PO_RECEIVED
+    elif any(ln.quantity_received > 0 for ln in lines):
+        new_status = PO_PARTIAL
+    else:
+        new_status = PO_OPEN
+    db.execute(
+        text("UPDATE purchase_orders SET status = :s WHERE po_id = :pid"),
+        {"s": new_status, "pid": po_id},
+    )
+    return new_status
+
+
 def record_unreceive(
     db,
     *,
@@ -220,31 +274,20 @@ def record_unreceive(
             receipt_quantity=qty_to_reverse,
         )
 
-    # Decrement PO line + flip its status. GREATEST(0, ...) is
+    # Decrement the PO line's received qty. GREATEST(0, ...) is
     # redundant once the warehouse-available check passes but keeps
-    # the same shape as cancel_receiving for reviewer familiarity.
+    # the same shape as cancel_receiving for reviewer familiarity. The
+    # line + header status flips are derived afterward by
+    # recompute_po_status so the rule lives in one place.
     db.execute(
         text(
             """
             UPDATE purchase_order_lines
-               SET quantity_received = GREATEST(0, quantity_received - :qty),
-                   status = CASE
-                       WHEN GREATEST(0, quantity_received - :qty) = 0
-                           THEN :pol_pending
-                       WHEN GREATEST(0, quantity_received - :qty) >= quantity_ordered
-                           THEN :pol_received
-                       ELSE :pol_partial
-                   END
+               SET quantity_received = GREATEST(0, quantity_received - :qty)
              WHERE po_line_id = :plid
             """
         ),
-        {
-            "qty": qty_to_reverse,
-            "plid": receipt.po_line_id,
-            "pol_pending": POL_PENDING,
-            "pol_received": POL_RECEIVED,
-            "pol_partial": POL_PARTIAL,
-        },
+        {"qty": qty_to_reverse, "plid": receipt.po_line_id},
     )
 
     # Hard-delete the receipt row -- the audit row + event carry the
@@ -256,28 +299,10 @@ def record_unreceive(
         {"rid": receipt_id},
     )
 
-    # PO status recompute. Re-open if any line dropped below
-    # quantity_ordered; matches receive_items's status flip on the
-    # other side.
-    all_lines = db.execute(
-        text(
-            "SELECT quantity_received, quantity_ordered "
-            "  FROM purchase_order_lines WHERE po_id = :pid"
-        ),
-        {"pid": receipt.po_id},
-    ).fetchall()
-    if all(ln.quantity_received >= ln.quantity_ordered for ln in all_lines):
-        new_po_status = PO_RECEIVED
-    elif any(ln.quantity_received > 0 for ln in all_lines):
-        new_po_status = PO_PARTIAL
-    else:
-        new_po_status = PO_OPEN
-    db.execute(
-        text(
-            "UPDATE purchase_orders SET status = :s WHERE po_id = :pid"
-        ),
-        {"s": new_po_status, "pid": receipt.po_id},
-    )
+    # PO line + header status recompute. Re-opens any line that dropped
+    # below quantity_ordered and the header in lockstep; matches
+    # receive_items's status flip on the other side.
+    new_po_status = recompute_po_status(db, receipt.po_id)
 
     write_audit_log(
         db,

--- a/api/tests/test_po_line_edit_reopen.py
+++ b/api/tests/test_po_line_edit_reopen.py
@@ -1,0 +1,211 @@
+"""PO line-edit reopen + purchaseorderedit.completed outbound event.
+
+Covers stikman28/sentry-wms#55: bumping quantity_ordered on a RECEIVED
+line must reopen it (RECEIVED -> PARTIAL) so the over-receipt becomes
+receivable, and every admin PO edit emits purchaseorderedit.completed so
+the ERP can reverse-sync the change.
+
+Fixture: seed PO-2026-005 (po_id 5) is a single line -- item 20
+(TST-020), quantity_ordered 100 -- so the PO header status tracks the
+one line directly. Warehouse 1, staging bin 1 (matches the other admin
+PO tests).
+"""
+
+import json
+
+from db_test_context import get_raw_connection
+from services.events_schema_registry import get_validator
+
+PO_ID = 5
+SKU = "TST-020"
+BIN = 1
+
+
+def _receive(client, headers, item_id, qty, po_id=PO_ID, bin_id=BIN):
+    return client.post(
+        "/api/receiving/receive",
+        json={
+            "po_id": po_id,
+            "items": [{"item_id": item_id, "quantity": qty, "bin_id": bin_id}],
+        },
+        headers=headers,
+    )
+
+
+def _detail(client, headers, po_id=PO_ID):
+    return client.get(
+        f"/api/admin/purchase-orders/{po_id}", headers=headers,
+    ).get_json()
+
+
+def _line(detail, idx=0):
+    return detail["lines"][idx]
+
+
+def _po_edit_events(po_id=PO_ID):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT payload FROM integration_events "
+        " WHERE aggregate_type = 'purchase_order' AND aggregate_id = %s "
+        "   AND event_type = 'purchaseorderedit.completed' "
+        " ORDER BY event_id",
+        (po_id,),
+    )
+    rows = [r[0] if isinstance(r[0], dict) else json.loads(r[0]) for r in cur.fetchall()]
+    cur.close()
+    return rows
+
+
+def _assert_valid(payload):
+    errors = list(get_validator("purchaseorderedit.completed", 1).iter_errors(payload))
+    assert errors == [], errors
+
+
+class TestOverReceiptReopen:
+    def test_qty_bump_reopens_received_line_and_makes_overreceipt_receivable(
+        self, client, auth_headers,
+    ):
+        # Receive the full order -> line + PO go RECEIVED.
+        assert _receive(client, auth_headers, item_id=20, qty=100).status_code == 200
+        before = _detail(client, auth_headers)
+        line = _line(before)
+        assert line["status"] == "RECEIVED"
+        assert before["purchase_order"]["status"] == "RECEIVED"
+
+        # The extra unit is hard-blocked today: receiving accepts only
+        # OPEN/PARTIAL POs, so a fully-RECEIVED PO refuses any further
+        # receipt -- the over-receipt is stuck until the PO reopens.
+        blocked = _receive(client, auth_headers, item_id=20, qty=1)
+        assert blocked.status_code == 400
+        assert "cannot receive" in blocked.get_json()["error"]
+
+        # Bump quantity_ordered: the line reopens to PARTIAL (and the PO
+        # with it) so the remaining unit becomes a normal in-order receipt.
+        resp = client.patch(
+            f"/api/admin/purchase-orders/{PO_ID}/lines/{line['po_line_id']}",
+            json={"quantity_ordered": 101},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["quantity_ordered"] == 101
+        assert body["line_status"] == "PARTIAL"
+        assert body["po_status"] == "PARTIAL"
+
+        # The over-receipt is now receivable without the global override.
+        assert _receive(client, auth_headers, item_id=20, qty=1).status_code == 200
+        after = _line(_detail(client, auth_headers))
+        assert after["quantity_received"] == 101
+        assert after["status"] == "RECEIVED"
+        assert _detail(client, auth_headers)["purchase_order"]["status"] == "RECEIVED"
+
+    def test_qty_below_received_still_rejected(self, client, auth_headers):
+        # The reopen path must not weaken the non-negative-variance guard.
+        _receive(client, auth_headers, item_id=20, qty=40)
+        line = _line(_detail(client, auth_headers))
+        resp = client.patch(
+            f"/api/admin/purchase-orders/{PO_ID}/lines/{line['po_line_id']}",
+            json={"quantity_ordered": 30},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "less than" in resp.get_json()["error"]
+
+
+class TestPurchaseOrderEditEvent:
+    def test_line_qty_edit_emits_sku_qualified_event(self, client, auth_headers):
+        line = _line(_detail(client, auth_headers))
+        resp = client.patch(
+            f"/api/admin/purchase-orders/{PO_ID}/lines/{line['po_line_id']}",
+            json={"quantity_ordered": 120},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        events = _po_edit_events()
+        assert len(events) == 1
+        payload = events[0]
+        assert payload["po_number"] == "PO-2026-005"
+        assert payload["status"] == "OPEN"  # nothing received yet
+        assert payload["changes"] == [{
+            "field": f"line[{SKU}].quantity_ordered",
+            "old_value": "100",
+            "new_value": "120",
+        }]
+        assert payload["purchase_order_external_id"]  # uuid fallback, non-empty
+        _assert_valid(payload)
+
+    def test_no_event_when_quantity_unchanged(self, client, auth_headers):
+        line = _line(_detail(client, auth_headers))
+        resp = client.patch(
+            f"/api/admin/purchase-orders/{PO_ID}/lines/{line['po_line_id']}",
+            json={"quantity_ordered": line["quantity_ordered"]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        assert _po_edit_events() == []
+
+    def test_header_edit_emits_event(self, client, auth_headers):
+        resp = client.put(
+            f"/api/admin/purchase-orders/{PO_ID}",
+            json={"notes": "rush -- vendor backorder cleared"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        events = _po_edit_events()
+        assert len(events) == 1
+        payload = events[0]
+        assert {
+            "field": "notes",
+            "old_value": None,
+            "new_value": "rush -- vendor backorder cleared",
+        } in payload["changes"]
+        _assert_valid(payload)
+
+    def test_add_line_reopens_received_po_and_emits(self, client, auth_headers):
+        # Fully receive the PO, then add a fresh unreceived line.
+        _receive(client, auth_headers, item_id=20, qty=100)
+        assert _detail(client, auth_headers)["purchase_order"]["status"] == "RECEIVED"
+
+        resp = client.post(
+            f"/api/admin/purchase-orders/{PO_ID}/lines",
+            json={"item_id": 1, "quantity_ordered": 5},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["po_status"] == "PARTIAL"
+
+        events = _po_edit_events()
+        assert len(events) == 1
+        assert events[0]["changes"] == [{
+            "field": "line[TST-001]",
+            "old_value": None,
+            "new_value": "5",
+        }]
+        assert events[0]["status"] == "PARTIAL"
+        _assert_valid(events[0])
+
+    def test_remove_line_emits_event(self, client, auth_headers):
+        add = client.post(
+            f"/api/admin/purchase-orders/{PO_ID}/lines",
+            json={"item_id": 1, "quantity_ordered": 7},
+            headers=auth_headers,
+        )
+        po_line_id = add.get_json()["po_line_id"]
+        resp = client.delete(
+            f"/api/admin/purchase-orders/{PO_ID}/lines/{po_line_id}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Two edits this PO: the add then the remove. Assert the latest.
+        events = _po_edit_events()
+        assert len(events) == 2
+        assert events[-1]["changes"] == [{
+            "field": "line[TST-001]",
+            "old_value": "7",
+            "new_value": None,
+        }]
+        _assert_valid(events[-1])


### PR DESCRIPTION
Bumping `quantity_ordered` on a RECEIVED PO line through the admin edit surface now reopens it (RECEIVED -> PARTIAL) and the PO header with it, so an over-receipt becomes receivable instead of being stuck behind a fully-received line. Line and header status are derived through a new shared `recompute_po_status` helper in `receiving_service`; `record_unreceive` now uses the same helper in place of its own inline copy.

Every admin PO edit (header PUT, line add/update/remove) emits a new `purchaseorderedit.completed` event carrying the per-field diff so the ERP can reverse-sync a correction made in Sentry. Line edits qualify the changed field with the SKU (`line[SKU].quantity_ordered`) so the consumer knows which line moved.

Covers `stikman28/sentry-wms#55`.
