### PR TITLE
feat(receiving): turbo scans optimistically with batched background submit

### DIFF
--- a/api/routes/receiving.py
+++ b/api/routes/receiving.py
@@ -291,6 +291,30 @@ def receive_items(validated):
     # drained after g.db.commit() to fire Teams cards.
     _deferred_notifications: list = []
 
+    # Hoist request-constant external-id resolution out of the per-item
+    # loop. The PO and the user are the same for every item in this
+    # request, so resolve each once and reuse the cached value in every
+    # item's emit_event payload. (Same values as before, fewer round
+    # trips.)
+    po_external_id = (
+        resolve_source_external_id(g.db, "purchase_order", po.external_id)
+        or str(po.external_id)
+    )
+    completed_by_user_external_id = get_user_external_id(g.db, username)
+
+    # Per-request memo for item external-id resolution so a repeated
+    # item_id resolves once.
+    _item_external_id_cache: dict = {}
+
+    # v1.5.0 #112 audit window shrink: instead of writing each item's
+    # audit_log row mid-loop (which fires the chain-hash trigger and
+    # takes LOCK TABLE audit_log_chain_head IN EXCLUSIVE MODE, held to
+    # COMMIT), collect each item's audit args here and write them all
+    # near the end, just before the final PO-status update + commit.
+    # quantity_received_before is captured at loop time (pre-call value)
+    # so the row stays self-contained and identical to the old behavior.
+    _pending_audit_rows: list = []
+
     for item_entry in items:
         item_id = item_entry.item_id
         quantity = item_entry.quantity
@@ -381,17 +405,21 @@ def receive_items(validated):
         # Look up the item's canonical UUID, then resolve it to the
         # source-system external_id (the SKU the upstream pusher used at
         # Pipe B time) for the wire payload. Falls back to canonical UUID
-        # when no upstream mapping exists. Cheap, two round-trips per
-        # receipt; a higher-volume emit site would memoize per-request.
-        item_row = g.db.execute(
-            text("SELECT external_id FROM items WHERE item_id = :iid"),
-            {"iid": item_id},
-        ).fetchone()
-        item_canonical = item_row.external_id if item_row else None
-        item_external_id = (
-            resolve_source_external_id(g.db, "item", item_canonical)
-            or (str(item_canonical) if item_canonical else None)
-        )
+        # when no upstream mapping exists. Memoized per request so a
+        # repeated item_id resolves once.
+        if item_id in _item_external_id_cache:
+            item_external_id = _item_external_id_cache[item_id]
+        else:
+            item_row = g.db.execute(
+                text("SELECT external_id FROM items WHERE item_id = :iid"),
+                {"iid": item_id},
+            ).fetchone()
+            item_canonical = item_row.external_id if item_row else None
+            item_external_id = (
+                resolve_source_external_id(g.db, "item", item_canonical)
+                or (str(item_canonical) if item_canonical else None)
+            )
+            _item_external_id_cache[item_id] = item_external_id
 
         # 2 & 3. Update PO line quantity and status
         new_qty_received = po_line.quantity_received + quantity
@@ -410,26 +438,26 @@ def receive_items(validated):
         # 4. Create or update inventory
         add_inventory(g.db, item_id, bin_id, warehouse_id, quantity, lot_number)
 
-        # 5. Audit log
+        # 5. Audit log (deferred)
         # quantity_ordered + quantity_received_before make the row
         # self-contained: ordered total / cumulative-before-this-call /
         # this transaction. Investigators can reconstruct PO progress
         # from one row without joining purchase_order_lines.
