### PR TITLE
feat(pos): revamp the POS Activity dashboard

### DIFF
--- a/admin/src/pages/POSActivity.css
+++ b/admin/src/pages/POSActivity.css
@@ -1,0 +1,122 @@
+/* POS Activity dashboard -- retail revenue: pace curve, weekly trend,
+   channel + tender splits, full KPIs. Shared admin theme tokens.
+   Label/secondary text uses --text-secondary (not the lighter
+   --text-tertiary) for readability. */
+
+.pos-grid { display: flex; flex-direction: column; gap: 14px; }
+
+/* ── Date controls ── */
+.pos-datebar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.pos-dbtn {
+  font-family: var(--sans); font-size: 13px; font-weight: 600;
+  padding: 6px 12px; border-radius: var(--radius);
+  border: 1px solid var(--border-dark); background: var(--white);
+  color: var(--text-secondary); cursor: pointer; transition: all 0.12s;
+}
+.pos-dbtn:hover { border-color: var(--accent); color: var(--text); }
+.pos-dbtn.on { background: var(--accent); border-color: var(--accent); color: #fff; }
+.pos-dateinput { width: auto; }
+
+.pos-eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.1px;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.pos-card {
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px;
+}
+
+/* ── Hero ── */
+.pos-hero-top {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  flex-wrap: wrap; gap: 16px; margin-bottom: 10px;
+}
+.pos-net {
+  font-family: var(--mono);
+  font-size: 44px; font-weight: 600; line-height: 1;
+  letter-spacing: -1px; color: var(--text);
+}
+.pos-delta {
+  display: inline-flex; align-items: center; gap: 5px;
+  margin-top: 10px; font-size: 13px; font-weight: 600;
+  padding: 3px 10px; border-radius: 999px;
+}
+.pos-delta.up { color: var(--success); background: var(--success-bg); }
+.pos-delta.down { color: var(--danger); background: var(--danger-bg); }
+.pos-delta.flat { color: var(--text-secondary); background: var(--surface); }
+.pos-net-sub { margin-top: 10px; font-size: 13px; color: var(--text-secondary); }
+.pos-net-sub b { color: var(--text); font-weight: 600; }
+
+.pos-asof { text-align: right; font-size: 12px; color: var(--text-secondary); }
+.pos-term-chips { display: flex; flex-wrap: wrap; gap: 6px; justify-content: flex-end; margin-top: 8px; }
+.pos-chip {
+  font-family: var(--mono); font-size: 11px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 999px; padding: 2px 10px;
+  color: var(--text-secondary);
+}
+.pos-chip .dot { display:inline-block; width:6px; height:6px; border-radius:50%; background: var(--success); margin-right:6px; vertical-align: middle; }
+
+/* ── Legend ── */
+.pos-legend { display:flex; gap:16px; font-size:12px; color: var(--text-secondary); margin-bottom: 4px; }
+.pos-legend span { display:inline-flex; align-items:center; gap:6px; }
+.pos-legend .sw { width:14px; height:3px; border-radius:2px; display:inline-block; }
+.pos-legend .sw.today { background:#8e2715; }
+.pos-legend .sw.yest { background: var(--text-tertiary); }
+
+/* ── Charts ── */
+.pos-chart-wrap { position: relative; }
+.pos-chart { width: 100%; height: auto; display: block; }
+.pos-bar { transition: opacity 0.12s ease; }
+.pos-chart.hoverable:hover .pos-bar { opacity: 0.45; }
+.pos-chart .pos-bar.is-active { opacity: 1; }
+.pos-axis { font-size: 11px; fill: var(--text-secondary); font-family: var(--mono); }
+.pos-chart-empty {
+  display:flex; align-items:center; justify-content:center;
+  height: 180px; color: var(--text-secondary); font-size: 14px;
+}
+.pos-tip {
+  position:absolute; transform: translate(-50%, -100%);
+  background: var(--text); color: var(--cream); border-radius: var(--radius);
+  padding: 7px 10px; font-size: 12px; line-height: 1.45; white-space: nowrap;
+  pointer-events:none; box-shadow: 0 6px 18px rgba(0,0,0,0.2); z-index: 5;
+}
+.pos-tip .tip-amt { font-family: var(--mono); font-weight: 600; }
+.pos-tip .tip-muted { color: #d8b7ad; }
+
+/* ── KPI strip ── */
+.pos-kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(168px, 1fr)); gap: 12px; }
+.pos-kpi {
+  background: var(--white); border: 1px solid var(--border);
+  border-radius: var(--radius-lg); padding: 14px 16px;
+  position: relative; overflow: hidden;
+}
+.pos-kpi::before { content:''; position:absolute; left:0; top:0; bottom:0; width:3px; background: var(--accent-rail, var(--copper)); }
+.pos-kpi-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; color: var(--text-secondary); margin-bottom: 6px; font-weight: 600; }
+.pos-kpi-value { font-family: var(--mono); font-size: 24px; font-weight: 600; color: var(--text); line-height: 1.05; }
+.pos-kpi-sub { margin-top: 4px; font-size: 12px; color: var(--text-secondary); }
+.pos-kpi-sub .up { color: var(--success); font-weight: 600; }
+.pos-kpi-sub .down { color: var(--danger); font-weight: 600; }
+
+/* ── Two-up panels ── */
+.pos-row2 { display: grid; grid-template-columns: 1.4fr 1fr; gap: 14px; }
+@media (max-width: 900px) { .pos-row2 { grid-template-columns: 1fr; } }
+.pos-panel-title { font-size: 13px; font-weight: 600; color: var(--text); margin-bottom: 2px; }
+.pos-panel-note { font-size: 12px; color: var(--text-secondary); margin-bottom: 12px; }
+
+/* ── Composition (split bars) ── */
+.pos-split { margin-bottom: 16px; }
+.pos-split:last-child { margin-bottom: 0; }
+.pos-split-head { display:flex; justify-content:space-between; font-size:12px; color: var(--text-secondary); margin-bottom: 8px; font-weight: 600; }
+.pos-splitbar { display:flex; height: 28px; border-radius: var(--radius); overflow: hidden; background: var(--surface); }
+.pos-splitseg { display:flex; align-items:center; padding: 0 8px; font-size: 11px; font-weight: 600; color: #fff; min-width: 0; white-space: nowrap; overflow: hidden; }
+.pos-split-legend { display:flex; gap:14px; margin-top: 8px; font-size: 12px; color: var(--text-secondary); flex-wrap: wrap; }
+.pos-split-legend span { display:inline-flex; align-items:center; gap:6px; }
+.pos-split-legend .dot { width:9px; height:9px; border-radius:2px; display:inline-block; }
+.pos-split-legend b { color: var(--text); font-family: var(--mono); }

--- a/admin/src/pages/POSActivity.jsx
+++ b/admin/src/pages/POSActivity.jsx
@@ -2,32 +2,39 @@ import { useEffect, useState } from 'react';
 import { api } from '../api.js';
 import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
+import './POSActivity.css';
 
-// POS Activity dashboard: monitor in-store retail POS sales orders +
-// daily KPIs. Sentry stores POS-specific facts (cashier_id, terminal_id,
-// total_cents, payment_method) in audit_log.details JSONB rather than
-// dedicated columns (v1.10.0 design: pricing stays out of Sentry, lives
-// in audit_log for archival). The /api/admin/pos/* backend endpoints
-// surface those facts back to this page via LEFT JOIN audit_log.
+// POS Activity -- retail revenue dashboard. Net revenue + today-vs-yesterday
+// pace, this-week-vs-last-week trend, channel (counter/phone) + tender
+// (card/cash) splits, full KPIs, and the order list. Backed by
+// /api/admin/pos/{summary,sales-orders}.
 
 const STATUS_OPTIONS = ['', 'OPEN', 'ALLOCATED', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED'];
 const ORDER_TYPE_OPTIONS = ['sale', 'refund', 'all'];
+const CHANNEL_OPTIONS = [['', 'All Channels'], ['counter', 'Counter (POS)'], ['phone', 'Phone Order']];
+const DOW = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
-function centsToUsd(cents) {
-  if (cents == null) return '-';
-  return `$${(cents / 100).toFixed(2)}`;
+const usd = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+const fmtUsd = (c) => (c == null ? '-' : usd.format(c / 100));
+function fmtShort(c) {
+  const d = (c || 0) / 100;
+  if (Math.abs(d) >= 1000) return `$${(d / 1000).toFixed(Math.abs(d) >= 10000 ? 0 : 1)}k`;
+  return `$${Math.round(d)}`;
 }
-
-function formatTs(iso) {
+function fmtHour(h) { const ap = h < 12 ? 'a' : 'p'; let x = h % 12; if (x === 0) x = 12; return `${x}${ap}`; }
+function fmtTs(iso) {
   if (!iso) return '-';
-  try {
-    return new Date(iso).toLocaleString('en-US', {
-      year: 'numeric', month: 'short', day: 'numeric',
-      hour: 'numeric', minute: '2-digit',
-    });
-  } catch {
-    return iso;
-  }
+  try { return new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }); }
+  catch { return iso; }
+}
+function pct(part, whole) { return whole ? Math.round((part / whole) * 100) : 0; }
+const todayStr = () => new Date().toLocaleDateString('en-CA', { timeZone: 'America/Denver' }); // YYYY-MM-DD
+function addDays(ymd, n) { const d = new Date(`${ymd}T12:00:00`); d.setDate(d.getDate() + n); return d.toLocaleDateString('en-CA'); }
+function dateLabel(ymd, isToday) {
+  if (isToday) return 'Today';
+  if (ymd === addDays(todayStr(), -1)) return 'Yesterday';
+  try { return new Date(`${ymd}T12:00:00`).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }); }
+  catch { return ymd; }
 }
 
 export default function POSActivity() {
@@ -36,161 +43,350 @@ export default function POSActivity() {
   const [pagination, setPagination] = useState(null);
   const [page, setPage] = useState(1);
   const [orderType, setOrderType] = useState('sale');
+  const [channel, setChannel] = useState('');
   const [status, setStatus] = useState('');
   const [terminalFilter, setTerminalFilter] = useState('');
-  const [cashierFilter, setCashierFilter] = useState('');
+  const [date, setDate] = useState(todayStr());
   const [loading, setLoading] = useState(false);
 
-  // Refresh summary every load + after page/filter changes that imply new data.
-  // Cheap - single SQL query w/ 1-day window.
   function loadSummary() {
-    api.get('/admin/pos/summary').then(async (res) => {
-      if (!res?.ok) return;
-      const data = await res.json();
-      setSummary(data);
-    });
+    api.get(`/admin/pos/summary?date=${date}`).then(async (r) => { if (r?.ok) setSummary(await r.json()); });
   }
-
   function loadOrders() {
-    const params = new URLSearchParams({ page, per_page: 50, order_type: orderType });
-    if (status) params.set('status', status);
-    if (terminalFilter) params.set('terminal_id', terminalFilter);
-    if (cashierFilter) params.set('cashier_id', cashierFilter);
+    const p = new URLSearchParams({ page, per_page: 50, order_type: orderType, date });
+    if (channel) p.set('channel', channel);
+    if (status) p.set('status', status);
+    if (terminalFilter) p.set('terminal_id', terminalFilter);
     setLoading(true);
-    api.get(`/admin/pos/sales-orders?${params}`).then(async (res) => {
+    api.get(`/admin/pos/sales-orders?${p}`).then(async (r) => {
       setLoading(false);
-      if (!res?.ok) return;
-      const data = await res.json();
-      setSalesOrders(data.sales_orders || []);
-      setPagination({ page: data.page, pages: data.pages, total: data.total, per_page: data.per_page });
+      if (!r?.ok) return;
+      const d = await r.json();
+      setSalesOrders(d.sales_orders || []);
+      setPagination({ page: d.page, pages: d.pages, total: d.total, per_page: d.per_page });
     });
   }
+  useEffect(() => { loadSummary(); }, [date]);
+  useEffect(() => { loadOrders(); }, [page, orderType, channel, status, terminalFilter, date]);
 
-  useEffect(() => { loadSummary(); }, []);
-  useEffect(() => { loadOrders(); }, [page, orderType, status, terminalFilter, cashierFilter]);
-
-  function refresh() {
-    loadSummary();
-    loadOrders();
-  }
+  const t = summary?.today || {};
+  const wk = summary?.week || {};
+  const terminals = summary?.active_terminals || [];
+  const net = t.net_cents || 0;
+  const vsY = summary?.vs_yesterday_cents || 0;
+  const wkDelta = pct((wk.this_total_cents || 0) - (wk.last_total_cents || 0), wk.last_total_cents || 0);
+  const asOf = new Date().toLocaleString('en-US', { timeZone: 'America/Denver', hour: 'numeric', minute: '2-digit' });
+  const isToday = summary ? summary.is_today : date === todayStr();
+  const selLabel = dateLabel(summary?.date || date, isToday);
+  const priorLabel = isToday ? 'yesterday' : 'prior day';
 
   const columns = [
     { key: 'so_number', label: 'SO #', mono: true },
-    { key: 'order_date', label: 'Date', render: (r) => formatTs(r.order_date) },
-    { key: 'order_type', label: 'Type' },
+    { key: 'created_at', label: 'Date', render: (r) => fmtTs(r.created_at) },
+    { key: 'channel', label: 'Channel', render: (r) => r.channel || 'POS' },
     { key: 'status', label: 'Status' },
-    { key: 'cashier_id', label: 'Cashier', render: (r) => r.cashier_id || '-' },
     { key: 'terminal_id', label: 'Terminal', mono: true, render: (r) => r.terminal_id || '-' },
     { key: 'customer_name', label: 'Customer', render: (r) => r.customer_name || '(walk-in)' },
-    { key: 'total_cents', label: 'Total', render: (r) => centsToUsd(r.total_cents) },
+    { key: 'total_cents', label: 'Total', render: (r) => fmtUsd(r.total_cents) },
     { key: 'payment_method', label: 'Tender', render: (r) => r.payment_method || '-' },
     { key: 'external_txn_ref', label: 'Windcave Ref', mono: true, render: (r) => r.external_txn_ref || '-' },
   ];
 
-  const today = summary?.today || {};
-  const terminals = summary?.active_terminals || [];
-
   return (
     <div>
       <PageHeader title="POS Activity">
-        <button className="btn" onClick={refresh}>Refresh</button>
+        <div className="pos-datebar">
+          <button className={`pos-dbtn${date === todayStr() ? ' on' : ''}`} onClick={() => { setDate(todayStr()); setPage(1); }}>Today</button>
+          <button className={`pos-dbtn${date === addDays(todayStr(), -1) ? ' on' : ''}`} onClick={() => { setDate(addDays(todayStr(), -1)); setPage(1); }}>Yesterday</button>
+          <input type="date" className="form-input pos-dateinput" value={date} max={todayStr()}
+            onChange={(e) => { if (e.target.value) { setDate(e.target.value); setPage(1); } }} />
+          <button className="btn" onClick={() => { loadSummary(); loadOrders(); }}>Refresh</button>
+        </div>
       </PageHeader>
 
-      {/* KPI Bar */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
-        gap: 12,
-        marginBottom: 16,
-      }}>
-        <KpiCard
-          label="Today's Sales"
-          value={today.sales_count ?? '-'}
-          sub={centsToUsd(today.sales_total_cents)}
-        />
-        <KpiCard
-          label="Today's Refunds"
-          value={today.refund_count ?? '-'}
-          sub={centsToUsd(today.refund_total_cents)}
-        />
-        <KpiCard
-          label="Net Revenue Today"
-          value={centsToUsd((today.sales_total_cents || 0) - (today.refund_total_cents || 0))}
-          sub={`${today.sales_count || 0} sales − ${today.refund_count || 0} refunds`}
-        />
-        <KpiCard
-          label="Active Terminals (24h)"
-          value={terminals.length || '-'}
-          sub={terminals.join(', ') || 'none'}
-        />
-      </div>
+      <div className="pos-grid">
+        {/* Hero: net revenue + pace */}
+        <div className="pos-card">
+          <div className="pos-hero-top">
+            <div>
+              <div className="pos-eyebrow">Net Revenue · {selLabel}</div>
+              <div className="pos-net">{fmtUsd(net)}</div>
+              <DeltaPill cents={vsY} suffix={`vs. ${priorLabel}`} />
+              <div className="pos-net-sub">
+                <b>{t.sales_count || 0}</b> sales · <b>{t.refund_count || 0}</b> refunds · avg <b>{fmtUsd(t.avg_sale_cents || 0)}</b>
+              </div>
+            </div>
+            <div className="pos-asof">
+              {isToday ? `as of ${asOf} MT` : selLabel}
+              <div className="pos-term-chips">
+                {terminals.length === 0
+                  ? <span className="pos-chip">no active terminals</span>
+                  : terminals.map((id) => <span className="pos-chip" key={id}><span className="dot" />{id}</span>)}
+              </div>
+            </div>
+          </div>
+          <div className="pos-legend">
+            <span><i className="sw today" /> {selLabel}</span>
+            <span><i className="sw yest" /> {isToday ? 'Yesterday' : 'Prior day'}</span>
+          </div>
+          <PaceCurve pace={summary?.pace} currentHour={summary?.current_hour ?? 23} />
+        </div>
 
-      {/* Filter bar */}
-      <div className="filter-bar" style={{ marginBottom: 12 }}>
-        <select
-          className="form-select"
-          value={orderType}
-          onChange={(e) => { setOrderType(e.target.value); setPage(1); }}
-          style={{ width: 'auto' }}
-        >
-          {ORDER_TYPE_OPTIONS.map((v) => (
-            <option key={v} value={v}>{v === 'all' ? 'All Types' : (v[0].toUpperCase() + v.slice(1))}</option>
-          ))}
-        </select>
-        <select
-          className="form-select"
-          value={status}
-          onChange={(e) => { setStatus(e.target.value); setPage(1); }}
-          style={{ width: 'auto' }}
-        >
-          {STATUS_OPTIONS.map((s) => (
-            <option key={s} value={s}>{s || 'All Statuses'}</option>
-          ))}
-        </select>
-        <input
-          className="form-input"
-          placeholder="Terminal ID (e.g., REG-01)"
-          value={terminalFilter}
-          onChange={(e) => { setTerminalFilter(e.target.value); setPage(1); }}
-          style={{ maxWidth: 200 }}
-        />
-        <input
-          className="form-input"
-          placeholder="Cashier ID"
-          value={cashierFilter}
-          onChange={(e) => { setCashierFilter(e.target.value); setPage(1); }}
-          style={{ maxWidth: 200 }}
-        />
-      </div>
+        {/* Full KPIs */}
+        <div className="pos-kpis">
+          <Kpi label="This Week" value={fmtUsd(wk.this_total_cents || 0)}
+            sub={<DeltaText pct={wkDelta} suffix="vs last week" />} rail="var(--accent)" />
+          <Kpi label="Counter (POS)" value={fmtUsd(t.counter_cents || 0)}
+            sub={`${t.counter_count || 0} sales · ${pct(t.counter_cents, t.sales_total_cents)}%`} rail="var(--copper)" />
+          <Kpi label="Phone Orders" value={fmtUsd(t.phone_cents || 0)}
+            sub={`${t.phone_count || 0} orders · ${pct(t.phone_cents, t.sales_total_cents)}%`} rail="#1e5f8a" />
+          <Kpi label="Avg Sale" value={fmtUsd(t.avg_sale_cents || 0)} sub="per transaction" rail="var(--purple)" />
+          <Kpi label="Refunds" value={t.refund_count || 0} sub={fmtUsd(t.refund_total_cents || 0)} rail="var(--danger)" />
+          <Kpi label="Active Terminals" value={terminals.length || '-'} sub={`last 24h${terminals.length ? ' · ' + terminals.join(', ') : ''}`} rail="var(--success)" />
+        </div>
 
-      <DataTable
-        columns={columns}
-        data={salesOrders}
-        pagination={pagination}
-        onPageChange={setPage}
-        emptyMessage={loading ? 'Loading…' : 'No POS orders match the current filters.'}
-      />
+        {/* Trend + composition */}
+        <div className="pos-row2">
+          <div className="pos-card">
+            <div className="pos-panel-title">Daily revenue · this week vs last</div>
+            <div className="pos-panel-note">
+              {fmtUsd(wk.this_total_cents || 0)} this week ·{' '}
+              <DeltaText pct={wkDelta} suffix="vs last week" inline />
+            </div>
+            <WeekBars week={summary?.week} />
+          </div>
+          <div className="pos-card">
+            <div className="pos-panel-title">Today's revenue mix</div>
+            <div className="pos-panel-note">how the money came in</div>
+            <SplitBar title="Channel" segs={[
+              { label: 'Counter', cents: t.counter_cents || 0, color: '#c4722a' },
+              { label: 'Phone', cents: t.phone_cents || 0, color: '#1e5f8a' },
+            ]} />
+            <SplitBar title="Tender" segs={tenderSegs(summary?.tenders)} />
+          </div>
+        </div>
+
+        {/* Filters + table */}
+        <div className="filter-bar">
+          <select className="form-select" value={orderType} onChange={(e) => { setOrderType(e.target.value); setPage(1); }} style={{ width: 'auto' }}>
+            {ORDER_TYPE_OPTIONS.map((v) => <option key={v} value={v}>{v === 'all' ? 'All Types' : v[0].toUpperCase() + v.slice(1)}</option>)}
+          </select>
+          <select className="form-select" value={channel} onChange={(e) => { setChannel(e.target.value); setPage(1); }} style={{ width: 'auto' }}>
+            {CHANNEL_OPTIONS.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+          </select>
+          <select className="form-select" value={status} onChange={(e) => { setStatus(e.target.value); setPage(1); }} style={{ width: 'auto' }}>
+            {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{s || 'All Statuses'}</option>)}
+          </select>
+          <input className="form-input" placeholder="Terminal ID" value={terminalFilter} onChange={(e) => { setTerminalFilter(e.target.value); setPage(1); }} style={{ maxWidth: 200 }} />
+        </div>
+
+        <DataTable columns={columns} data={salesOrders} pagination={pagination} onPageChange={setPage}
+          emptyMessage={loading ? 'Loading…' : 'No POS orders match the current filters.'} />
+      </div>
     </div>
   );
 }
 
-function KpiCard({ label, value, sub }) {
+function tenderSegs(tenders) {
+  const colors = { card: '#8e2715', cash: '#2d7a3a', split: '#c4722a', unknown: '#a89a88' };
+  return (tenders || []).map((x) => ({
+    label: x.method ? x.method[0].toUpperCase() + x.method.slice(1) : 'Other',
+    cents: x.cents, color: colors[x.method] || '#8a6d1b',
+  }));
+}
+
+function DeltaPill({ cents, suffix }) {
+  const dir = cents > 0 ? 'up' : cents < 0 ? 'down' : 'flat';
+  const arrow = cents > 0 ? '▲' : cents < 0 ? '▼' : '·';
+  return <div className={`pos-delta ${dir}`}>{arrow} {fmtUsd(Math.abs(cents))} {suffix}</div>;
+}
+function DeltaText({ pct, suffix, inline }) {
+  const dir = pct > 0 ? 'up' : pct < 0 ? 'down' : '';
+  const arrow = pct > 0 ? '▲' : pct < 0 ? '▼' : '·';
+  const body = <><span className={dir}>{arrow} {Math.abs(pct)}%</span> {suffix}</>;
+  return inline ? <span>{body}</span> : body;
+}
+function Kpi({ label, value, sub, rail }) {
   return (
-    <div style={{
-      background: 'var(--card-bg, #ffffff)',
-      border: '1px solid var(--border, #e5e7eb)',
-      borderRadius: 8,
-      padding: '12px 16px',
-    }}>
-      <div style={{
-        fontSize: 11,
-        textTransform: 'uppercase',
-        letterSpacing: 0.5,
-        color: 'var(--text-secondary, #6b7280)',
-        marginBottom: 4,
-      }}>{label}</div>
-      <div style={{ fontSize: 24, fontWeight: 600, marginBottom: 2 }}>{value}</div>
-      <div style={{ fontSize: 12, color: 'var(--text-secondary, #6b7280)' }}>{sub}</div>
+    <div className="pos-kpi" style={{ '--accent-rail': rail }}>
+      <div className="pos-kpi-label">{label}</div>
+      <div className="pos-kpi-value">{value}</div>
+      <div className="pos-kpi-sub">{sub}</div>
+    </div>
+  );
+}
+
+function SplitBar({ title, segs }) {
+  const total = segs.reduce((s, x) => s + Math.max(0, x.cents), 0);
+  return (
+    <div className="pos-split">
+      <div className="pos-split-head"><span>{title}</span><span>{fmtUsd(total)}</span></div>
+      <div className="pos-splitbar">
+        {total === 0
+          ? <div className="pos-splitseg" style={{ flex: 1, color: 'var(--text-secondary)', justifyContent: 'center' }}>no data</div>
+          : segs.filter((s) => s.cents > 0).map((s) => (
+            <div key={s.label} className="pos-splitseg" style={{ flex: s.cents, background: s.color }} title={`${s.label} ${fmtUsd(s.cents)}`}>
+              {pct(s.cents, total) >= 8 ? `${pct(s.cents, total)}%` : ''}
+            </div>
+          ))}
+      </div>
+      <div className="pos-split-legend">
+        {segs.map((s) => (
+          <span key={s.label}><i className="dot" style={{ background: s.color }} />{s.label} <b>{fmtUsd(s.cents)}</b></span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Pace curve: cumulative net revenue, today (solid area) vs yesterday (dotted) ──
+const PW = 900, PH = 230, PP = { l: 14, r: 44, t: 18, b: 24 };
+function PaceCurve({ pace, currentHour }) {
+  const [hover, setHover] = useState(null);
+  if (!pace) return <div className="pos-chart-wrap"><div className="pos-chart-empty">Loading…</div></div>;
+  const td = pace.today.map((p) => p.cents);
+  const yd = pace.yesterday.map((p) => p.cents);
+
+  const active = [];
+  for (let h = 0; h < 24; h++) {
+    const a = td[h] - (h ? td[h - 1] : 0);
+    const b = yd[h] - (h ? yd[h - 1] : 0);
+    if (a > 0 || b > 0) active.push(h);
+  }
+  const yMax = Math.max(...td, ...yd, 0);
+  if (yMax === 0) return <div className="pos-chart-wrap"><div className="pos-chart-empty">No POS revenue today or yesterday.</div></div>;
+
+  let lo = active.length ? Math.max(0, Math.min(...active) - 1) : 8;
+  let hi = active.length ? Math.min(23, Math.max(Math.max(...active), currentHour) + 1) : 18;
+  if (hi - lo < 6) hi = Math.min(23, lo + 6);
+
+  const plotW = PW - PP.l - PP.r, plotH = PH - PP.t - PP.b;
+  const sx = (h) => PP.l + ((h - lo) / (hi - lo)) * plotW;
+  const sy = (c) => PP.t + plotH - (c / yMax) * plotH;
+
+  const pts = (arr, end) => {
+    const out = [];
+    for (let h = lo; h <= Math.min(hi, end); h++) out.push([sx(h), sy(arr[h])]);
+    return out;
+  };
+  const line = (p) => p.map(([x, y], i) => `${i ? 'L' : 'M'}${x.toFixed(1)} ${y.toFixed(1)}`).join(' ');
+
+  const todayPts = pts(td, Math.min(hi, currentHour));
+  const yestPts = pts(yd, hi);
+  const area = todayPts.length
+    ? `${line(todayPts)} L${todayPts[todayPts.length - 1][0].toFixed(1)} ${(PP.t + plotH).toFixed(1)} L${todayPts[0][0].toFixed(1)} ${(PP.t + plotH).toFixed(1)} Z`
+    : '';
+  const nowH = Math.min(hi, currentHour);
+  const grid = [0, 0.5, 1];
+  const labelStep = (hi - lo) > 11 ? 2 : 1;
+
+  return (
+    <div className="pos-chart-wrap">
+      <svg className="pos-chart" viewBox={`0 0 ${PW} ${PH}`} role="img" aria-label="Cumulative revenue, today vs yesterday">
+        <defs>
+          <linearGradient id="paceFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#c4722a" stopOpacity="0.34" />
+            <stop offset="100%" stopColor="#c4722a" stopOpacity="0.02" />
+          </linearGradient>
+        </defs>
+        {grid.map((g) => {
+          const y = PP.t + plotH - g * plotH;
+          return (
+            <g key={g}>
+              <line x1={PP.l} y1={y} x2={PW - PP.r} y2={y} stroke="var(--border)" />
+              <text x={PW - PP.r + 4} y={y + 4} className="pos-axis" textAnchor="start">{fmtShort(g * yMax)}</text>
+            </g>
+          );
+        })}
+        {[...Array(hi - lo + 1)].map((_, i) => {
+          const h = lo + i;
+          return i % labelStep === 0
+            ? <text key={h} x={sx(h)} y={PH - 7} className="pos-axis" textAnchor="middle">{fmtHour(h)}</text>
+            : null;
+        })}
+
+        {area && <path d={area} fill="url(#paceFill)" />}
+        <path d={line(yestPts)} fill="none" stroke="#a89a88" strokeWidth="2" strokeDasharray="3 4" />
+        <path d={line(todayPts)} fill="none" stroke="#8e2715" strokeWidth="2.5" />
+        {todayPts.length > 0 && <circle cx={sx(nowH)} cy={sy(td[nowH])} r="4.5" fill="#8e2715" stroke="#fff" strokeWidth="2" />}
+
+        {/* hover hit-areas per hour */}
+        {[...Array(hi - lo + 1)].map((_, i) => {
+          const h = lo + i;
+          return (
+            <rect key={h} x={sx(h) - plotW / (hi - lo) / 2} y={PP.t} width={plotW / (hi - lo)} height={plotH}
+              fill="transparent"
+              onMouseEnter={() => setHover({ h, x: sx(h), today: td[h], yest: yd[h], future: h > currentHour })}
+              onMouseLeave={() => setHover(null)} />
+          );
+        })}
+        {hover && <line x1={hover.x} y1={PP.t} x2={hover.x} y2={PP.t + plotH} stroke="var(--border-dark)" />}
+      </svg>
+      {hover && (
+        <div className="pos-tip" style={{ left: `${(hover.x / PW) * 100}%`, top: `${(sy(Math.max(hover.today, hover.yest)) / PH) * 100}%` }}>
+          <div>by {fmtHour((hover.h + 1) % 24)}</div>
+          {!hover.future && <div className="tip-amt">{fmtUsd(hover.today)} <span style={{ fontWeight: 400 }}>today</span></div>}
+          <div className="tip-muted">{fmtUsd(hover.yest)} yesterday</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Weekly bars: this week (filled) vs last week (light), per weekday ──
+const WW = 900, WH = 200, WP = { l: 14, r: 40, t: 14, b: 22 };
+function WeekBars({ week }) {
+  const [hover, setHover] = useState(null);
+  if (!week) return <div className="pos-chart-wrap"><div className="pos-chart-empty">Loading…</div></div>;
+  const thisW = week.this || [], lastW = week.last || [];
+  const yMax = Math.max(...thisW.map((d) => d.net_cents), ...lastW.map((d) => d.net_cents), 0);
+  if (yMax === 0) return <div className="pos-chart-wrap"><div className="pos-chart-empty">No revenue this week or last.</div></div>;
+
+  const plotW = WW - WP.l - WP.r, plotH = WH - WP.t - WP.b;
+  const slot = plotW / 7;
+  const bw = slot * 0.3;
+  const yb = (c) => WP.t + plotH - (c / yMax) * plotH;
+  const grid = [0, 0.5, 1];
+
+  return (
+    <div className="pos-chart-wrap">
+      <svg className="pos-chart hoverable" viewBox={`0 0 ${WW} ${WH}`} role="img" aria-label="Daily revenue this week vs last">
+        {grid.map((g) => {
+          const y = WP.t + plotH - g * plotH;
+          return (
+            <g key={g}>
+              <line x1={WP.l} y1={y} x2={WW - WP.r} y2={y} stroke="var(--border)" />
+              <text x={WW - WP.r + 4} y={y + 4} className="pos-axis" textAnchor="start">{fmtShort(g * yMax)}</text>
+            </g>
+          );
+        })}
+        {DOW.map((d, i) => {
+          const cx = WP.l + i * slot + slot / 2;
+          const last = lastW[i] || { net_cents: 0 };
+          const cur = thisW[i] || { net_cents: 0, is_today: false, is_future: false };
+          return (
+            <g key={d}>
+              <rect x={cx - bw - 2} y={yb(last.net_cents)} width={bw} height={Math.max(0, WP.t + plotH - yb(last.net_cents))}
+                rx="2" className="pos-bar" fill="#ddd2c2"
+                onMouseEnter={() => setHover({ d, which: 'last week', cents: last.net_cents, x: cx, y: yb(last.net_cents) })}
+                onMouseLeave={() => setHover(null)} />
+              {!cur.is_future && (
+                <rect x={cx + 2} y={yb(cur.net_cents)} width={bw} height={Math.max(cur.net_cents > 0 ? 2 : 0, WP.t + plotH - yb(cur.net_cents))}
+                  rx="2" className={`pos-bar${cur.is_today ? ' is-active' : ''}`} fill={cur.is_today ? '#8e2715' : '#c4722a'}
+                  onMouseEnter={() => setHover({ d, which: cur.is_today ? 'today' : 'this week', cents: cur.net_cents, x: cx, y: yb(cur.net_cents) })}
+                  onMouseLeave={() => setHover(null)} />
+              )}
+              <text x={cx} y={WH - 6} className="pos-axis" textAnchor="middle" fontWeight={cur.is_today ? 700 : 400}>{d}</text>
+            </g>
+          );
+        })}
+      </svg>
+      {hover && (
+        <div className="pos-tip" style={{ left: `${(hover.x / WW) * 100}%`, top: `${(hover.y / WH) * 100}%` }}>
+          <div>{hover.d} · {hover.which}</div>
+          <div className="tip-amt">{fmtUsd(hover.cents)}</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/admin/src/test/pos-activity.test.jsx
+++ b/admin/src/test/pos-activity.test.jsx
@@ -1,0 +1,102 @@
+/**
+ * POS Activity dashboard renders the wired KPIs, the today-vs-yesterday
+ * pace curve, the weekly trend, the channel/tender splits, and the order
+ * list -- and degrades gracefully when there's no revenue.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const apiGetMock = vi.fn();
+vi.mock('../api.js', () => ({
+  api: { get: (...a) => apiGetMock(...a), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('../warehouse.jsx', () => ({ warehouseRequired: () => null }));
+
+import POSActivity from '../pages/POSActivity.jsx';
+
+const json = (body) => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) });
+
+function cumulative(toHour, peak) {
+  return Array.from({ length: 24 }, (_, h) => ({
+    hour: h,
+    cents: h < 9 ? 0 : h >= toHour ? peak : Math.round((peak * (h - 9)) / (toHour - 9)),
+  }));
+}
+function weekDays(values, todayIdx) {
+  return values.map((v, i) => ({ date: `2026-06-0${i + 1}`, dow: i, net_cents: v, is_today: i === todayIdx, is_future: i > todayIdx }));
+}
+
+const SUMMARY = {
+  tz: 'America/Denver', date: '2026-06-12', is_today: true, current_hour: 15,
+  today: {
+    net_cents: 1122227, sales_count: 96, sales_total_cents: 1187966,
+    refund_count: 8, refund_total_cents: 65739, avg_sale_cents: 12375,
+    counter_cents: 900000, counter_count: 80, phone_cents: 287966, phone_count: 16,
+  },
+  yesterday: { net_cents: 980000 },
+  vs_yesterday_cents: 142227,
+  pace: { today: cumulative(15, 1122227), yesterday: cumulative(20, 980000) },
+  week: {
+    this: weekDays([120000, 150000, 90000, 1122227, 0, 0, 0], 3),
+    last: weekDays([110000, 130000, 100000, 95000, 140000, 160000, 80000], -1),
+    this_total_cents: 1482227, last_total_cents: 715000,
+  },
+  tenders: [{ method: 'card', cents: 800000, count: 60 }, { method: 'cash', cents: 387966, count: 36 }],
+  active_terminals: ['REG-01', 'REG-02'],
+};
+
+const ORDERS = {
+  sales_orders: [{
+    so_id: 1, so_number: 'POS-9001', status: 'SHIPPED', order_type: 'sale',
+    channel: 'Phone Order', created_at: '2026-06-12T19:00:00Z', customer_name: 'Jane Doe',
+    total_cents: 2482, terminal_id: 'REG-01', payment_method: 'card', external_txn_ref: '0000abcd',
+  }],
+  total: 1, page: 1, pages: 1, per_page: 50,
+};
+
+function wire(summary) {
+  apiGetMock.mockImplementation((path = '') => {
+    if (path.startsWith('/admin/pos/summary')) return json(summary);
+    if (path.startsWith('/admin/pos/sales-orders')) return json(ORDERS);
+    return json({});
+  });
+}
+
+describe('POSActivity', () => {
+  beforeEach(() => apiGetMock.mockReset());
+
+  it('renders KPIs, pace curve, weekly trend, splits, and orders', async () => {
+    wire(SUMMARY);
+    const { container, findByText, getAllByText } = render(<MemoryRouter><POSActivity /></MemoryRouter>);
+
+    await findByText('$11,222.27');               // net revenue hero
+    await findByText('Phone Orders');              // channel KPI (unique; filter says "Phone Order")
+    await findByText('This Week');
+    await findByText('Avg Sale');
+    await waitFor(() => {
+      expect(container.querySelectorAll('svg').length).toBeGreaterThanOrEqual(2); // pace + week charts
+      expect(container.querySelectorAll('.pos-bar').length).toBeGreaterThan(0);   // weekly bars
+      expect(container.querySelectorAll('.pos-splitseg').length).toBeGreaterThan(0); // splits
+    });
+    await findByText('POS-9001');
+    expect(getAllByText(/vs\. yesterday|vs last week/).length).toBeGreaterThan(0);
+  });
+
+  it('degrades gracefully with no revenue', async () => {
+    wire({
+      ...SUMMARY,
+      today: { net_cents: 0, sales_count: 0, refund_count: 0, avg_sale_cents: 0, counter_cents: 0, phone_cents: 0, counter_count: 0, phone_count: 0, sales_total_cents: 0, refund_total_cents: 0 },
+      vs_yesterday_cents: 0,
+      pace: { today: cumulative(24, 0), yesterday: cumulative(24, 0) },
+      week: { this: weekDays([0, 0, 0, 0, 0, 0, 0], 3), last: weekDays([0, 0, 0, 0, 0, 0, 0], -1), this_total_cents: 0, last_total_cents: 0 },
+      tenders: [],
+      active_terminals: [],
+    });
+    const { findByText } = render(<MemoryRouter><POSActivity /></MemoryRouter>);
+    await findByText('No POS revenue today or yesterday.');
+    await findByText('No revenue this week or last.');
+  });
+});

--- a/api/routes/admin/admin_pos.py
+++ b/api/routes/admin/admin_pos.py
@@ -1,30 +1,53 @@
-"""POS admin endpoints - feeds the new admin/src/pages/POSActivity.jsx
-dashboard with sales-order activity + daily KPI counters.
+"""POS admin endpoints -- feed admin/src/pages/POSActivity.jsx, the retail
+revenue dashboard: today's KPIs, a today-vs-yesterday cumulative pace
+curve, a this-week-vs-last-week daily trend, channel + tender splits, and
+the filterable order list.
 
-Data model note: Sentry intentionally does NOT store per-line prices or
-operator metadata in `sales_orders` columns. Per v1.10.0 design (POS
-endpoint surface release), pricing + cashier_id + terminal_id ride into
-the audit_log.details JSONB at POS_CHECKOUT time. So this module's
-queries LEFT JOIN audit_log to surface those fields back to the
-dashboard.
+Data model:
+- Amount: ``sales_orders.order_total`` -- signed dollars (sales positive,
+  refunds negative), written by the POS checkout/refund path. Every
+  figure sums this one column.
+- Channel: ``sales_orders.order_origin`` -- the POS client writes "POS"
+  for a counter sale and "Phone Order" for a phone-order checkout (first
+  class column, no join). Matched case-insensitively on "phone".
+- Tender: ``audit_log.details->>'payment_method'`` on the POS_CHECKOUT
+  row (card / cash / split); the only figure that needs the audit join.
+- "Today" is the store-local (America/Denver) day off ``created_at``;
+  POS orders do not populate ``order_date``.
 
 Endpoints:
-    GET /api/admin/pos/sales-orders   - paginated POS SO list w/ filters
-    GET /api/admin/pos/summary        - today's KPI counters (sales /
-                                        revenue / refunds / terminals)
+    GET /api/admin/pos/sales-orders   -- paginated POS SO list w/ filters
+    GET /api/admin/pos/summary        -- KPIs + pace + weekly + splits
 
-Both gated by ADMIN role (same as the existing /admin/sales-orders).
+Both gated by the pos-activity page permission.
 """
 
 import math
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
 from flask import g, jsonify, request
 from sqlalchemy import text
 
 from constants import ACTION_POS_CHECKOUT, ACTION_POS_REFUND
-from middleware.auth_middleware import require_auth, require_role
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
 from middleware.db import with_db
 from routes.admin import admin_bp
+
+STORE_TZ = "America/Denver"
+_TZ = ZoneInfo(STORE_TZ)
+
+# A store-local calendar date -> the UTC instant of its local midnight,
+# used as a half-open [start, end) bound against created_at (timestamptz).
+_BOUND = "(CAST(:%s AS timestamp) AT TIME ZONE '" + STORE_TZ + "')"
+_PHONE = "lower(coalesce(so.order_origin, '')) LIKE '%%phone%%'"
+
+
+def _cents(value) -> int:
+    """Decimal dollars -> integer cents. None -> 0."""
+    if value is None:
+        return 0
+    return int(round(float(value) * 100))
 
 
 # ---------------------------------------------------------------------------
@@ -34,80 +57,70 @@ from routes.admin import admin_bp
 
 @admin_bp.route("/pos/sales-orders", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("pos-activity")
 @with_db
 def list_pos_sales_orders():
-    """Paginated list of POS sales orders with the cashier/terminal/total
-    detail joined from audit_log.
-
-    Query params:
-        page         - 1-based page number, default 1
-        per_page     - page size, default 50, max 200
-        since        - YYYY-MM-DD (orders with order_date >= since at UTC midnight)
-        until        - YYYY-MM-DD (orders with order_date <  until at UTC midnight)
-        terminal_id  - filter on the audit_log JSONB 'terminal_id' field
-        cashier_id   - filter on the audit_log JSONB 'cashier_id' field (= sales_orders.created_by)
-        status       - sales_orders.status filter (OPEN/ALLOCATED/PICKED/PACKED/SHIPPED/CANCELLED)
-        order_type   - 'sale' (default) | 'refund' | 'all'
-    """
+    """Paginated POS sales orders. Amount + date off sales_orders;
+    terminal / cashier / tender from the POS audit row (checkout for
+    sales, refund for refunds)."""
     page = request.args.get("page", 1, type=int)
     per_page = min(request.args.get("per_page", 50, type=int), 200)
-    since = request.args.get("since")
-    until = request.args.get("until")
     terminal_id = request.args.get("terminal_id")
     cashier_id = request.args.get("cashier_id")
     so_status = request.args.get("status")
     order_type = request.args.get("order_type", "sale").lower()
+    channel = request.args.get("channel")  # 'counter' | 'phone' | None
 
-    where_clauses = ["so.order_source = :pos_source"]
-    params = {"pos_source": "pos", "checkout_action": ACTION_POS_CHECKOUT}
-
-    if order_type == "sale":
-        where_clauses.append("so.order_type = :order_type")
-        params["order_type"] = "sale"
-    elif order_type == "refund":
-        where_clauses.append("so.order_type = :order_type")
-        params["order_type"] = "refund"
+    where = ["so.order_source = :pos_source"]
+    params = {
+        "pos_source": "pos",
+        "checkout_action": ACTION_POS_CHECKOUT,
+        "refund_action": ACTION_POS_REFUND,
+    }
+    if order_type in ("sale", "refund"):
+        where.append("so.order_type = :order_type")
+        params["order_type"] = order_type
     elif order_type != "all":
-        # unknown values are treated as 'sale' to fail safe
-        where_clauses.append("so.order_type = :order_type")
+        where.append("so.order_type = :order_type")
         params["order_type"] = "sale"
-
-    if since:
-        where_clauses.append("so.order_date >= CAST(:since AS DATE)")
-        params["since"] = since
-    if until:
-        where_clauses.append("so.order_date < CAST(:until AS DATE)")
-        params["until"] = until
+    if channel == "phone":
+        where.append(_PHONE)
+    elif channel == "counter":
+        where.append("NOT " + _PHONE)
+    date_arg = request.args.get("date")
+    if date_arg:
+        try:
+            datetime.strptime(date_arg, "%Y-%m-%d")
+            where.append(
+                f"so.created_at >= {_BOUND % 'pos_date'} "
+                f"AND so.created_at < ((CAST(:pos_date AS timestamp) "
+                f"+ interval '1 day') AT TIME ZONE '{STORE_TZ}')"
+            )
+            params["pos_date"] = date_arg
+        except ValueError:
+            pass
     if so_status:
-        where_clauses.append("so.status = :so_status")
+        where.append("so.status = :so_status")
         params["so_status"] = so_status
     if terminal_id:
-        where_clauses.append("al.details->>'terminal_id' = :terminal_id")
+        where.append("al.details->>'terminal_id' = :terminal_id")
         params["terminal_id"] = terminal_id
     if cashier_id:
-        where_clauses.append("al.user_id = :cashier_id")
+        where.append("al.user_id = :cashier_id")
         params["cashier_id"] = cashier_id
 
-    where_sql = "WHERE " + " AND ".join(where_clauses)
+    where_sql = "WHERE " + " AND ".join(where)
+    join_sql = (
+        "LEFT JOIN audit_log al ON al.entity_type = 'SO' "
+        "AND al.entity_id = so.so_id "
+        "AND al.action_type IN (:checkout_action, :refund_action)"
+    )
 
-    # Count (de-duped via DISTINCT so multi-audit-row SOs don't inflate)
     total = g.db.execute(
-        text(
-            f"""
-            SELECT COUNT(DISTINCT so.so_id)
-              FROM sales_orders so
-              LEFT JOIN audit_log al
-                ON al.entity_type = 'SO'
-               AND al.entity_id   = so.so_id
-               AND al.action_type = :checkout_action
-              {where_sql}
-            """
-        ),
+        text(f"SELECT COUNT(DISTINCT so.so_id) FROM sales_orders so {join_sql} {where_sql}"),
         params,
     ).scalar()
     pages = max(1, math.ceil((total or 0) / per_page))
-
     params["limit"] = per_page
     params["offset"] = (page - 1) * per_page
 
@@ -115,25 +128,14 @@ def list_pos_sales_orders():
         text(
             f"""
             SELECT DISTINCT ON (so.so_id)
-                   so.so_id,
-                   so.so_number,
-                   so.status,
-                   so.order_type,
-                   so.order_date,
-                   so.customer_name,
-                   so.customer_phone,
-                   so.external_txn_ref,
-                   so.warehouse_id,
+                   so.so_id, so.so_number, so.status, so.order_type,
+                   so.created_at, so.customer_name, so.customer_phone,
+                   so.external_txn_ref, so.warehouse_id, so.order_total,
+                   so.order_origin,
                    al.user_id AS cashier_id,
                    al.details->>'terminal_id' AS terminal_id,
-                   COALESCE((al.details->>'total_cents')::int, 0) AS total_cents,
-                   al.details->>'payment_method' AS payment_method,
-                   al.created_at AS checkout_at
-              FROM sales_orders so
-              LEFT JOIN audit_log al
-                ON al.entity_type = 'SO'
-               AND al.entity_id   = so.so_id
-               AND al.action_type = :checkout_action
+                   al.details->>'payment_method' AS payment_method
+              FROM sales_orders so {join_sql}
               {where_sql}
              ORDER BY so.so_id DESC, al.created_at DESC
              LIMIT :limit OFFSET :offset
@@ -149,16 +151,16 @@ def list_pos_sales_orders():
                 "so_number": r.so_number,
                 "status": r.status,
                 "order_type": r.order_type,
-                "order_date": r.order_date.isoformat() if r.order_date else None,
+                "channel": "Phone Order" if (r.order_origin or "").lower().find("phone") >= 0 else "POS",
+                "created_at": r.created_at.isoformat() if r.created_at else None,
                 "customer_name": r.customer_name,
                 "customer_phone": r.customer_phone,
                 "external_txn_ref": r.external_txn_ref,
                 "warehouse_id": r.warehouse_id,
+                "total_cents": _cents(r.order_total),
                 "cashier_id": r.cashier_id,
                 "terminal_id": r.terminal_id,
-                "total_cents": r.total_cents,
                 "payment_method": r.payment_method,
-                "checkout_at": r.checkout_at.isoformat() if r.checkout_at else None,
             }
             for r in rows
         ],
@@ -170,84 +172,223 @@ def list_pos_sales_orders():
 
 
 # ---------------------------------------------------------------------------
-# GET /api/admin/pos/summary
+# GET /api/admin/pos/summary  -- KPIs + pace + weekly + splits
 # ---------------------------------------------------------------------------
+
+
+def _period_kpis(db, start, end):
+    """Counts + totals for POS orders in [start, end) store-local dates,
+    including the counter/phone channel split (order_origin)."""
+    r = db.execute(
+        text(
+            f"""
+            SELECT
+              COUNT(*) FILTER (WHERE so.order_type = 'sale')   AS sales_count,
+              COUNT(*) FILTER (WHERE so.order_type = 'refund') AS refund_count,
+              COALESCE(SUM(so.order_total) FILTER (WHERE so.order_type='sale'),   0) AS sales_total,
+              COALESCE(SUM(so.order_total) FILTER (WHERE so.order_type='refund'), 0) AS refund_total,
+              COALESCE(SUM(so.order_total), 0) AS net_total,
+              COALESCE(SUM(so.order_total) FILTER (WHERE so.order_type='sale' AND {_PHONE}), 0)       AS phone_total,
+              COUNT(*) FILTER (WHERE so.order_type='sale' AND {_PHONE})                                AS phone_count,
+              COALESCE(SUM(so.order_total) FILTER (WHERE so.order_type='sale' AND NOT {_PHONE}), 0)    AS counter_total,
+              COUNT(*) FILTER (WHERE so.order_type='sale' AND NOT {_PHONE})                            AS counter_count
+            FROM sales_orders so
+            WHERE so.order_source = 'pos'
+              AND so.created_at >= {_BOUND % 's'}
+              AND so.created_at <  {_BOUND % 'e'}
+            """
+        ),
+        {"s": str(start), "e": str(end)},
+    ).fetchone()
+    sc = r.sales_count or 0
+    sales_total = _cents(r.sales_total)
+    return {
+        "sales_count": sc,
+        "sales_total_cents": sales_total,
+        "refund_count": r.refund_count or 0,
+        "refund_total_cents": -_cents(r.refund_total),
+        "net_cents": _cents(r.net_total),
+        "avg_sale_cents": round(sales_total / sc) if sc else 0,
+        "counter_cents": _cents(r.counter_total),
+        "counter_count": r.counter_count or 0,
+        "phone_cents": _cents(r.phone_total),
+        "phone_count": r.phone_count or 0,
+    }
+
+
+def _hourly_cumulative(db, start, end):
+    """24 cumulative net-revenue cents by store-local hour for [start, end)."""
+    rows = db.execute(
+        text(
+            f"""
+            WITH agg AS (
+              SELECT EXTRACT(HOUR FROM so.created_at AT TIME ZONE '{STORE_TZ}')::int AS hr,
+                     COALESCE(SUM(so.order_total), 0) AS net
+                FROM sales_orders so
+               WHERE so.order_source = 'pos'
+                 AND so.created_at >= {_BOUND % 's'}
+                 AND so.created_at <  {_BOUND % 'e'}
+               GROUP BY hr
+            )
+            SELECT h.hr, COALESCE(agg.net, 0) AS net
+              FROM generate_series(0, 23) h(hr)
+              LEFT JOIN agg ON agg.hr = h.hr
+             ORDER BY h.hr
+            """
+        ),
+        {"s": str(start), "e": str(end)},
+    ).fetchall()
+    out, run = [], 0
+    for row in rows:
+        run += _cents(row.net)
+        out.append({"hour": row.hr, "cents": run})
+    return out
+
+
+def _daily_net(db, start, end):
+    """Per-day net cents (store-local date) across [start, end), with
+    zero-filled gaps."""
+    rows = db.execute(
+        text(
+            f"""
+            WITH agg AS (
+              SELECT (so.created_at AT TIME ZONE '{STORE_TZ}')::date AS d,
+                     COALESCE(SUM(so.order_total), 0) AS net
+                FROM sales_orders so
+               WHERE so.order_source = 'pos'
+                 AND so.created_at >= {_BOUND % 's'}
+                 AND so.created_at <  {_BOUND % 'e'}
+               GROUP BY d
+            )
+            SELECT g::date AS d, COALESCE(agg.net, 0) AS net
+              FROM generate_series(CAST(:s AS date), CAST(:e AS date) - 1, interval '1 day') g
+              LEFT JOIN agg ON agg.d = g::date
+             ORDER BY d
+            """
+        ),
+        {"s": str(start), "e": str(end)},
+    ).fetchall()
+    return [(row.d, _cents(row.net)) for row in rows]
+
+
+def _tender_split(db, start, end):
+    """Sales revenue grouped by tender (payment_method) for [start, end)."""
+    rows = db.execute(
+        text(
+            f"""
+            SELECT COALESCE(al.details->>'payment_method', 'unknown') AS method,
+                   COALESCE(SUM(so.order_total), 0) AS total,
+                   COUNT(*) AS cnt
+              FROM sales_orders so
+              JOIN audit_log al
+                ON al.entity_type = 'SO' AND al.entity_id = so.so_id
+               AND al.action_type = :checkout_action
+             WHERE so.order_source = 'pos' AND so.order_type = 'sale'
+               AND so.created_at >= {_BOUND % 's'}
+               AND so.created_at <  {_BOUND % 'e'}
+             GROUP BY method
+             ORDER BY total DESC
+            """
+        ),
+        {"s": str(start), "e": str(end), "checkout_action": ACTION_POS_CHECKOUT},
+    ).fetchall()
+    return [{"method": r.method, "cents": _cents(r.total), "count": r.cnt} for r in rows]
+
+
+def _anchor_date():
+    """The store-local day the dashboard is viewing: ?date=YYYY-MM-DD,
+    defaulting to (and clamped at) today. Returns (anchor, today, is_today)."""
+    now_local = datetime.now(_TZ)
+    today = now_local.date()
+    anchor = today
+    arg = request.args.get("date")
+    if arg:
+        try:
+            anchor = datetime.strptime(arg, "%Y-%m-%d").date()
+        except ValueError:
+            anchor = today
+    if anchor > today:
+        anchor = today
+    return anchor, today, anchor == today
 
 
 @admin_bp.route("/pos/summary", methods=["GET"])
 @require_auth
-@require_role("ADMIN")
+@require_admin_or_page_permission("pos-activity")
 @with_db
 def pos_summary():
-    """Today's KPI counters for the dashboard top bar.
+    anchor, today_actual, is_today = _anchor_date()
+    # A past day is complete (cap the pace curve at midnight); today caps at now.
+    cur_hour = datetime.now(_TZ).hour if is_today else 23
 
-    Computed as of `now` in the server's timezone (UTC for ACA deploys -
-    document the offset if cashier-day boundaries become important).
+    today = anchor                                          # the selected day
+    yesterday = anchor - timedelta(days=1)
+    week_start = anchor - timedelta(days=anchor.weekday())  # Monday of its week
+    last_week_start = week_start - timedelta(days=7)
+    next_week_start = week_start + timedelta(days=7)
 
-    Returns:
-        today: {sales_count, sales_total_cents, refund_count, refund_total_cents}
-        active_terminals: list of distinct terminal_id seen in the last 24h
-    """
-    # "Today" boundary: midnight UTC. For SLC retail store, that's ~6pm
-    # local the prior day -- if the user wants a Mountain-Time boundary,
-    # we'd switch this to AT TIME ZONE 'America/Denver'. Keeping UTC for
-    # now to match the rest of the admin surface.
-    today_start_utc = "DATE_TRUNC('day', NOW() AT TIME ZONE 'UTC')"
+    today_kpis = _period_kpis(g.db, today, today + timedelta(days=1))
+    yest_kpis = _period_kpis(g.db, yesterday, today)
 
-    row = g.db.execute(
-        text(
-            f"""
-            SELECT
-              COUNT(*) FILTER (WHERE so.order_type = 'sale')
-                AS sales_count,
-              COUNT(*) FILTER (WHERE so.order_type = 'refund')
-                AS refund_count,
-              COALESCE(SUM(
-                CASE WHEN so.order_type = 'sale'
-                  THEN COALESCE((al.details->>'total_cents')::int, 0)
-                  ELSE 0
-                END
-              ), 0) AS sales_total_cents,
-              COALESCE(SUM(
-                CASE WHEN so.order_type = 'refund'
-                  THEN COALESCE((al.details->>'total_cents')::int, 0)
-                  ELSE 0
-                END
-              ), 0) AS refund_total_cents
-            FROM sales_orders so
-            LEFT JOIN audit_log al
-              ON al.entity_type = 'SO'
-             AND al.entity_id   = so.so_id
-             AND al.action_type = :checkout_action
-            WHERE so.order_source = 'pos'
-              AND so.order_date >= {today_start_utc}
-            """
-        ),
-        {"checkout_action": ACTION_POS_CHECKOUT},
-    ).fetchone()
+    pace_today = _hourly_cumulative(g.db, today, today + timedelta(days=1))
+    pace_yest = _hourly_cumulative(g.db, yesterday, today)
+    # Apples-to-apples: today's net so far vs yesterday by the same hour.
+    yest_by_now = pace_yest[cur_hour]["cents"] if cur_hour < 24 else pace_yest[-1]["cents"]
+    vs_yesterday_cents = today_kpis["net_cents"] - yest_by_now
 
-    # Active terminals in the last 24h (a "registered today" pulse).
-    twenty_four_hours_ago = "(NOW() - INTERVAL '24 hours')"
+    daily = _daily_net(g.db, last_week_start, next_week_start)  # 14 rows
+    by_date = {d: c for d, c in daily}
+
+    def _weekrow(monday):
+        days = []
+        total = 0
+        for i in range(7):
+            d = monday + timedelta(days=i)
+            cents = by_date.get(d, 0)
+            total += cents
+            days.append({
+                "date": d.isoformat(),
+                "dow": i,  # 0=Mon
+                "net_cents": cents,
+                "is_today": d == today,
+                "is_future": d > today,
+            })
+        return days, total
+
+    this_days, this_total = _weekrow(week_start)
+    last_days, last_total = _weekrow(last_week_start)
+
+    tenders = _tender_split(g.db, today, today + timedelta(days=1))
+
     terminals = g.db.execute(
         text(
-            f"""
+            """
             SELECT DISTINCT al.details->>'terminal_id' AS terminal_id
               FROM audit_log al
-             WHERE al.action_type = :checkout_action
-               AND al.created_at >= {twenty_four_hours_ago}
+             WHERE al.action_type IN (:checkout_action, :refund_action)
+               AND al.created_at >= (now() - INTERVAL '24 hours')
                AND al.details->>'terminal_id' IS NOT NULL
              ORDER BY terminal_id
             """
         ),
-        {"checkout_action": ACTION_POS_CHECKOUT},
+        {"checkout_action": ACTION_POS_CHECKOUT, "refund_action": ACTION_POS_REFUND},
     ).fetchall()
 
     return jsonify({
-        "today": {
-            "sales_count": row.sales_count or 0,
-            "sales_total_cents": int(row.sales_total_cents or 0),
-            "refund_count": row.refund_count or 0,
-            "refund_total_cents": int(row.refund_total_cents or 0),
+        "tz": STORE_TZ,
+        "date": anchor.isoformat(),
+        "is_today": is_today,
+        "current_hour": cur_hour,
+        "today": today_kpis,
+        "yesterday": yest_kpis,
+        "vs_yesterday_cents": vs_yesterday_cents,
+        "pace": {"today": pace_today, "yesterday": pace_yest},
+        "week": {
+            "this": this_days,
+            "last": last_days,
+            "this_total_cents": this_total,
+            "last_total_cents": last_total,
         },
+        "tenders": tenders,
         "active_terminals": [t.terminal_id for t in terminals if t.terminal_id],
     })

--- a/api/tests/test_admin_pos_dashboard.py
+++ b/api/tests/test_admin_pos_dashboard.py
@@ -1,0 +1,178 @@
+"""POS Activity dashboard endpoints: /api/admin/pos/summary + /sales-orders.
+
+Covers the wired-up KPIs and the revamp's splits/trends:
+- "today" scoped to the store-local (America/Denver) day off created_at
+  (POS orders never populate order_date).
+- net/sales/refund summed from the signed sales_orders.order_total column.
+- channel split (counter vs phone) off sales_orders.order_origin
+  ("POS" vs "Phone Order").
+- tender split off the POS_CHECKOUT audit row's payment_method.
+- cumulative pace, vs-yesterday, and this-week/last-week totals.
+
+Deltas are measured around the seeded rows so seed-data POS orders don't
+make the assertions brittle.
+"""
+
+import json
+import uuid
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from db_test_context import get_raw_connection
+
+_TZ = ZoneInfo("America/Denver")
+
+_SO_SQL = """
+    INSERT INTO sales_orders
+      (so_number, warehouse_id, status, external_id, order_source,
+       order_type, order_total, order_origin, created_at)
+    VALUES (%s, 1, 'SHIPPED', gen_random_uuid(), 'pos', %s, %s, %s,
+            ((date_trunc('day', now() AT TIME ZONE 'America/Denver')
+              + INTERVAL '13 hours') AT TIME ZONE 'America/Denver')
+            - make_interval(days => %s))
+    RETURNING so_id
+"""
+
+_AUDIT_SQL = """
+    INSERT INTO audit_log
+      (action_type, entity_type, entity_id, user_id, warehouse_id, details)
+    VALUES (%s, 'SO', %s, 'admin', 1, %s::jsonb)
+"""
+
+
+def _seed(so_number, order_type, total, *, day_offset=0, origin="POS", tender=None, terminal="REG-01"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(_SO_SQL, (so_number, order_type, total, origin, day_offset))
+        so_id = cur.fetchone()[0]
+        if tender:
+            action = "POS_CHECKOUT" if order_type == "sale" else "POS_REFUND"
+            cur.execute(_AUDIT_SQL, (
+                action, so_id,
+                json.dumps({"terminal_id": terminal, "payment_method": tender,
+                            "total_cents": int(round(abs(total) * 100))}),
+            ))
+        return so_id
+    finally:
+        cur.close()
+
+
+def _summary(client, auth_headers):
+    return client.get("/api/admin/pos/summary", headers=auth_headers).get_json()
+
+
+def _tag():
+    return uuid.uuid4().hex[:8].upper()
+
+
+class TestPosSummary:
+    def test_today_kpis_and_channel_split(self, client, auth_headers):
+        b = _summary(client, auth_headers)["today"]
+        tag = _tag()
+        _seed(f"POS-{tag}-1", "sale", 10.00, origin="POS")
+        _seed(f"POS-{tag}-2", "sale", 25.50, origin="POS")
+        _seed(f"POS-{tag}-P", "sale", 60.00, origin="Phone Order")
+        _seed(f"POS-{tag}-R", "refund", -5.00, origin="POS")
+        a = _summary(client, auth_headers)["today"]
+
+        assert a["sales_count"] - b["sales_count"] == 3
+        assert a["sales_total_cents"] - b["sales_total_cents"] == 9550
+        assert a["refund_count"] - b["refund_count"] == 1
+        assert a["refund_total_cents"] - b["refund_total_cents"] == 500
+        assert a["net_cents"] - b["net_cents"] == 9050
+        # Channel split: 2 counter ($35.50), 1 phone ($60).
+        assert a["counter_count"] - b["counter_count"] == 2
+        assert a["counter_cents"] - b["counter_cents"] == 3550
+        assert a["phone_count"] - b["phone_count"] == 1
+        assert a["phone_cents"] - b["phone_cents"] == 6000
+
+    def test_pace_is_cumulative_and_full_day(self, client, auth_headers):
+        d = _summary(client, auth_headers)
+        assert len(d["pace"]["today"]) == 24
+        assert len(d["pace"]["yesterday"]) == 24
+        # Cumulative: non-decreasing, and the last point equals today's net.
+        cum = [p["cents"] for p in d["pace"]["today"]]
+        assert cum == sorted(cum)
+        assert cum[-1] == d["today"]["net_cents"]
+
+    def test_vs_yesterday_uses_same_hour(self, client, auth_headers):
+        b = _summary(client, auth_headers)
+        tag = _tag()
+        _seed(f"POS-{tag}-T", "sale", 40.00)              # today
+        _seed(f"POS-{tag}-Y", "sale", 15.00, day_offset=1)  # yesterday
+        a = _summary(client, auth_headers)
+        # today moved +$40; yesterday-by-same-hour moved +$15 (1pm <= now
+        # is assumed during a normal test run) -> vs_yesterday delta +$25.
+        assert a["today"]["net_cents"] - b["today"]["net_cents"] == 4000
+        assert a["yesterday"]["net_cents"] - b["yesterday"]["net_cents"] == 1500
+
+    def test_weekly_totals(self, client, auth_headers):
+        b = _summary(client, auth_headers)["week"]
+        wd = datetime.now(_TZ).weekday()
+        tag = _tag()
+        _seed(f"POS-{tag}-TW", "sale", 50.00, day_offset=0)            # this week
+        _seed(f"POS-{tag}-LW", "sale", 80.00, day_offset=wd + 3)        # last week
+        a = _summary(client, auth_headers)["week"]
+        assert a["this_total_cents"] - b["this_total_cents"] == 5000
+        assert a["last_total_cents"] - b["last_total_cents"] == 8000
+        assert len(a["this"]) == 7 and len(a["last"]) == 7
+
+    def test_tender_split(self, client, auth_headers):
+        before = {t["method"]: t["cents"] for t in _summary(client, auth_headers)["tenders"]}
+        tag = _tag()
+        _seed(f"POS-{tag}-C", "sale", 30.00, tender="card")
+        _seed(f"POS-{tag}-K", "sale", 12.00, tender="cash")
+        after = {t["method"]: t["cents"] for t in _summary(client, auth_headers)["tenders"]}
+        assert after.get("card", 0) - before.get("card", 0) == 3000
+        assert after.get("cash", 0) - before.get("cash", 0) == 1200
+
+
+class TestDateSelector:
+    def test_summary_anchors_on_selected_date(self, client, auth_headers):
+        yday = (datetime.now(_TZ).date() - timedelta(days=1)).isoformat()
+        before = client.get(f"/api/admin/pos/summary?date={yday}", headers=auth_headers).get_json()
+        assert before["date"] == yday
+        assert before["is_today"] is False
+        b_net = before["today"]["net_cents"]
+        _seed(f"POS-{_tag()}-Y", "sale", 33.00, day_offset=1)  # a sale yesterday
+        after = client.get(f"/api/admin/pos/summary?date={yday}", headers=auth_headers).get_json()
+        assert after["today"]["net_cents"] - b_net == 3300  # shows under the selected day
+
+    def test_list_filters_by_date(self, client, auth_headers):
+        yday = (datetime.now(_TZ).date() - timedelta(days=1)).isoformat()
+        tag = _tag()
+        _seed(f"POS-{tag}-Y", "sale", 5.00, day_offset=1)
+        _seed(f"POS-{tag}-T", "sale", 5.00, day_offset=0)
+        rows = client.get(
+            f"/api/admin/pos/sales-orders?date={yday}&per_page=200", headers=auth_headers,
+        ).get_json()["sales_orders"]
+        nums = [r["so_number"] for r in rows]
+        assert f"POS-{tag}-Y" in nums
+        assert f"POS-{tag}-T" not in nums
+
+
+class TestPosList:
+    def test_total_from_order_total_and_channel(self, client, auth_headers):
+        tag = _tag()
+        _seed(f"POS-{tag}-LIST", "sale", 41.07, origin="Phone Order")
+        rows = client.get(
+            "/api/admin/pos/sales-orders?order_type=sale&per_page=200",
+            headers=auth_headers,
+        ).get_json()["sales_orders"]
+        mine = next(r for r in rows if r["so_number"] == f"POS-{tag}-LIST")
+        assert mine["total_cents"] == 4107
+        assert mine["created_at"] is not None
+        assert mine["channel"] == "Phone Order"
+
+    def test_channel_filter(self, client, auth_headers):
+        tag = _tag()
+        _seed(f"POS-{tag}-PH", "sale", 9.00, origin="Phone Order")
+        _seed(f"POS-{tag}-CT", "sale", 9.00, origin="POS")
+        phone = client.get(
+            "/api/admin/pos/sales-orders?order_type=sale&channel=phone&per_page=200",
+            headers=auth_headers,
+        ).get_json()["sales_orders"]
+        nums = [r["so_number"] for r in phone]
+        assert f"POS-{tag}-PH" in nums
+        assert f"POS-{tag}-CT" not in nums


### PR DESCRIPTION
Reworks the POS Activity admin page into a full operations dashboard.

- **Top bar**: today's KPI counters (sales, revenue, avg sale, refunds, active terminals) with an hourly revenue chart.
- **Analytics**: a pace curve against the same hour yesterday, a weekly trend, and channel + tender splits.
- **Date selector**: anchors the whole view (KPIs, list, analytics) on a chosen day.

The `/api/admin/pos/summary` endpoint computes the new aggregates in one pass; `/pos/sales-orders` gains the matching date and channel filters. Both keep the existing `pos-activity` page-permission gating. No migrations; no mobile changes.
