### PR TITLE
feat(inventory): cycle-count approval shows expected/scanned/variance

### DIFF
--- a/admin/nginx.conf.template
+++ b/admin/nginx.conf.template
@@ -62,8 +62,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 120s;
-        proxy_send_timeout 120s;
+        # Kept above the gunicorn --timeout (180s, see api/Dockerfile) so
+        # nginx never severs a backend still finishing a large write
+        # (e.g. a 300+ line cycle-count approval).
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
 
         # When the upstream is HTTPS (e.g. ACA HTTPS-only ingress), nginx
         # needs SNI to negotiate TLS against a virtual-host-routed gateway.

--- a/admin/src/pages/CycleCountApproval.jsx
+++ b/admin/src/pages/CycleCountApproval.jsx
@@ -7,6 +7,7 @@ export default function CycleCountApproval() {
   const [decisions, setDecisions] = useState({});
   const [message, setMessage] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [sortBy, setSortBy] = useState('count'); // 'count' | 'bin'
 
   useEffect(() => { loadPending(); }, []);
 
@@ -67,6 +68,16 @@ export default function CycleCountApproval() {
     groups[key].push(a);
   });
 
+  // Order the count cards by the selected key. Each count is scoped to a
+  // single bin, so bin sort and count-number sort both operate at the
+  // group level.
+  const sortedGroups = Object.entries(groups).sort(([idA, itemsA], [idB, itemsB]) => {
+    if (sortBy === 'bin') {
+      return (itemsA[0]?.bin_code || '').localeCompare(itemsB[0]?.bin_code || '', undefined, { numeric: true });
+    }
+    return (Number(idA) || 0) - (Number(idB) || 0);
+  });
+
   const thStyle = { textAlign: 'left', padding: '6px 8px', fontSize: 11, color: 'var(--text-secondary)', fontWeight: 600 };
   const tdStyle = { padding: '6px 8px' };
 