-        write_audit_log(
-            g.db,
-            action_type=ACTION_RECEIVE,
-            entity_type="PO",
-            entity_id=po_id,
-            user_id=username,
-            warehouse_id=warehouse_id,
-            details={
+        # quantity_received_before is captured HERE (the pre-call value
+        # of po_line.quantity_received) so the deferred write below
+        # records the same number it would have mid-loop. The write
+        # itself is deferred to the end of the handler so the chain-hash
+        # trigger's EXCLUSIVE table lock is held for the shortest window
+        # rather than across the rest of the loop + backorder matcher.
+        _pending_audit_rows.append(
+            {
                 "quantity_ordered": po_line.quantity_ordered,
                 "quantity_received_before": po_line.quantity_received,
                 "quantity": quantity,
                 "item_id": item_id,
                 "bin_id": bin_id,
                 "receipt_id": receipt_id,
-            },
+            }
         )
 
         # 6. v1.5.0 #112: emit receipt.completed on the integration_events
@@ -451,11 +479,9 @@ def receive_items(validated):
                 # creates receipts; they originate inside Sentry).
                 "receipt_external_id": str(receipt_external_id),
                 # po_external_id resolves to the source-system PO identifier
-                # (e.g. our PO number) when one was Pipe-B'd in.
-                "po_external_id": (
-                    resolve_source_external_id(g.db, "purchase_order", po.external_id)
-                    or str(po.external_id)
-                ),
+                # (e.g. our PO number) when one was Pipe-B'd in. Resolved
+                # once before the loop; reused here.
+                "po_external_id": po_external_id,
                 "lines": [
                     {
                         "item_external_id": item_external_id,
@@ -464,7 +490,7 @@ def receive_items(validated):
                         "serial_number": serial_number,
                     }
                 ],
-                "completed_by_user_external_id": get_user_external_id(g.db, username),
+                "completed_by_user_external_id": completed_by_user_external_id,
                 "completed_at": receipt_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
             },
         )
@@ -481,6 +507,23 @@ def receive_items(validated):
             item_id=item_id,
             source_txn_id=g.source_txn_id,
             deferred_notifications=_deferred_notifications,
+        )
+
+    # Deferred audit writes. Done here -- after the per-item loop and
+    # its backorder-matcher work -- so the chain-hash trigger's
+    # LOCK TABLE audit_log_chain_head IN EXCLUSIVE MODE (held until
+    # COMMIT) is acquired as late as possible, shrinking the window the
+    # global lock is held. Written in per-item order so the chain mirrors
+    # receipt order, identical to the previous mid-loop behavior.
+    for audit_details in _pending_audit_rows:
+        write_audit_log(
+            g.db,
+            action_type=ACTION_RECEIVE,
+            entity_type="PO",
+            entity_id=po_id,
+            user_id=username,
+            warehouse_id=warehouse_id,
+            details=audit_details,
         )
 
     # Update PO status based on all lines

--- a/api/tests/test_receiving.py
+++ b/api/tests/test_receiving.py
@@ -10,6 +10,11 @@ def _query_one(sql, params=None):
     return row
 
 
+def _query_val(sql, params=None):
+    row = _query_one(sql, params)
+    return row[0] if row else None
+
+
 class TestPOLookup:
     def test_lookup_po_by_barcode(self, client, auth_headers):
         resp = client.get("/api/receiving/po/PO-2026-001", headers=auth_headers)
