### PR TITLE
feat(admin): local pickup dashboard + distinct REFUNDED order status

### DIFF
--- a/admin/src/components/StatusTag.jsx
+++ b/admin/src/components/StatusTag.jsx
@@ -11,6 +11,7 @@ const STATUS_MAP = {
   SHIPPED: 'tag-success',
   CLOSED: 'tag-gray',
   CANCELLED: 'tag-gray',
+  REFUNDED: 'tag-warning',
   INACTIVE: 'tag-gray',
   LOW: 'tag-danger',
   VARIANCE: 'tag-danger',

--- a/admin/src/pages/Dashboard.jsx
+++ b/admin/src/pages/Dashboard.jsx
@@ -2,8 +2,10 @@ import { useState, useEffect, useMemo } from 'react';
 import { api } from '../api.js';
 import { formatDateOnly } from '../utils/date.js';
 import { useWarehouse } from '../warehouse.jsx';
+import { useAuth } from '../auth.jsx';
 import PageHeader from '../components/PageHeader.jsx';
 import Modal from '../components/Modal.jsx';
+import StatusTag from '../components/StatusTag.jsx';
 
 // v1.8.0 (#299) productivity dashboard. Reads /api/v1/dashboard/
 // productivity for the warehouse-scoped per-user metrics, and
@@ -199,10 +201,18 @@ export default function Dashboard() {
         >
           Marketplace Health
         </button>
+        <button
+          type="button"
+          className={`data-tab${tab === 'local-pickup' ? ' active' : ''}`}
+          onClick={() => setTab('local-pickup')}
+        >
+          Local Pickup
+        </button>
       </div>
       {tab === 'productivity' && <ProductivityView warehouseId={warehouseId} />}
       {tab === 'received' && <ReceivedTodayView warehouseId={warehouseId} />}
       {tab === 'shipping' && <ShippingHealthView warehouseId={warehouseId} />}
+      {tab === 'local-pickup' && <LocalPickupView warehouseId={warehouseId} />}
     </div>
   );
 }