@@ -82,10 +93,25 @@ export default function CycleCountApproval() {
         <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>No pending adjustments</p>
       ) : (
         <>
-          {Object.entries(groups).map(([countId, items]) => (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12, fontSize: 12, color: 'var(--text-secondary)' }}>
+            <span>Sort by</span>
+            <button
+              className={`btn btn-sm${sortBy === 'count' ? ' btn-primary' : ''}`}
+              onClick={() => setSortBy('count')}
+            >
+              Count #
+            </button>
+            <button
+              className={`btn btn-sm${sortBy === 'bin' ? ' btn-primary' : ''}`}
+              onClick={() => setSortBy('bin')}
+            >
+              Bin
+            </button>
+          </div>
+          {sortedGroups.map(([countId, items]) => (
             <div key={countId} className="card" style={{ marginBottom: 16 }}>
               <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 12 }}>
-                Count #{countId} &mdash; {items[0].bin_code}
+                Count #{countId} - {items[0].bin_code}
               </div>
               <table style={{ width: '100%', fontSize: 13, borderCollapse: 'collapse' }}>
                 <thead>
@@ -93,7 +119,9 @@ export default function CycleCountApproval() {
                     <th style={thStyle}>SKU</th>
                     <th style={thStyle}>Item Name</th>
                     <th style={thStyle}>Bin</th>
-                    <th style={{ ...thStyle, textAlign: 'right' }}>Change</th>
+                    <th style={{ ...thStyle, textAlign: 'right' }}>Expected</th>
+                    <th style={{ ...thStyle, textAlign: 'right' }}>Scanned</th>
+                    <th style={{ ...thStyle, textAlign: 'right' }}>Variance</th>
                     <th style={thStyle}>Counted By</th>
                     <th style={thStyle}>Decision</th>
                   </tr>
@@ -108,6 +136,8 @@ export default function CycleCountApproval() {
                         <td className="mono" style={tdStyle}>{a.sku}</td>
                         <td style={{ ...tdStyle, color: 'var(--text-secondary)' }}>{a.item_name}</td>
                         <td className="mono" style={tdStyle}>{a.bin_code}</td>
+                        <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{a.expected_quantity ?? '-'}</td>
+                        <td className="mono" style={{ ...tdStyle, textAlign: 'right' }}>{a.counted_quantity ?? '-'}</td>
                         <td className="mono" style={{ ...tdStyle, textAlign: 'right', color: changeColor, fontWeight: 600 }}>{changeText}</td>
                         <td style={tdStyle}>{a.adjusted_by || '-'}</td>
                         <td style={tdStyle}>

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -40,8 +40,11 @@ USER appuser
 
 EXPOSE 5000
 
-# --timeout 60: gunicorn's default 30s worker timeout cuts off the
-# slowest PO inbound payloads (wide product-line counts) before the
-# upsert + line-table write completes. 60s gives the canonical write
-# path headroom without masking a runaway query.
-CMD ["gunicorn", "-w", "4", "--timeout", "60", "-b", "0.0.0.0:5000", "app:create_app()"]
+# --timeout 180: gunicorn's default 30s worker timeout cuts off the
+# slowest PO inbound payloads (wide product-line counts) and the
+# largest cycle-count approvals (a single bin can carry 300+ varianced
+# lines, each applied + event-emitted in one transaction) before the
+# write completes. 180s gives the canonical write paths headroom
+# without masking a runaway query. nginx proxy_read/send_timeout must
+# stay above this so the proxy never severs a still-working backend.
+CMD ["gunicorn", "-w", "4", "--timeout", "180", "-b", "0.0.0.0:5000", "app:create_app()"]

--- a/api/routes/admin/admin_users.py
+++ b/api/routes/admin/admin_users.py
@@ -719,6 +719,10 @@ def update_settings(validated):
 @require_admin_or_page_permission("cycle-counts")
 @with_db
 def list_cycle_counts():
+    # No row cap: operators need to reach every count, and the UI has no
+    # pagination control. Lines are fetched in a single batched query
+    # (count_id = ANY) and grouped in Python so dropping the limit does
+    # not reintroduce a per-count N+1 round trip.
     rows = g.db.execute(
         text(
             """
@@ -727,48 +731,50 @@ def list_cycle_counts():
             FROM cycle_counts cc
             JOIN bins b ON b.bin_id = cc.bin_id
             ORDER BY cc.created_at DESC
-            LIMIT 200
             """
         )
     ).fetchall()
 
-    counts = []
-    for r in rows:
-        lines = g.db.execute(
+    count_ids = [r.count_id for r in rows]
+    lines_by_count = {}
+    if count_ids:
+        line_rows = g.db.execute(
             text(
                 """
-                SELECT ccl.count_line_id, i.sku, i.item_name,
+                SELECT ccl.count_id, ccl.count_line_id, i.sku, i.item_name,
                        ccl.expected_quantity, ccl.counted_quantity, ccl.unexpected,
                        (ccl.counted_quantity - ccl.expected_quantity) AS variance
                 FROM cycle_count_lines ccl
                 JOIN items i ON i.item_id = ccl.item_id
-                WHERE ccl.count_id = :cid
-                ORDER BY i.sku
+                WHERE ccl.count_id = ANY(:cids)
+                ORDER BY ccl.count_id, i.sku
                 """
             ),
-            {"cid": r.count_id},
+            {"cids": count_ids},
         ).fetchall()
+        for l in line_rows:
+            lines_by_count.setdefault(l.count_id, []).append({
+                "count_line_id": l.count_line_id,
+                "sku": l.sku,
+                "item_name": l.item_name,
+                "expected_quantity": l.expected_quantity,
+                "counted_quantity": l.counted_quantity,
+                "unexpected": l.unexpected,
+                "variance": l.variance,
+            })
 
-        counts.append({
+    counts = [
+        {
             "count_id": r.count_id,
             "bin_code": r.bin_code,
             "status": r.status,
             "assigned_to": r.assigned_to,
             "created_at": r.created_at.isoformat() if r.created_at else None,
             "completed_at": r.completed_at.isoformat() if r.completed_at else None,
-            "lines": [
-                {
-                    "count_line_id": l.count_line_id,
-                    "sku": l.sku,
-                    "item_name": l.item_name,
-                    "expected_quantity": l.expected_quantity,
-                    "counted_quantity": l.counted_quantity,
-                    "unexpected": l.unexpected,
-                    "variance": l.variance,
-                }
-                for l in lines
-            ],
-        })
+            "lines": lines_by_count.get(r.count_id, []),
+        }
+        for r in rows
+    ]
 
     return jsonify({"cycle_counts": counts})
 
@@ -781,12 +787,26 @@ def list_cycle_counts():
 @with_db
 def list_pending_adjustments():
     """Return pending inventory adjustments grouped by cycle count."""
+    # expected_quantity / counted_quantity come from the originating
+    # cycle_count_line (keyed by count + item). Correlated subselects so a
+    # non-cycle-count adjustment (cycle_count_id NULL) simply yields NULL
+    # without fanning the adjustment row out across line matches.
     rows = g.db.execute(
         text("""
             SELECT ia.adjustment_id, ia.item_id, ia.bin_id, ia.warehouse_id,
                    ia.quantity_change, ia.reason_code, ia.reason_detail,
                    ia.status, ia.adjusted_by, ia.adjusted_at, ia.cycle_count_id,
-                   i.sku, i.item_name, b.bin_code
+                   i.sku, i.item_name, b.bin_code,
+                   (SELECT ccl.expected_quantity
+                      FROM cycle_count_lines ccl
+                     WHERE ccl.count_id = ia.cycle_count_id
+                       AND ccl.item_id = ia.item_id
+                     LIMIT 1) AS expected_quantity,
+                   (SELECT ccl.counted_quantity
+                      FROM cycle_count_lines ccl
+                     WHERE ccl.count_id = ia.cycle_count_id
+                       AND ccl.item_id = ia.item_id
+                     LIMIT 1) AS counted_quantity
             FROM inventory_adjustments ia
             JOIN items i ON i.item_id = ia.item_id
             JOIN bins b ON b.bin_id = ia.bin_id
@@ -804,6 +824,8 @@ def list_pending_adjustments():
                 "bin_id": r.bin_id,
                 "warehouse_id": r.warehouse_id,
                 "quantity_change": r.quantity_change,
+                "expected_quantity": r.expected_quantity,
+                "counted_quantity": r.counted_quantity,
                 "reason_code": r.reason_code,
                 "reason_detail": r.reason_detail,
                 "status": r.status,

--- a/api/tests/test_inventory.py
+++ b/api/tests/test_inventory.py
@@ -345,3 +345,50 @@ class TestAdjustmentSelfApproval:
         )
         assert resp.status_code == 403
         assert "Cannot approve your own cycle count" in resp.get_json()["error"]
+
+
+class TestPendingAdjustmentsList:
+    """Approval screen feed: /admin/adjustments/pending must carry the
+    expected / counted / variance figures the operator approves against."""
+
+    def _create_variance(self, client, auth_headers, delta=5):
+        create_resp = client.post(
+            "/api/inventory/cycle-count/create",
+            json={"warehouse_id": 1, "bin_ids": [3]},
+            headers=auth_headers,
+        )
+        count_id = create_resp.get_json()["counts"][0]["count_id"]
+
+        detail_resp = client.get(
+            f"/api/inventory/cycle-count/{count_id}", headers=auth_headers
+        )
+        line = detail_resp.get_json()["lines"][0]
+        expected = line["expected_quantity"]
+
+        submit_resp = client.post(
+            "/api/inventory/cycle-count/submit",
+            json={
+                "count_id": count_id,
+                "lines": [
+                    {"count_line_id": line["count_line_id"], "counted_quantity": expected + delta}
+                ],
+            },
+            headers=auth_headers,
+        )
+        adj = submit_resp.get_json()["summary"]["adjustments"][0]
+        return adj["adjustment_id"], expected, expected + delta
+
+    def test_pending_carries_expected_counted_variance(self, client, auth_headers):
+        adj_id, expected, counted = self._create_variance(client, auth_headers, delta=5)
+
+        resp = client.get("/api/admin/adjustments/pending", headers=auth_headers)
+        assert resp.status_code == 200
+        rows = resp.get_json()["adjustments"]
+
+        match = next((a for a in rows if a["adjustment_id"] == adj_id), None)
+        assert match is not None, "submitted variance should appear in the pending queue"
+        assert match["expected_quantity"] == expected
+        assert match["counted_quantity"] == counted
+        # Variance the operator sees == counted - expected == quantity_change.
+        assert match["counted_quantity"] - match["expected_quantity"] == match["quantity_change"]
+        assert match["quantity_change"] == 5

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -13806,9 +13806,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
The cycle-count approval screen showed only the net Change per line. An operator approving a variance needs to see what the system expected, what was scanned, and the resulting variance side by side.

- **Approval screen** (`/admin/adjustments/pending`): now returns `expected_quantity` and `counted_quantity` for each pending adjustment, pulled from the originating `cycle_count_line` via correlated subselects (NULL for non-cycle-count adjustments, no row fan-out). The screen renders Expected / Scanned / Variance columns and sorts the count cards by count number or bin.
- **Full list** (`/admin/cycle-counts`): drops its 200-row cap and fetches every count's lines in one batched query (`count_id = ANY`) grouped in Python, so the full list is reachable without reintroducing a per-count N+1.
- **Timeouts**: approving a single bin with 300+ varianced lines applies each line's inventory change and emits its events in one transaction, which ran past the 60s gunicorn worker timeout. Raised gunicorn `--timeout` 60s -> 180s and nginx `proxy_read/send_timeout` 120s -> 300s (kept above the app ceiling so the proxy never severs a still-working backend).

No migrations; no mobile changes.