@@ -160,6 +165,125 @@ class TestReceiveItems:
         }
         resp = client.post("/api/receiving/receive", json=payload)
         assert resp.status_code == 401
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Batched receiving: multiple distinct items in one request
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBatchedReceive:
+    """One /receive request carrying several distinct items must update
+    every line, land inventory for each, write one audit row + emit one
+    event per item, and return the receipt_ids in submission order. A
+    batch where any line is rejected (e.g. over-receipt with over-receipt
+    disabled) must roll back atomically -- no receipts, no line changes."""
+
+    def test_batch_receive_multiple_items(self, client, auth_headers, seed_data):
+        bid = seed_data["staging_bin_id"]
+        # Three distinct lines on PO-2026-001 (items 1/2/3 each ordered
+        # 100), partial quantities so the PO stays PARTIAL.
+        payload = {
+            "po_id": 1,
+            "items": [
+                {"item_id": 1, "quantity": 10, "bin_id": bid},
+                {"item_id": 2, "quantity": 20, "bin_id": bid},
+                {"item_id": 3, "quantity": 30, "bin_id": bid},
+            ],
+        }
+        resp = client.post("/api/receiving/receive", json=payload, headers=auth_headers)
+        assert resp.status_code == 200, resp.get_json()
+        data = resp.get_json()
+
+        # One receipt per submitted item, in submission order, distinct.
+        receipt_ids = data["receipt_ids"]
+        assert len(receipt_ids) == 3
+        assert len(set(receipt_ids)) == 3
+        assert receipt_ids == sorted(receipt_ids), (
+            "receipt_ids should preserve per-item insertion order"
+        )
+        assert data["po_status"] == "PARTIAL"
+
+        # All three lines updated.
+        for item_id, qty in ((1, 10), (2, 20), (3, 30)):
+            received = _query_val(
+                "SELECT quantity_received FROM purchase_order_lines "
+                "WHERE po_id = 1 AND item_id = %s",
+                (item_id,),
+            )
+            assert received == qty, f"line item {item_id} should show {qty} received"
+
+            # Inventory landed in the staging bin for each item.
+            on_hand = _query_val(
+                "SELECT quantity_on_hand FROM inventory "
+                "WHERE item_id = %s AND bin_id = %s",
+                (item_id, bid),
+            )
+            assert on_hand == qty, f"item {item_id} inventory should be {qty}"
+
+        # Exactly one audit row per item for this receive. The audit
+        # details JSON carries receipt_id; count rows whose receipt_id
+        # matches one we just created.
+        audit_count = _query_val(
+            "SELECT COUNT(*) FROM audit_log "
+            "WHERE action_type = 'RECEIVE' AND entity_id = 1 "
+            "  AND (details->>'receipt_id')::int = ANY(%s)",
+            (receipt_ids,),
+        )
+        assert audit_count == 3, "one audit row per received item"
+
+        # Exactly one receipt.completed event per receipt.
+        event_count = _query_val(
+            "SELECT COUNT(*) FROM integration_events "
+            "WHERE event_type = 'receipt.completed' AND aggregate_id = ANY(%s)",
+            (receipt_ids,),
+        )
+        assert event_count == 3, "one receipt.completed event per receipt"
+
+    def test_batch_over_receipt_rolls_back_atomically(self, client, auth_headers, seed_data):
+        bid = seed_data["staging_bin_id"]
+        # Snapshot pre-call line state for items 1, 2, 3.
+        before = {}
+        for item_id in (1, 2, 3):
+            before[item_id] = _query_val(
+                "SELECT quantity_received FROM purchase_order_lines "
+                "WHERE po_id = 1 AND item_id = %s",
+                (item_id,),
+            )
+
+        # Item 1 over-receives (ordered 100, request 150) with
+        # allow_over_receipt unset -> the handler returns 400 inside the
+        # loop without committing, so the whole batch is rejected. Items
+        # 2 and 3 are later in the batch and are never reached; none of
+        # the three lines may change and no receipts may land.
+        payload = {
+            "po_id": 1,
+            "items": [
+                {"item_id": 1, "quantity": 150, "bin_id": bid},
+                {"item_id": 2, "quantity": 20, "bin_id": bid},
+                {"item_id": 3, "quantity": 30, "bin_id": bid},
+            ],
+        }
+        resp = client.post("/api/receiving/receive", json=payload, headers=auth_headers)
+        assert resp.status_code == 400, resp.get_json()
+        assert "Over-receipt" in resp.get_json()["error"]
+
+        # Line quantities unchanged for every item in the batch.
+        for item_id in (1, 2, 3):
+            after = _query_val(
+                "SELECT quantity_received FROM purchase_order_lines "
+                "WHERE po_id = 1 AND item_id = %s",
+                (item_id,),
+            )
+            assert after == before[item_id], (
+                f"line item {item_id} must be unchanged after a rejected batch"
+            )
+
+        # No receipts landed for any item in this PO from this request.
+        receipt_count = _query_val(
+            "SELECT COUNT(*) FROM item_receipts WHERE po_id = 1"
+        )
+        assert receipt_count == 0, "no receipt should survive a rolled-back batch"
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/mobile/src/hooks/__tests__/useBatchedReceive.test.js
+++ b/mobile/src/hooks/__tests__/useBatchedReceive.test.js
@@ -1,0 +1,90 @@
+/**
+ * useBatchedReceive: optimistic batched turbo-receive submitter.
+ *
+ * Mobile vitest has no React Native runtime (see components/__tests__/
+ * ScanInput.test.js for the pattern), so the stateful hook is exercised two
+ * ways: (1) real unit tests of the pure aggregator, and (2) a source-level
+ * gate over the safety invariants that keep receipts from being lost or
+ * double-counted. End-to-end turbo behavior is device-verified; the
+ * server-side batch path is covered in api/tests/test_receiving.py.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { aggregateReceiveBatch } from '../useBatchedReceive';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOK_PATH = resolve(__dirname, '..', 'useBatchedReceive.js');
+
+const entry = (item_id, bin_id) => ({ key: item_id, payload: { item_id, bin_id } });
+
+describe('aggregateReceiveBatch', () => {
+  it('collapses repeated scans of one item into a single line with a count', () => {
+    const items = aggregateReceiveBatch([entry(7, 3), entry(7, 3), entry(7, 3)]);
+    expect(items).toEqual([{ item_id: 7, bin_id: 3, quantity: 3 }]);
+  });
+
+  it('keeps the same item in different bins as separate lines', () => {
+    const items = aggregateReceiveBatch([entry(7, 3), entry(7, 4), entry(7, 3)]);
+    expect(items).toEqual([
+      { item_id: 7, bin_id: 3, quantity: 2 },
+      { item_id: 7, bin_id: 4, quantity: 1 },
+    ]);
+  });
+
+  it('groups distinct items and preserves first-seen order', () => {
+    const items = aggregateReceiveBatch([entry(2, 1), entry(9, 1), entry(2, 1)]);
+    expect(items).toEqual([
+      { item_id: 2, bin_id: 1, quantity: 2 },
+      { item_id: 9, bin_id: 1, quantity: 1 },
+    ]);
+  });
+
+  it('returns an empty array for an empty buffer', () => {
+    expect(aggregateReceiveBatch([])).toEqual([]);
+  });
+
+  it('conserves count: total quantity equals the number of scans', () => {
+    const scans = [entry(1, 1), entry(1, 1), entry(2, 1), entry(2, 2), entry(3, 1)];
+    const total = aggregateReceiveBatch(scans).reduce((s, it) => s + it.quantity, 0);
+    expect(total).toBe(scans.length);
+  });
+});
+
+describe('useBatchedReceive safety invariants (source gate)', () => {
+  let src;
+  beforeAll(() => { src = readFileSync(HOOK_PATH, 'utf8'); });
+
+  it('flushes one batch at a time (single-flight guard)', () => {
+    expect(src).toMatch(/if \(flushing\.current/);
+  });
+
+  it('flushes immediately once the buffer reaches batchMax', () => {
+    expect(src).toMatch(/buffer\.current\.length >= batchMaxRef\.current/);
+  });
+
+  it('debounces flushing with a timer', () => {
+    expect(src).toMatch(/setTimeout\(/);
+  });
+
+  it('drain only resolves when the buffer is empty and nothing is in flight', () => {
+    expect(src).toMatch(/buffer\.current\.length === 0 && !flushing\.current/);
+  });
+
+  it('clears a batch\'s optimistic counts when it settles (success or failure)', () => {
+    // bumpPending(key, -1) runs in the flush finally for every attempted scan
+    expect(src).toMatch(/finally\s*\{[\s\S]*bumpPending\(key, -1\)/);
+  });
+
+  it('re-flushes scans that arrived during an in-flight flush', () => {
+    expect(src).toMatch(/if \(buffer\.current\.length > 0\) flush\(\)/);
+  });
+
+  it('reset clears both pending and the buffer', () => {
+    expect(src).toMatch(/pendingRef\.current = \{\}/);
+    expect(src).toMatch(/buffer\.current = \[\]/);
+  });
+});

--- a/mobile/src/hooks/useBatchedReceive.js
+++ b/mobile/src/hooks/useBatchedReceive.js
@@ -1,0 +1,138 @@
+import { useRef, useState, useCallback, useEffect } from 'react';
+
+/**
+ * Collapse buffered scans into one receive line per (item_id, bin_id), with
+ * quantity = number of scans. First-seen (item_id, bin_id) order is kept.
+ * Exported for unit testing.
+ */
+export function aggregateReceiveBatch(entries) {
+  const byKey = new Map();
+  for (const { payload } of entries) {
+    const k = `${payload.item_id}:${payload.bin_id}`;
+    const cur = byKey.get(k) || { item_id: payload.item_id, bin_id: payload.bin_id, quantity: 0 };
+    cur.quantity += 1;
+    byKey.set(k, cur);
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * Optimistic batched submitter for turbo receiving.
+ *
+ * Decouples the operator's scan rate from backend latency: each scan
+ * counts instantly (optimistic `pending`) and is buffered, then the buffer
+ * is flushed to the backend in batches -- debounced by `flushMs`, or
+ * immediately once it reaches `batchMax`. Only one flush is in flight at a
+ * time; scans that arrive during a flush ride the next batch.
+ *
+ * - enqueue(key, payload): count +1 for `key` and buffer `payload`.
+ * - getPending(key): synchronous current pending for `key` (ref-backed, so
+ *   rapid same-tick scans project correctly before React re-renders).
+ * - onConfirm(items, resp): a batch committed server-side (reconcile up).
+ * - onError(items, err): a batch failed; `pending` is rolled back -- the
+ *   caller should surface it and refetch server truth.
+ * - drain(): flush everything and resolve once the buffer is empty and no
+ *   batch is in flight. Call before leaving a PO so nothing is lost.
+ * - reset(): drop buffered/pending state (e.g. switching POs after a drain).
+ *
+ * `pending[key]` is decremented when a batch settles, success or failure --
+ * on success the caller folds the quantities into its confirmed counts, on
+ * failure the optimistic counts simply disappear.
+ *
+ * Callbacks and config are held in refs, so the caller may pass fresh
+ * closures every render without breaking the in-flight flush loop.
+ */
+export default function useBatchedReceive({ submit, onConfirm, onError, flushMs = 400, batchMax = 20 }) {
+  const submitRef = useRef(submit); submitRef.current = submit;
+  const onConfirmRef = useRef(onConfirm); onConfirmRef.current = onConfirm;
+  const onErrorRef = useRef(onError); onErrorRef.current = onError;
+  const flushMsRef = useRef(flushMs); flushMsRef.current = flushMs;
+  const batchMaxRef = useRef(batchMax); batchMaxRef.current = batchMax;
+
+  const buffer = useRef([]);          // [{ key, payload }] not yet flushed
+  const flushing = useRef(false);
+  const timer = useRef(null);
+  const drainWaiters = useRef([]);
+  const pendingRef = useRef({});      // synchronous mirror of `pending`
+  const [pending, setPending] = useState({});
+  const [busy, setBusy] = useState(false);
+
+  const bumpPending = (key, delta) => {
+    const next = (pendingRef.current[key] || 0) + delta;
+    if (next <= 0) delete pendingRef.current[key];
+    else pendingRef.current[key] = next;
+    setPending({ ...pendingRef.current });
+  };
+
+  const getPending = useCallback((key) => pendingRef.current[key] || 0, []);
+
+  const maybeSettleDrain = () => {
+    if (buffer.current.length === 0 && !flushing.current) {
+      setBusy(false);
+      const waiters = drainWaiters.current;
+      drainWaiters.current = [];
+      waiters.forEach((w) => w());
+    }
+  };
+
+  const flush = useCallback(async () => {
+    if (flushing.current || buffer.current.length === 0) {
+      maybeSettleDrain();
+      return;
+    }
+    flushing.current = true;
+    setBusy(true);
+    if (timer.current) { clearTimeout(timer.current); timer.current = null; }
+
+    const batch = buffer.current;
+    buffer.current = [];
+
+    const items = aggregateReceiveBatch(batch);
+
+    try {
+      const resp = await submitRef.current(items);
+      onConfirmRef.current?.(items, resp);
+    } catch (err) {
+      onErrorRef.current?.(items, err);
+    } finally {
+      // The batch has settled either way: clear its optimistic counts.
+      for (const { key } of batch) bumpPending(key, -1);
+      flushing.current = false;
+      if (buffer.current.length > 0) flush();
+      else maybeSettleDrain();
+    }
+  }, []);
+
+  const scheduleFlush = useCallback(() => {
+    if (buffer.current.length >= batchMaxRef.current) { flush(); return; }
+    if (timer.current) return;
+    timer.current = setTimeout(() => { timer.current = null; flush(); }, flushMsRef.current);
+  }, [flush]);
+
+  const enqueue = useCallback((key, payload) => {
+    buffer.current.push({ key, payload });
+    bumpPending(key, +1);
+    setBusy(true);
+    scheduleFlush();
+  }, [scheduleFlush]);
+
+  const drain = useCallback(() => new Promise((resolve) => {
+    if (buffer.current.length === 0 && !flushing.current) { resolve(); return; }
+    drainWaiters.current.push(resolve);
+    flush();
+  }), [flush]);
+
+  const reset = useCallback(() => {
+    if (timer.current) { clearTimeout(timer.current); timer.current = null; }
+    buffer.current = [];
+    pendingRef.current = {};
+    setPending({});
+    setBusy(false);
+  }, []);
+
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+  const pendingTotal = Object.values(pending).reduce((a, b) => a + b, 0);
+
+  return { enqueue, getPending, pending, pendingTotal, busy, drain, reset };
+}

--- a/mobile/src/screens/ReceiveScreen.js
+++ b/mobile/src/screens/ReceiveScreen.js
@@ -1,11 +1,11 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, TextInput, Modal, Vibration, Pressable, BackHandler, StyleSheet } from 'react-native';
 import ModeSelector from '../components/ModeSelector';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import ScanInput from '../components/ScanInput';
 import ErrorPopup from '../components/ErrorPopup';
 import PagedList from '../components/PagedList';
-import useScanQueue from '../hooks/useScanQueue';
+import useBatchedReceive from '../hooks/useBatchedReceive';
 import useScreenError from '../hooks/useScreenError';
 import { useAuth } from '../auth/AuthContext';
 import client from '../api/client';
@@ -43,8 +43,16 @@ export default function ReceiveScreen({ navigation, route }) {
   const [qtyFocused, setQtyFocused] = useState(false);
   // Track items that have already shown over-receive warning (show only once per item)
   const [overReceiveWarned, setOverReceiveWarned] = useState(new Set());
-  // Track receipt IDs created in this session for cancel/undo
+  // Track receipt IDs created in this session for cancel/undo. The ref
+  // mirror lets the cancel handler read freshly-confirmed IDs right after
+  // draining the batch queue (optimistic confirms update state async).
   const [sessionReceiptIds, setSessionReceiptIds] = useState([]);
+  const sessionReceiptIdsRef = useRef([]);
+  const addReceiptIds = useCallback((ids) => {
+    if (!ids || ids.length === 0) return;
+    sessionReceiptIdsRef.current = [...sessionReceiptIdsRef.current, ...ids];
+    setSessionReceiptIds(sessionReceiptIdsRef.current);
+  }, []);
   // Modal state for replacing Alert.alert
   const [confirmModal, setConfirmModal] = useState({ visible: false, title: '', message: '', onConfirm: null, confirmText: 'OK', cancelText: 'Cancel' });
 
@@ -182,6 +190,7 @@ export default function ReceiveScreen({ navigation, route }) {
       setLines(resp.data.lines || []);
       setActiveItem(null);
       setTurboStatus('');
+      resetReceives();
       setCurrentPoIndex(index);
       setPhase('receiving');
     } catch (err) {
@@ -249,7 +258,7 @@ export default function ReceiveScreen({ navigation, route }) {
 
       // Track receipt IDs for cancel/undo
       if (resp.data?.receipt_ids) {
-        setSessionReceiptIds((prev) => [...prev, ...resp.data.receipt_ids]);
+        addReceiptIds(resp.data.receipt_ids);
       }
 
       await refreshPO();
@@ -289,8 +298,49 @@ export default function ReceiveScreen({ navigation, route }) {
     await doReceiveStandard(qty);
   };
 
-  // Turbo mode
-  const processTurboScan = useCallback(async (barcode) => {
+  // --- Turbo mode: optimistic scan + batched background submit ---
+  // Each scan counts instantly and is buffered; batches flush in the
+  // background, so the operator scans continuously (multiple/sec) instead
+  // of waiting a full round-trip per scan.
+  const submitBatch = useCallback(
+    (items) => client.post('/api/receiving/receive', {
+      po_id: po.po_id,
+      items,
+      warehouse_id: warehouseId,
+    }),
+    [po, warehouseId]
+  );
+
+  const handleBatchConfirm = useCallback((items, resp) => {
+    if (resp?.data?.receipt_ids) {
+      addReceiptIds(resp.data.receipt_ids);
+    }
+    // Fold the confirmed quantities into server-truth lines (no refetch).
+    setLines((prev) => prev.map((l) => {
+      const conf = items.find((it) => it.item_id === l.item_id);
+      return conf ? { ...l, quantity_received: l.quantity_received + conf.quantity } : l;
+    }));
+  }, []);
+
+  const handleBatchError = useCallback(async (items, err) => {
+    const n = items.reduce((s, it) => s + it.quantity, 0);
+    showError(err.response?.data?.error || `Failed to save ${n} scan${n !== 1 ? 's' : ''}  -  re-scan them`);
+    // The hook rolled back this batch's optimistic counts; refetch server
+    // truth to reconcile.
+    await refreshPO();
+  }, [showError]);
+
+  const {
+    enqueue: enqueueReceive,
+    getPending,
+    pending: pendingByItem,
+    pendingTotal,
+    busy: syncing,
+    drain: drainReceives,
+    reset: resetReceives,
+  } = useBatchedReceive({ submit: submitBatch, onConfirm: handleBatchConfirm, onError: handleBatchError });
+
+  const processTurboScan = useCallback((barcode) => {
     const match = lines.find(
       (l) => l.upc === barcode || l.sku === barcode || l.item_barcode === barcode
     );
@@ -298,49 +348,28 @@ export default function ReceiveScreen({ navigation, route }) {
       showError('Item not on this PO');
       return;
     }
-
-    // Over-receive check for turbo mode
-    const totalAfterReceive = match.quantity_received + 1;
-    if (totalAfterReceive > match.quantity_ordered && !allowOverReceiving) {
+    const projected = match.quantity_received + getPending(match.item_id) + 1;
+    if (projected > match.quantity_ordered && !allowOverReceiving) {
       showError('Cannot receive more than ordered');
       return;
     }
-
-    try {
-      const turboResp = await client.post('/api/receiving/receive', {
-        po_id: po.po_id,
-        items: [{ item_id: match.item_id, quantity: 1, bin_id: receivingBinId || match.staging_bin_id || 1 }],
-        warehouse_id: warehouseId,
-      });
-
-      if (turboResp.data?.receipt_ids) {
-        setSessionReceiptIds((prev) => [...prev, ...turboResp.data.receipt_ids]);
-      }
-
-      const updatedLines = await refreshPO();
-      const updatedMatch = updatedLines.find((l) => l.item_id === match.item_id);
-      const recv = updatedMatch?.quantity_received || match.quantity_received + 1;
-      const ordered = match.quantity_ordered;
-
-      setTurboStatus(`${match.item_name}: ${recv} / ${ordered}`);
-
-      if (recv >= ordered) {
-        try { Vibration.vibrate(200); } catch {}
-      }
-    } catch (err) {
-      showError(err.response?.data?.error || 'Failed to receive');
+    const binId = receivingBinId || match.staging_bin_id || 1;
+    enqueueReceive(match.item_id, { item_id: match.item_id, bin_id: binId });
+    setTurboStatus(`${match.item_name}: ${projected} / ${match.quantity_ordered}`);
+    if (projected >= match.quantity_ordered) {
+      try { Vibration.vibrate(200); } catch {}
     }
-  }, [lines, po, warehouseId, receivingBinId, showError, allowOverReceiving]);
+  }, [lines, allowOverReceiving, receivingBinId, enqueueReceive, getPending, showError]);
 
-  const [enqueueTurbo, turboProcessing] = useScanQueue(processTurboScan, errorRef);
+  const handleScanItem = mode === 'turbo' ? processTurboScan : handleScanItemStandard;
 
-  const handleScanItem = mode === 'turbo' ? enqueueTurbo : handleScanItemStandard;
-
-  const handleNextPO = () => {
+  const handleNextPO = async () => {
+    await drainReceives();
     loadPO(currentPoIndex + 1);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
+    await drainReceives();
     setPhase('done');
   };
 
@@ -353,10 +382,14 @@ export default function ReceiveScreen({ navigation, route }) {
       cancelText: 'Stay',
       onConfirm: async () => {
         setConfirmModal((p) => ({ ...p, visible: false }));
-        if (sessionReceiptIds.length > 0) {
+        // Flush buffered/in-flight scans first so every receipt has an id,
+        // then reverse them all.
+        await drainReceives();
+        const ids = sessionReceiptIdsRef.current;
+        if (ids.length > 0) {
           try {
             await client.post('/api/receiving/cancel', {
-              receipt_ids: sessionReceiptIds,
+              receipt_ids: ids,
               po_id: po?.po_id,
               warehouse_id: warehouseId,
             });
@@ -377,6 +410,14 @@ export default function ReceiveScreen({ navigation, route }) {
     setActiveItem(null);
     setCurrentPoIndex(0);
     setTurboStatus('');
+    resetReceives();
+    sessionReceiptIdsRef.current = [];
+    setSessionReceiptIds([]);
+  };
+
+  const handleExit = async () => {
+    if (phase === 'receiving') await drainReceives();
+    navigation.goBack();
   };
 
   // --- Render ---
@@ -385,7 +426,7 @@ export default function ReceiveScreen({ navigation, route }) {
     <View style={screenStyles.screen}>
       <ScreenHeader
         title="RECEIVE"
-        onBack={() => navigation.goBack()}
+        onBack={handleExit}
         right={
           phase === 'scan_pos' && poQueue.length > 0 ? (
             <View style={styles.badge}>
@@ -480,13 +521,16 @@ export default function ReceiveScreen({ navigation, route }) {
                 <ScanInput
                   placeholder="SCAN ITEM"
                   onScan={handleScanItem}
-                  disabled={scanDisabled || (mode === 'standard' && !!activeItem) || (mode === 'turbo' && turboProcessing)}
+                  disabled={scanDisabled || (mode === 'standard' && !!activeItem)}
                   suppressRefocus={qtyFocused}
                 />
 
-                {mode === 'turbo' && turboStatus !== '' && (
+                {mode === 'turbo' && (turboStatus !== '' || pendingTotal > 0) && (
                   <View style={styles.turboCard}>
-                    <Text style={styles.turboText}>{turboStatus}</Text>
+                    {turboStatus !== '' && <Text style={styles.turboText}>{turboStatus}</Text>}
+                    {pendingTotal > 0 && (
+                      <Text style={styles.turboPending}>{'↻'} syncing {pendingTotal}...</Text>
+                    )}
                   </View>
                 )}
 
@@ -515,20 +559,24 @@ export default function ReceiveScreen({ navigation, route }) {
                   </View>
                 )}
 
-                {[...lines].sort((a, b) => {
-                  const aDone = a.quantity_received >= a.quantity_ordered ? 1 : 0;
-                  const bDone = b.quantity_received >= b.quantity_ordered ? 1 : 0;
+                {[...lines].map((line) => ({
+                  line,
+                  received: line.quantity_received + (pendingByItem[line.item_id] || 0),
+                })).sort((a, b) => {
+                  const aDone = a.received >= a.line.quantity_ordered ? 1 : 0;
+                  const bDone = b.received >= b.line.quantity_ordered ? 1 : 0;
                   return aDone - bDone;
-                }).map((line) => {
-                  const done = line.quantity_received >= line.quantity_ordered;
+                }).map(({ line, received }) => {
+                  const done = received >= line.quantity_ordered;
+                  const hasPending = (pendingByItem[line.item_id] || 0) > 0;
                   return (
                     <View key={line.po_line_id || line.item_id} style={[listStyles.row, done && styles.lineRowDone]}>
                       <View style={{ flex: 1 }}>
                         <Text style={[listStyles.sku, done ? styles.textDone : styles.textPending]}>{line.sku}</Text>
                         <Text style={[listStyles.itemName, { fontSize: 13 }]}>{line.item_name}</Text>
                       </View>
-                      <Text style={[styles.lineQty, done ? styles.textDone : styles.textPending]}>
-                        {line.quantity_received}/{line.quantity_ordered}
+                      <Text style={[styles.lineQty, done ? styles.textDone : styles.textPending, hasPending && styles.lineQtyPending]}>
+                        {received}/{line.quantity_ordered}
                       </Text>
                     </View>
                   );
@@ -705,6 +753,7 @@ const styles = StyleSheet.create({
     padding: 12, marginBottom: 16, alignItems: 'center',
   },
   turboText: { fontFamily: fonts.mono, fontSize: 14, fontWeight: '600', color: colors.success },
+  turboPending: { fontFamily: fonts.mono, fontSize: 11, color: colors.textMuted, marginTop: 4 },
   receiveCard: {
     borderWidth: 1.5, borderColor: colors.accentRed, borderRadius: radii.card,
     padding: 12, marginBottom: 10,
@@ -712,6 +761,7 @@ const styles = StyleSheet.create({
   expectedText: { fontFamily: fonts.mono, fontSize: 12, color: colors.textMuted, marginTop: 6 },
   qtyRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginVertical: 12 },
   lineQty: { fontFamily: fonts.mono, fontSize: 14, fontWeight: '700', color: colors.textPrimary },
+  lineQtyPending: { color: colors.copper },
   lineRowDone: { borderColor: colors.success },
   textDone: { color: colors.success },
   textPending: { color: colors.accentRed },


### PR DESCRIPTION
The handheld receive screen no longer blocks on a full round-trip per scan (a receive POST plus a PO refetch), which had capped the operator near one scan/second.

- **Optimistic + batched scanning**: each scan counts instantly against an optimistic local total and is buffered; batches flush to the receive endpoint in the background (debounced, or at a size cap), so scanning is continuous. Counts reconcile from each batch response. A failed batch rolls back its optimistic counts and refetches server truth; leaving a PO drains the queue first so no scan is lost. The per-scan PO refetch is removed.
- **Backend handler optimization**: the receive handler resolves the PO and user external-ids once per request instead of per item, memoizes item resolves, and defers the audit-log writes to just before commit so the audit-chain global lock is held for a shorter window.

Mobile-touching: `versionCode`/`version` are bumped in the release branch. No new APK is cut here; this feeds the single end-of-cycle APK build. No migrations.
