### PR TITLE
ci: add gitleaks secret-scanning gate

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,41 @@
+name: gitleaks
+
+# Secret scanning for this public OSS repo. Runs the gitleaks binary
+# directly (the official gitleaks-action requires a registered
+# GITLEAKS_LICENSE for org-owned repos, which this is). Scans the entire
+# git history on every push and pull request and fails on any finding.
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          # Full history so gitleaks scans every commit, not just the tip.
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.21.2
+        run: |
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -fsSL "$url" -o /tmp/gitleaks.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan history for secrets
+        # Picks up .gitleaks.toml from the repo root automatically.
+        # --redact keeps any finding out of the CI logs; --exit-code 1
+        # fails the job when a secret is detected.
+        run: gitleaks detect --source . --redact --verbose --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,38 @@
+# gitleaks configuration for sentry-wms.
+#
+# Extends the gitleaks default ruleset and allowlists ONLY the known-benign
+# placeholder secrets that the default rules flag in the test suite and CI.
+# Every entry is a precise value regex, never a path exclude, so a real
+# secret introduced anywhere -- including these same files -- is still
+# caught.
+#
+# Findings enumerated with gitleaks 8.21.2:
+#   gitleaks detect --source .
+#
+# Note: the AWS doc example key AKIAIOSFODNN7EXAMPLE and the local dev
+# creds postgresql://sentry:sentry@... are NOT listed here because the
+# default ruleset does not flag them (the former is in gitleaks' own
+# built-in allowlist), so adding them would be dead config.
+
+title = "sentry-wms gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known-benign placeholder secrets in tests and CI dummy keys"
+regexes = [
+  # api/tests/test_log_sanitize.py + api/tests/test_connectors.py: fixed
+  # placeholder API keys / OAuth tokens that assert the log scrubber redacts
+  # them. Matched by their literal value, which no real credential shares.
+  '''ABCDEFGHIJ1234567890LMNOPQR''',
+  '''ABCDEFGHIJKLMNOP1234567890abcdef''',
+  '''0123456789abcdefABCDEFGHIJ0123456789xyz''',
+  # api/tests/test_log_sanitize.py: example JWTs whose signature segment is
+  # the literal string "signaturepart" -- never present in a real token.
+  '''eyJhbGciOiJIUzI1NiJ9\.eyJ[A-Za-z0-9]+\.signaturepart[A-Za-z0-9]*''',
+  # The dummy HMAC key (0123456789abcdef repeated) used to exercise pubsub
+  # signature verification, in .github/workflows/test.yml and
+  # api/tests/test_webhook_dispatcher_pubsub_signing.py.
+  '''0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef''',
+]


### PR DESCRIPTION
Scans the full git history for secrets on every push and pull request and fails the build on any finding, so nothing sensitive can land in this public repo.

- Runs the pinned gitleaks 8.21.2 binary directly rather than the `gitleaks-action`, which requires a registered license for org-owned repos. The checkout uses `fetch-depth: 0` so the scan covers every commit.
- `.gitleaks.toml` extends the default ruleset and allowlists only the known-benign placeholder secrets the default rules flag in the test suite and CI (fixed-value API keys and JWTs in the log-sanitizer tests, the dummy pubsub HMAC key), each matched by precise value rather than a path exclude, so a real secret in those same files is still caught.

The allowlist was checked against a planted fake token to confirm it is not over-broad: detection still fires.