@@ -916,5 +926,382 @@ function ShipTodayBubble({ row, onClick }) {
         &#10003;
       </span>
     </div>
+  );
+}
+
+
+// -- Local Pickup -----------------------------------------------------------
+//
+// Daily worklist for the retail shop: every sales order whose ship_method
+// names a local pickup / will-call (server filter local_pickup=true, which
+// matches "local" OR "pickup"). The counter worker searches by customer or
+// order number, narrows by status, edits an order in place, and hits the
+// red "Picked Up?" button when a customer collects -- that reuses the SO
+// edit endpoint's PICKED/PACKED -> SHIPPED transition, which waives the
+// tracking number for pickups. Marking shipped and editing a non-OPEN order
+// both need ADMIN or the so-full-edit override, so the controls disable
+// (with a reason) for a plain USER and the worklist explains the 403.
+
+const LOCAL_PICKUP_STATUS_OPTIONS = ['All', 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED'];
+const SHIPPABLE_STATUSES = new Set(['PICKED', 'PACKED']);
+
+function LocalPickupView({ warehouseId }) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'ADMIN';
+  const hasSOFullEdit = isAdmin || (user?.allowed_overrides || []).includes('so-full-edit');
+
+  const [rows, setRows] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [forbidden, setForbidden] = useState(false);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('All');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [editing, setEditing] = useState(null);
+  const [shippingId, setShippingId] = useState(null);
+  const [confirming, setConfirming] = useState(null);  // SO awaiting pickup confirm
+  const [alertMsg, setAlertMsg] = useState(null);       // {title, message} loud modal
+
+  // Debounce the search box so a request does not fire on every keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  useEffect(() => {
+    if (!warehouseId) return;
+    load();
+  }, [warehouseId, debouncedSearch, statusFilter]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function load() {
+    setLoading(true);
+    setError('');
+    const qp = new URLSearchParams({
+      local_pickup: 'true',
+      warehouse_id: String(warehouseId),
+      per_page: '1000',
+    });
+    if (debouncedSearch) qp.set('q', debouncedSearch);
+    if (statusFilter !== 'All') qp.set('status', statusFilter);
+    const res = await api.get(`/admin/sales-orders?${qp}`, { silentPermissionDenied: true });
+    setLoading(false);
+    if (!res) return;
+    if (res.status === 403) { setForbidden(true); setRows([]); setTotal(0); return; }
+    setForbidden(false);
+    if (!res.ok) { setError('Could not load local pickup orders.'); return; }
+    const data = await res.json();
+    setRows(data.sales_orders || []);
+    setTotal(data.total ?? (data.sales_orders || []).length);
+  }
+
+  // Clicking the red button never silently no-ops: if the order can't be
+  // picked up (wrong status, or no permission) we say so loudly in a modal;
+  // otherwise we open the JSX confirm modal. The real ship runs in doPickup.
+  function requestPickup(so) {
+    if (!(isAdmin || hasSOFullEdit)) {
+      setAlertMsg({
+        title: 'Permission needed',
+        message: `You can't mark ${so.so_number} picked up. This needs the `
+          + 'ADMIN role or the so-full-edit override on your account.',
+      });
+      return;
+    }
+    if (!SHIPPABLE_STATUSES.has(so.status)) {
+      setAlertMsg({
+        title: 'Not ready for pickup',
+        message: `${so.so_number} is ${so.status}, not picked yet. An order `
+          + 'must be PICKED or PACKED before it can be marked picked up.',
+      });
+      return;
+    }
+    setConfirming(so);
+  }
+
+  async function doPickup(so) {
+    setShippingId(so.so_id);
+    // Reuse the SO edit endpoint's ship transition. ship_method already
+    // names a local pickup, so the backend waives the tracking number.
+    const res = await api.put(
+      `/admin/sales-orders/${so.so_id}`,
+      { status: 'SHIPPED' },
+      { silentPermissionDenied: true },
+    );
+    setShippingId(null);
+    setConfirming(null);
+    if (!res) return;
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setAlertMsg({
+        title: 'Could not mark picked up',
+        message: res.status === 403
+          ? `Not allowed: marking ${so.so_number} picked up needs ADMIN or the so-full-edit override.`
+          : (data.error || `Could not mark ${so.so_number} picked up (status ${res.status}).`),
+      });
+      return;
+    }
+    load();
+  }
+
+  if (!warehouseId) {
+    return <div style={{ padding: 24, color: 'var(--text-secondary)' }}>Select a warehouse.</div>;
+  }
+  if (forbidden) {
+    return (
+      <div style={{ padding: 24, color: 'var(--text-secondary)', maxWidth: 520 }}>
+        You do not have access to sales orders. Ask an admin to grant the
+        Sales Orders page permission, plus the so-full-edit override to mark
+        pickups complete.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 12, marginBottom: 16, flexWrap: 'wrap', alignItems: 'center' }}>
+        <input
+          className="form-input"
+          style={{ width: 280 }}
+          placeholder="Search by customer or order #"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          className="form-select"
+          style={{ width: 170 }}
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+        >
+          {LOCAL_PICKUP_STATUS_OPTIONS.map((s) => (
+            <option key={s} value={s}>{s === 'All' ? 'All statuses' : s}</option>
+          ))}
+        </select>
+        <span style={{ marginLeft: 'auto', fontSize: 13, color: 'var(--text-secondary)' }}>
+          {loading ? 'Loading…' : `${rows.length} order${rows.length === 1 ? '' : 's'}`}
+        </span>
+        <button className="btn btn-sm" onClick={load} disabled={loading}>Refresh</button>
+      </div>
+
+      {error && <div className="form-error" style={{ marginBottom: 12 }}>{error}</div>}
+      {total > rows.length && (
+        <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 12 }}>
+          Showing {rows.length} of {total}. Narrow with the status filter or search.
+        </div>
+      )}
+
+      {!loading && rows.length === 0 ? (
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>No local pickup orders match.</p>
+      ) : (
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>Order #</th>
+              <th>Customer</th>
+              <th>Status</th>
+              <th>Order Date</th>
+              <th style={{ textAlign: 'right' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((so) => {
+              const status = so.status;
+              const canEdit = isAdmin || hasSOFullEdit || status === 'OPEN';
+              return (
+                <tr key={so.so_id}>
+                  <td className="mono">{so.so_number}</td>
+                  <td>{so.customer_name || '-'}</td>
+                  <td><StatusTag status={status} /></td>
+                  <td className="mono" style={{ fontSize: 12 }}>
+                    {so.order_date ? formatDateOnly(so.order_date)
+                      : (so.created_at ? formatDateOnly(so.created_at) : '-')}
+                  </td>
+                  <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
+                    <button
+                      className="btn btn-sm"
+                      style={{ marginRight: 8 }}
+                      onClick={() => setEditing(so)}
+                      disabled={!canEdit}
+                      title={canEdit ? 'Edit order' : 'Editing a picked order needs ADMIN or so-full-edit'}
+                    >
+                      Edit
+                    </button>
+                    {status === 'SHIPPED' ? (
+                      <span style={{ fontSize: 12, color: '#1f9d55', fontWeight: 600 }}>Picked up &#10003;</span>
+                    ) : (
+                      <button
+                        className="btn btn-sm btn-danger"
+                        onClick={() => requestPickup(so)}
+                        disabled={shippingId === so.so_id}
+                        title="Mark this order picked up (ships it)"
+                      >
+                        {shippingId === so.so_id ? 'Working…' : 'Picked Up?'}
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {editing && (
+        <LocalPickupEditModal
+          so={editing}
+          canEditAll={isAdmin || hasSOFullEdit}
+          onClose={() => setEditing(null)}
+          onSaved={() => { setEditing(null); load(); }}
+        />
+      )}
+
+      {confirming && (
+        <Modal
+          title="Mark picked up?"
+          onClose={() => (shippingId == null ? setConfirming(null) : null)}
+          footer={(
+            <>
+              <button className="btn" onClick={() => setConfirming(null)} disabled={shippingId != null}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-danger"
+                onClick={() => doPickup(confirming)}
+                disabled={shippingId != null}
+              >
+                {shippingId != null ? 'Working…' : 'Yes, mark picked up'}
+              </button>
+            </>
+          )}
+        >
+          <p style={{ marginTop: 0 }}>
+            Mark order <strong>{confirming.so_number}</strong>
+            {confirming.customer_name ? ` (${confirming.customer_name})` : ''} as picked up?
+          </p>
+          <p style={{ color: 'var(--text-secondary)', fontSize: 13, marginBottom: 0 }}>
+            This marks it <strong>SHIPPED</strong> -- it records the handoff and releases the
+            order. It cannot be undone from here.
+          </p>
+        </Modal>
+      )}
+
+      {alertMsg && (
+        <Modal
+          title={alertMsg.title}
+          onClose={() => setAlertMsg(null)}
+          footer={<button className="btn btn-primary" onClick={() => setAlertMsg(null)}>OK</button>}
+        >
+          <p style={{ margin: 0 }}>{alertMsg.message}</p>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+// In-place edit of the fields a counter worker touches on a pickup order.
+// Full line-item edits stay on the Sales Orders page; this is the narrow
+// header surface (PUT /admin/sales-orders/<id>). Prefills from the list row
+// -- the list already returns every field shown here -- so no extra fetch.
+function LocalPickupEditModal({ so, canEditAll, onClose, onSaved }) {
+  const editable = canEditAll || so.status === 'OPEN';
+  const [form, setForm] = useState({
+    customer_name: so.customer_name || '',
+    customer_phone: so.customer_phone || '',
+    ship_method: so.ship_method || '',
+    ship_address: so.ship_address || '',
+    priority: so.priority ?? 0,
+    memo: so.memo || '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  async function save() {
+    setSaving(true);
+    setError('');
+    const body = {
+      customer_name: form.customer_name || null,
+      customer_phone: form.customer_phone || null,
+      ship_method: form.ship_method || null,
+      ship_address: form.ship_address || null,
+      priority: Number(form.priority) || 0,
+      memo: form.memo || null,
+    };
+    const res = await api.put(`/admin/sales-orders/${so.so_id}`, body, { silentPermissionDenied: true });
+    setSaving(false);
+    if (!res) return;
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setError(
+        res.status === 403
+          ? 'Not allowed: editing a picked order needs ADMIN or the so-full-edit override.'
+          : (data.error || 'Could not save changes.'),
+      );
+      return;
+    }
+    onSaved();
+  }
+
+  return (
+    <Modal
+      title={`Edit ${so.so_number}`}
+      onClose={onClose}
+      footer={(
+        <>
+          <button className="btn" onClick={onClose}>Cancel</button>
+          <button className="btn btn-primary" onClick={save} disabled={saving || !editable}>
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </>
+      )}
+    >
+      {!editable && (
+        <div className="form-error" style={{ marginBottom: 12 }}>
+          This order is {so.status}; editing it needs ADMIN or the so-full-edit override.
+        </div>
+      )}
+      {error && <div className="form-error" style={{ marginBottom: 12 }}>{error}</div>}
+      <div className="form-group">
+        <label>Customer name</label>
+        <input
+          className="form-input" disabled={!editable} value={form.customer_name}
+          onChange={(e) => setForm({ ...form, customer_name: e.target.value })}
+        />
+      </div>
+      <div className="form-group">
+        <label>Customer phone</label>
+        <input
+          className="form-input" disabled={!editable} value={form.customer_phone}
+          onChange={(e) => setForm({ ...form, customer_phone: e.target.value })}
+        />
+      </div>
+      <div className="form-group">
+        <label>Ship method</label>
+        <input
+          className="form-input" disabled={!editable} value={form.ship_method}
+          onChange={(e) => setForm({ ...form, ship_method: e.target.value })}
+        />
+      </div>
+      <div className="form-group">
+        <label>Pickup / ship address</label>
+        <input
+          className="form-input" disabled={!editable} value={form.ship_address}
+          onChange={(e) => setForm({ ...form, ship_address: e.target.value })}
+        />
+      </div>
+      <div className="form-group">
+        <label>Priority</label>
+        <input
+          type="number" min="0" max="10" className="form-input" disabled={!editable}
+          value={form.priority}
+          onChange={(e) => setForm({ ...form, priority: e.target.value })}
+        />
+      </div>
+      <div className="form-group">
+        <label>Memo</label>
+        <textarea
+          className="form-input" rows={3} disabled={!editable} value={form.memo}
+          onChange={(e) => setForm({ ...form, memo: e.target.value })}
+        />
+      </div>
+    </Modal>
   );
 }

--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -9,12 +9,15 @@ import Modal from '../components/Modal.jsx';
 import StatusTag from '../components/StatusTag.jsx';
 import CreateRmaModal from '../components/CreateRmaModal.jsx';
 
-const STATUS_OPTIONS = ['All', 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED'];
-const EDITABLE_STATUS_OPTIONS = ['OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED'];
-// Lines are terminal once the SO has shipped or cancelled. Header edits
-// remain ADMIN-only for SHIPPED (external-system backfill); for CANCELLED
-// the operator should reopen via the cancel-undo workflow, not edit.
-const LINE_TERMINAL_STATUSES = new Set(['SHIPPED', 'CANCELLED']);
+const STATUS_OPTIONS = ['All', 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED', 'REFUNDED'];
+const EDITABLE_STATUS_OPTIONS = ['OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED', 'REFUNDED'];
+// Lines are terminal once the SO has shipped, cancelled, or been refunded.
+// Header edits remain ADMIN-only for SHIPPED (external-system backfill); for
+// CANCELLED / REFUNDED the operator should reopen via the cancel-undo
+// workflow, not edit. REFUNDED is a terminal label (mig 074) -- it is not in
+// STATUS_ORDER, so setting it routes through the normal PUT, never the
+// backward revert-status flow.
+const LINE_TERMINAL_STATUSES = new Set(['SHIPPED', 'CANCELLED', 'REFUNDED']);
 // so-refinement: forward-flow ordering. Mirrors _STATUS_ORDER in
 // api/services/sales_order_service.py. PICKING / PACKING / ALLOCATED
 // were retired in v1.13.0 (mig 058); the live flow is

--- a/admin/src/test/local-pickup-dashboard.test.jsx
+++ b/admin/src/test/local-pickup-dashboard.test.jsx
@@ -1,0 +1,120 @@
+/**
+ * Dashboard "Local Pickup" tab: lists the local-pickup worklist via the
+ * server-side local_pickup filter, and the red "Picked Up?" button marks an
+ * order shipped through the SO edit endpoint's PICKED -> SHIPPED transition.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const apiGetMock = vi.fn();
+const apiPutMock = vi.fn();
+vi.mock('../api.js', () => ({
+  api: {
+    get: (...a) => apiGetMock(...a),
+    put: (...a) => apiPutMock(...a),
+    post: vi.fn(), patch: vi.fn(), delete: vi.fn(),
+  },
+}));
+vi.mock('../warehouse.jsx', () => ({ useWarehouse: () => ({ warehouseId: 1 }) }));
+vi.mock('../auth.jsx', () => ({
+  useAuth: () => ({ user: { role: 'ADMIN', allowed_overrides: [] } }),
+}));
+
+import Dashboard from '../pages/Dashboard.jsx';
+
+const json = (body, status = 200) => Promise.resolve({
+  ok: status >= 200 && status < 300,
+  status,
+  json: () => Promise.resolve(body),
+});
+
+const PICKUP_ORDERS = {
+  sales_orders: [
+    {
+      so_id: 11, so_number: 'SO-PICK-1', customer_name: 'Neal Hoffberg',
+      status: 'PICKED', order_date: '2026-06-14T00:00:00Z',
+      ship_method: 'Local Pickup (Free)',
+      customer_phone: '555-1212', ship_address: '', priority: 0, memo: '',
+    },
+    {
+      so_id: 12, so_number: 'SO-OPEN-1', customer_name: 'Jane Angler',
+      status: 'OPEN', order_date: '2026-06-15T00:00:00Z',
+      ship_method: 'Will Call - Local',
+      customer_phone: '', ship_address: '', priority: 0, memo: '',
+    },
+  ],
+  total: 2, page: 1, pages: 1, per_page: 1000,
+};
+
+function wire() {
+  apiGetMock.mockImplementation((path = '') => {
+    if (path.startsWith('/admin/sales-orders')) return json(PICKUP_ORDERS);
+    return json({}); // dashboard preferences / productivity / etc.
+  });
+  apiPutMock.mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({}) });
+}
+
+async function openLocalPickupTab() {
+  const view = render(<MemoryRouter><Dashboard /></MemoryRouter>);
+  fireEvent.click(await view.findByText('Local Pickup'));
+  return view;
+}
+
+describe('Dashboard Local Pickup tab', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset();
+    apiPutMock.mockReset();
+    wire();
+  });
+
+  it('lists local pickup orders via the server-side local_pickup filter', async () => {
+    const { findByText } = await openLocalPickupTab();
+    await findByText('SO-PICK-1');
+    await findByText('Neal Hoffberg');
+    await findByText('SO-OPEN-1');
+    expect(apiGetMock).toHaveBeenCalledWith(
+      expect.stringContaining('local_pickup=true'),
+      expect.anything(),
+    );
+  });
+
+  it('passes the status filter through to the request', async () => {
+    const { findByText, getByDisplayValue } = await openLocalPickupTab();
+    await findByText('SO-PICK-1');
+    fireEvent.change(getByDisplayValue('All statuses'), { target: { value: 'PICKED' } });
+    await waitFor(() => {
+      expect(apiGetMock).toHaveBeenCalledWith(
+        expect.stringContaining('status=PICKED'),
+        expect.anything(),
+      );
+    });
+  });
+
+  it('confirms in a JSX modal (not window.confirm) then ships a PICKED order', async () => {
+    const { findByText, getAllByText } = await openLocalPickupTab();
+    await findByText('SO-PICK-1');
+    fireEvent.click(getAllByText('Picked Up?')[0]);  // first row = PICKED
+    // A JSX confirm modal appears; nothing ships until it is confirmed.
+    const confirmBtn = await findByText('Yes, mark picked up');
+    expect(apiPutMock).not.toHaveBeenCalled();
+    fireEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(apiPutMock).toHaveBeenCalledWith(
+        '/admin/sales-orders/11',
+        { status: 'SHIPPED' },
+        expect.anything(),
+      );
+    });
+  });
+
+  it('shows a loud modal (no silent no-op) when an OPEN order cannot be picked up', async () => {
+    const { findByText, getAllByText } = await openLocalPickupTab();
+    await findByText('SO-OPEN-1');
+    fireEvent.click(getAllByText('Picked Up?')[1]);  // second row = OPEN
+    await findByText('Not ready for pickup');
+    expect(apiPutMock).not.toHaveBeenCalled();
+  });
+});

--- a/admin/src/test/status-tag-refunded.test.jsx
+++ b/admin/src/test/status-tag-refunded.test.jsx
@@ -1,0 +1,23 @@
+/**
+ * StatusTag: REFUNDED (mig 074) renders as its own colour, visually
+ * distinct from CANCELLED, so operators can tell a refund from a cancel.
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import StatusTag from '../components/StatusTag.jsx';
+
+describe('StatusTag REFUNDED', () => {
+  it('renders REFUNDED with a distinct (non-cancelled) colour', () => {
+    const { getByText } = render(<StatusTag status="REFUNDED" />);
+    const el = getByText('REFUNDED');
+    expect(el.className).toContain('tag-warning');
+    expect(el.className).not.toContain('tag-gray');
+  });
+
+  it('still renders CANCELLED as gray', () => {
+    const { getByText } = render(<StatusTag status="CANCELLED" />);
+    expect(getByText('CANCELLED').className).toContain('tag-gray');
+  });
+});

--- a/api/constants.py
+++ b/api/constants.py
@@ -30,6 +30,13 @@ SO_CANCELLED = "CANCELLED"
 # from the picking queue until a CSR clears via the Fraud page.
 SO_FRAUD_REVIEW = "FRAUD_REVIEW"
 
+# A fully-refunded sale (or a cancel issued because the customer was
+# refunded). Distinct from CANCELLED so refunds read apart from plain
+# cancellations in the operator views and reporting. App-enforced -- no
+# DB CHECK on sales_orders.status. Pure status label: the money + the
+# inventory move in the refund flow, never on this status transition.
+SO_REFUNDED = "REFUNDED"
+
 # mig 067: backorder-only off-ramp. A BO SO created via
 # /partial-fulfill starts here and flips to OPEN when receipt.completed
 # makes all its lines satisfiable. Hidden from picker queues by the

--- a/api/routes/admin/admin_orders.py
+++ b/api/routes/admin/admin_orders.py
@@ -10,11 +10,11 @@ from sqlalchemy import text
 
 from constants import (
     PO_OPEN, PO_PARTIAL, PO_RECEIVED, PO_CLOSED, PO_ARCHIVED,
-    SO_OPEN, SO_PICKED, SO_PACKED, SO_SHIPPED, SO_CANCELLED,
+    SO_OPEN, SO_PICKED, SO_PACKED, SO_SHIPPED, SO_CANCELLED, SO_REFUNDED,
     SO_FRAUD_REVIEW, SO_WAITING_STOCK,
     TASK_PENDING, ADJ_PENDING, ADJ_APPROVED, ADJ_REASON_SHORT,
     ORDER_TYPE_BACKORDER,
-    CANCEL_REASONS, CANCEL_REASON_OTHER,
+    CANCEL_REASONS, CANCEL_REASON_OTHER, CANCEL_REASON_REFUNDED,
     COMPANY_TIMEZONE,
     ACTION_PICK,
     ACTION_PO_STATUS_CHANGED,
@@ -916,6 +916,12 @@ def list_sales_orders():
     # by pick_sequence so a picker walks the warehouse in physical
     # order; the shipper unpacks the cart in the same order.
     include_primary_bin = request.args.get("include_primary_bin", "false").lower() == "true"
+    # Opt-in filter for the Local Pickup dashboard: keep only orders whose
+    # ship_method names a local pickup / will-call. These are free-text
+    # values like "Local Pickup (Free)", so match either
+    # word ("local" or "pickup") rather than forcing a canonical enum. Pages
+    # that show the full SO ledger leave the param unset.
+    local_pickup = request.args.get("local_pickup", "false").lower() == "true"
     if status:
         where_clauses.append("so.status = :status")
         params["status"] = status
@@ -932,6 +938,10 @@ def list_sales_orders():
     if search:
         where_clauses.append("(so.so_number ILIKE :q OR so.customer_name ILIKE :q)")
         params["q"] = f"%{search}%"
+    if local_pickup:
+        where_clauses.append(
+            "(so.ship_method ILIKE '%local%' OR so.ship_method ILIKE '%pickup%')"
+        )
 
     where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
     total = g.db.execute(
@@ -2696,6 +2706,16 @@ def cancel_backorder(bo_so_id, validated):
             "error": str(exc),
             "current_status": exc.current_status,
         }), 400
+
+    # A backorder cancelled because the customer was refunded reads as
+    # REFUNDED, not a plain cancel. _cancel_so already ran the inventory
+    # unwind + emitted backorder.cancelled; this only relabels the terminal
+    # status, matching the POS full-refund path and the mig 074 backfill.
+    if reason == CANCEL_REASON_REFUNDED:
+        g.db.execute(
+            text("UPDATE sales_orders SET status = :st WHERE so_id = :sid"),
+            {"st": SO_REFUNDED, "sid": bo_so_id},
+        )
 
     g.db.commit()
 

--- a/api/routes/admin/admin_users.py
+++ b/api/routes/admin/admin_users.py
@@ -548,6 +548,9 @@ def dashboard():
     # v1.9.0 #311: surface cancelled count so operators have visibility
     # into cancellation rate alongside the other lifecycle counters.
     cancelled_count = g.db.execute(text(f"SELECT COUNT(*) FROM sales_orders WHERE status = 'CANCELLED' {wh_filter}"), wh_params).scalar()
+    # mig 074: refunds are their own terminal status now, counted apart from
+    # plain cancellations so the cancellation rate is not inflated by refunds.
+    refunded_count = g.db.execute(text(f"SELECT COUNT(*) FROM sales_orders WHERE status = 'REFUNDED' {wh_filter}"), wh_params).scalar()
 
     if require_packing:
         ready_to_pack = picked_count
@@ -625,6 +628,7 @@ def dashboard():
         "orders_in_picking": in_picking,
         "ready_to_ship": ready_to_ship,
         "cancelled_orders": cancelled_count,
+        "refunded_orders": refunded_count,
         "require_packing": require_packing,
         "total_skus": total_skus,
         "total_bins": total_bins,

--- a/api/routes/dashboard.py
+++ b/api/routes/dashboard.py
@@ -466,7 +466,7 @@ def shipping_health():
                    COUNT(so.so_id) FILTER (
                        WHERE so.ship_by_date IS NOT NULL
                          AND so.ship_by_date <= CURRENT_DATE
-                         AND so.status NOT IN ('SHIPPED', 'CANCELLED', 'FRAUD_REVIEW')
+                         AND so.status NOT IN ('SHIPPED', 'CANCELLED', 'REFUNDED', 'FRAUD_REVIEW')
                    ) AS need_to_ship_today
               FROM origins o
               LEFT JOIN sales_orders so

--- a/api/routes/pos.py
+++ b/api/routes/pos.py
@@ -1734,8 +1734,9 @@ def refund():
         raise
 
     # Mark the original SO refunded + cancelled, but only once it is fully
-    # refunded. A fully-refunded sale is a cancelled sale: status -> CANCELLED so
-    # the admin/picker views stop showing it as SHIPPED, and refunded_at +
+    # refunded. A fully-refunded sale flips to REFUNDED (distinct from CANCELLED) so
+    # the admin/picker views stop showing it as SHIPPED, refunds read apart from
+    # plain cancellations, and refunded_at +
     # refund_so_id record the completing credit-memo SO. A partial refund leaves
     # the original SHIPPED with refunded_at NULL so the order-level
     # already_refunded gate stays open for the next partial; the credit-memo SOs
@@ -1748,7 +1749,7 @@ def refund():
                 UPDATE sales_orders
                    SET refunded_at  = NOW(),
                        refund_so_id = :refund_so_id,
-                       status       = 'CANCELLED'
+                       status       = 'REFUNDED'
                  WHERE so_id = :original_so_id
                 """
             ),

--- a/api/tests/test_admin.py
+++ b/api/tests/test_admin.py
@@ -715,6 +715,76 @@ class TestSalesOrdersHidePrintedAndMarkPrinted:
         assert 1 not in filtered_ids
 
 
+def _set_ship_method(so_id, ship_method):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE sales_orders SET ship_method = %s WHERE so_id = %s",
+        (ship_method, so_id),
+    )
+    cur.close()
+
+
+class TestSalesOrdersLocalPickupFilter:
+    """Local Pickup dashboard: GET /admin/sales-orders?local_pickup=true
+    keeps only orders whose ship_method names a local pickup / will-call.
+    The match is a free-text contains on either word ("local" or
+    "pickup"), so values like "Local Pickup (Free)" and a bare
+    "Will Call - Local" both qualify without forcing a canonical enum."""
+
+    def test_local_pickup_true_keeps_only_local_or_pickup(self, client, auth_headers):
+        _set_ship_method(1, "Local Pickup (Free)")
+        _set_ship_method(2, "FedEx Ground")
+        resp = client.get(
+            "/api/admin/sales-orders?per_page=1000&local_pickup=true",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        rows = resp.get_json()["sales_orders"]
+        ids = {s["so_id"] for s in rows}
+        assert 1 in ids
+        assert 2 not in ids
+        # Every returned row satisfies the either-word rule.
+        for s in rows:
+            sm = (s["ship_method"] or "").lower()
+            assert "local" in sm or "pickup" in sm
+
+    def test_local_word_alone_matches(self, client, auth_headers):
+        # "local" without "pickup" is enough; the rule is either word.
+        _set_ship_method(3, "Will Call - Local")
+        resp = client.get(
+            "/api/admin/sales-orders?per_page=1000&local_pickup=true",
+            headers=auth_headers,
+        )
+        ids = {s["so_id"] for s in resp.get_json()["sales_orders"]}
+        assert 3 in ids
+
+    def test_local_pickup_composes_with_status(self, client, auth_headers):
+        # The filter ANDs with the status dropdown the dashboard sends.
+        _set_ship_method(1, "Local Pickup")
+        status = _query_val("SELECT status FROM sales_orders WHERE so_id = 1")
+        resp = client.get(
+            f"/api/admin/sales-orders?per_page=1000&local_pickup=true&status={status}",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        rows = resp.get_json()["sales_orders"]
+        assert 1 in {s["so_id"] for s in rows}
+        for s in rows:
+            assert s["status"] == status
+            sm = (s["ship_method"] or "").lower()
+            assert "local" in sm or "pickup" in sm
+
+    def test_filter_is_opt_in(self, client, auth_headers):
+        # Without the param a carrier-ship order is not narrowed away.
+        _set_ship_method(2, "FedEx Ground")
+        resp = client.get(
+            "/api/admin/sales-orders?per_page=1000",
+            headers=auth_headers,
+        )
+        assert 2 in {s["so_id"] for s in resp.get_json()["sales_orders"]}
+
+
 class TestSalesOrdersPrimaryBin:
     """avid-overhaul-mk1 P4.1: include_primary_bin=true on the SO list
     surfaces the bin_code + pick_sequence of the LOWEST-pick_sequence

--- a/api/tests/test_admin_so_edit_events.py
+++ b/api/tests/test_admin_so_edit_events.py
@@ -86,6 +86,50 @@ def _put_so(client, auth_headers, so_id, body, request_id):
     )
 
 
+def _set_status_raw(so_id, status):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE sales_orders SET status = %s WHERE so_id = %s",
+        (status, so_id),
+    )
+    cur.close()
+
+
+class TestRefundedStatus:
+    """mig 074: REFUNDED is a real, operator-settable terminal status,
+    distinct from CANCELLED. Setting it is a PLAIN label -- REFUNDED is not
+    a ship transition, so record_ship never runs (no fulfillment rows, no
+    inventory or money movement). Operators can also reclassify an existing
+    CANCELLED order to REFUNDED."""
+
+    def test_set_refunded_is_plain_label_no_fulfillment(
+        self, client, auth_headers, seed_data
+    ):
+        # Refunds are recorded on an order that already shipped.
+        _set_status_raw(SO_ID, "SHIPPED")
+        resp = _put_so(
+            client, auth_headers, SO_ID,
+            {"status": "REFUNDED"}, str(uuid.uuid4()),
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert _so_row(SO_ID)["status"] == "REFUNDED"
+        # Plain label: not a ship transition, so record_ship never ran --
+        # no fulfillment row written.
+        assert _fulfillment_rows(SO_ID) == []
+
+    def test_reclassify_cancelled_to_refunded(
+        self, client, auth_headers, seed_data
+    ):
+        _set_status_raw(SO_ID, "CANCELLED")
+        resp = _put_so(
+            client, auth_headers, SO_ID,
+            {"status": "REFUNDED"}, str(uuid.uuid4()),
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert _so_row(SO_ID)["status"] == "REFUNDED"
+
+
 class TestShipTransitionEmission:
     def test_picked_to_shipped_emits_both_events(self, client, auth_headers, seed_data):
         _advance_so_through_picking(client, auth_headers, SO_NUMBER)

--- a/api/tests/test_cancel_backorder.py
+++ b/api/tests/test_cancel_backorder.py
@@ -38,6 +38,28 @@ def _partial_fulfill_seed_so(client, auth_headers, so_id=1, short_qty=1):
     return resp.get_json()["backorder_so"]["so_id"]
 
 
+def test_cancel_with_refunded_reason_sets_refunded_status(client, auth_headers):
+    # mig 074: a backorder cancelled because the customer was refunded lands
+    # as REFUNDED (its own terminal status), not CANCELLED, while still
+    # carrying the reason. The inventory unwind + cancel audit/event still run
+    # (the relabel is on top of the shared cancel service).
+    bo_so_id = _partial_fulfill_seed_so(client, auth_headers)
+
+    resp = client.post(
+        f"/api/admin/sales-orders/{bo_so_id}/cancel-backorder",
+        json={"cancellation_reason": "refunded"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["cancellation_reason"] == "refunded"
+
+    row = _query_one(
+        "SELECT status, cancellation_reason FROM sales_orders WHERE so_id = %s",
+        (bo_so_id,),
+    )
+    assert row == ("REFUNDED", "refunded")
+
+
 class TestHappyPath:
     def test_cancel_waiting_stock_bo(self, client, auth_headers):
         bo_so_id = _partial_fulfill_seed_so(client, auth_headers)

--- a/api/tests/test_pos_refund.py
+++ b/api/tests/test_pos_refund.py
@@ -337,9 +337,9 @@ class TestHappyPath:
         after = _read_inventory(item_id=1, bin_id=3, warehouse_id=1)
         assert int(after[0]) == int(before[0])
 
-        # Original SO is cancelled, with refunded_at + refund_so_id populated.
+        # Original SO is refunded, with refunded_at + refund_so_id populated.
         sale_row = _read_so(sale_so_number)
-        assert sale_row[2] == "CANCELLED"  # full refund cancels the original
+        assert sale_row[2] == "REFUNDED"  # full refund marks the original refunded
         assert sale_row[6] is not None  # refunded_at
         assert sale_row[7] is not None  # refund_so_id
 
@@ -734,9 +734,9 @@ class TestPartialRefund:
         # Second partial refund of the same sale accrues the -2 suffix.
         assert second.get_json()["refund_so_id"] == f"{sale_so_number}-REFUND-2"
 
-        # Now fully refunded: original cancelled, inventory whole again.
+        # Now fully refunded: original marked REFUNDED, inventory whole again.
         sale_row = _read_so(sale_so_number)
-        assert sale_row[2] == "CANCELLED"
+        assert sale_row[2] == "REFUNDED"
         assert sale_row[6] is not None  # refunded_at
         assert sale_row[7] is not None  # refund_so_id (the completing memo)
         after = _read_inventory(item_id=1, bin_id=3, warehouse_id=1)
@@ -792,7 +792,7 @@ class TestPartialRefund:
         assert rf.status_code == 422
         assert rf.get_json()["error_kind"] == "refund_line_not_in_order"
 
-    def test_full_refund_via_explicit_lines_cancels_original(self, client, pos_token):
+    def test_full_refund_via_explicit_lines_refunds_original(self, client, pos_token):
         # The frontend's "select all" sends every line explicitly; this must
         # behave like a full-order refund.
         sale_body = _checkout_card_body(qty=2)
@@ -808,7 +808,7 @@ class TestPartialRefund:
         assert rf.status_code == 200
         assert rf.get_json()["fully_refunded"] is True
         sale_row = _read_so(sale_so_number)
-        assert sale_row[2] == "CANCELLED"
+        assert sale_row[2] == "REFUNDED"
         after = _read_inventory(item_id=1, bin_id=3, warehouse_id=1)
         assert int(after[0]) == int(before[0])
 

--- a/db/migrations/074_backfill_refunded_status.sql
+++ b/db/migrations/074_backfill_refunded_status.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- Migration 074: backfill REFUNDED sales-order status
+-- ============================================================
+-- Refunds now have their own terminal status (REFUNDED) instead of
+-- being recorded as CANCELLED. Going forward the POS full-refund path
+-- and the cancel-with-reason=refunded path write REFUNDED directly;
+-- this one-time pass relabels the EXISTING rows that are CANCELLED but
+-- are genuinely refunds, so history reads consistently and the
+-- cancellation-rate counters stop double-counting refunds.
+--
+-- A CANCELLED row is treated as a refund when ANY of:
+--   * refunded_at IS NOT NULL        -- set by the POS full-refund path
+--   * refund_so_id IS NOT NULL       -- the completing credit-memo SO
+--   * cancellation_reason = 'refunded' -- operator cancel-with-reason
+--
+-- Pure relabel: touches only sales_orders.status. No inventory, money,
+-- credit-memo, or event side effects -- those were recorded when the
+-- refund originally happened. refunded_at / refund_so_id /
+-- cancellation_reason are left intact as the audit trail.
+--
+-- Idempotent: a re-run matches nothing (the rows are REFUNDED now, no
+-- longer CANCELLED). status is plain VARCHAR(20) (no DB CHECK), so no
+-- type/constraint change is needed for the new value.
+--
+-- v1.8.0 migration discipline (V-213): SET lock_timeout /
+-- statement_timeout, BEGIN/COMMIT-wrapped.
+-- ============================================================
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+UPDATE sales_orders
+   SET status = 'REFUNDED'
+ WHERE status = 'CANCELLED'
+   AND (
+        refunded_at IS NOT NULL
+     OR refund_so_id IS NOT NULL
+     OR cancellation_reason = 'refunded'
+   );
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -191,7 +191,7 @@ CREATE TABLE sales_orders (
     customer_id VARCHAR(50),
     customer_phone VARCHAR(50),
     customer_address TEXT,
-    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED', 'FRAUD_REVIEW', 'WAITING_STOCK'. PICKING/PACKING retired in mig 060; "in picking" is derived from pick_batches. WAITING_STOCK added in mig 067 (backorder-only off-ramp).
+    status VARCHAR(20) NOT NULL DEFAULT 'OPEN',  -- 'OPEN', 'PICKED', 'PACKED', 'SHIPPED', 'CANCELLED', 'REFUNDED', 'FRAUD_REVIEW', 'WAITING_STOCK'. PICKING/PACKING retired in mig 060; "in picking" is derived from pick_batches. WAITING_STOCK added in mig 067 (backorder-only off-ramp); REFUNDED added in mig 074 (refund distinct from cancel).
     priority INT DEFAULT 0,                -- higher = pick first
     warehouse_id INT NOT NULL REFERENCES warehouses(warehouse_id),
     ship_method VARCHAR(50),


### PR DESCRIPTION
**Local Pickup dashboard**: a new Dashboard tab lists local-pickup sales orders (ship method matching "local" or "pickup"), searchable by customer or order number and filterable by status. A per-row "Picked Up?" marks a PICKED/PACKED order shipped through the existing edit endpoint (tracking waived for pickups), behind a confirm modal. Header fields a counter worker needs are editable in place, and `GET /admin/sales-orders` gains an opt-in `local_pickup` filter.

**Distinct REFUNDED status**: a new `REFUNDED` sales-order status, distinct from CANCELLED, so refunds read apart from plain cancellations. It is operator-settable and a pure status label (no inventory or money side effects). The POS full-refund and cancel-with-reason=refunded paths now land `REFUNDED`, **superseding the v1.22.0 behavior where a full refund cancelled the original**. REFUNDED is excluded from the dashboard "need to ship today" count and tracked as its own KPI so the cancellation rate is not inflated by refunds.

**Migration 074** backfills existing refunds (CANCELLED rows with `refunded_at`, `refund_so_id`, or `cancellation_reason=refunded`) to REFUNDED. Pure status relabel, idempotent, no DDL (status is unconstrained VARCHAR).
