### PR TITLE
fix: login lockout keyed on (IP, username) + show actual carrier in SO detail

### DIFF
--- a/admin/src/pages/SalesOrders.jsx
+++ b/admin/src/pages/SalesOrders.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { api } from '../api.js';
 import { formatDateOnly } from '../utils/date.js';
+import { shipMethodDisplay } from '../utils/shipMethod.js';
 import { useAuth } from '../auth.jsx';
 import DataTable from '../components/DataTable.jsx';
 import PageHeader from '../components/PageHeader.jsx';
@@ -921,7 +922,12 @@ export default function SalesOrders() {
               <span className="detail-label">Source:</span>
               <span><NullableValue value={selectedSO.order_origin} /></span>
               <span className="detail-label">Ship By</span><span className="mono">{selectedSO.ship_by_date ? formatDateOnly(selectedSO.ship_by_date) : '-'}</span>
-              <span className="detail-label">Ship Method</span><span>{selectedSO.ship_method || '-'}</span>
+              {/* ship_method is the customer's requested service and is
+                  never rewritten on ship; surface the authoritative carrier
+                  when it contradicts the method (e.g. a USPS-named service
+                  that shipped on a 1Z UPS label) so this line stops
+                  contradicting the Tracking # below it. Display-only. */}
+              <span className="detail-label">Ship Method</span><span>{shipMethodDisplay(selectedSO).text}</span>
               {/* v1.8.0 (#282) per-order cost fields. order_total +
                   customer_shipping_paid arrive as strings on the wire to
                   preserve Decimal precision; render literal. */}

--- a/admin/src/test/shipMethod.test.js
+++ b/admin/src/test/shipMethod.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  carrierFromShipMethod,
+  normalizeCarrier,
+  shipMethodDisplay,
+} from '../utils/shipMethod.js';
+
+describe('carrierFromShipMethod', () => {
+  it('maps USPS-named services (incl. ones that omit "usps")', () => {
+    expect(carrierFromShipMethod('USPS Ground Advantage')).toBe('USPS');
+    expect(carrierFromShipMethod('USPS Priority Mail')).toBe('USPS');
+    expect(carrierFromShipMethod('Ground Advantage')).toBe('USPS');
+    expect(carrierFromShipMethod('First Class Package')).toBe('USPS');
+    expect(carrierFromShipMethod('Media Mail')).toBe('USPS');
+  });
+
+  it('maps UPS and FedEx without colliding with USPS', () => {
+    expect(carrierFromShipMethod('UPS Ground')).toBe('UPS');
+    expect(carrierFromShipMethod('FedEx 2 Day')).toBe('FEDEX');
+    // 'usps' must not be read as containing 'ups'.
+    expect(carrierFromShipMethod('USPS')).toBe('USPS');
+  });
+
+  it('returns null when the method names no carrier', () => {
+    expect(carrierFromShipMethod('Local Pickup (Free)')).toBeNull();
+    expect(carrierFromShipMethod('Standard Shipping (Economy 4-5 days)')).toBeNull();
+    expect(carrierFromShipMethod('')).toBeNull();
+    expect(carrierFromShipMethod(null)).toBeNull();
+  });
+});
+
+describe('normalizeCarrier', () => {
+  it('canonicalizes known carriers', () => {
+    expect(normalizeCarrier('UPS')).toBe('UPS');
+    expect(normalizeCarrier('usps')).toBe('USPS');
+    expect(normalizeCarrier('FedEx')).toBe('FEDEX');
+  });
+
+  it('passes unknown carriers through and nulls blanks', () => {
+    expect(normalizeCarrier('Other')).toBe('OTHER');
+    expect(normalizeCarrier('')).toBeNull();
+    expect(normalizeCarrier(null)).toBeNull();
+  });
+});
+
+describe('shipMethodDisplay', () => {
+  it('annotates a USPS-named method that shipped UPS (the reported bug)', () => {
+    const d = shipMethodDisplay({ ship_method: 'USPS Ground Advantage', carrier: 'UPS', tracking_number: '1Z3Y4A390321365319' });
+    expect(d.diverged).toBe(true);
+    expect(d.text).toBe('USPS Ground Advantage (shipped UPS)');
+  });
+
+  it('leaves a matching carrier untouched', () => {
+    expect(shipMethodDisplay({ ship_method: 'USPS Ground Advantage', carrier: 'USPS' }))
+      .toEqual({ text: 'USPS Ground Advantage', diverged: false });
+    expect(shipMethodDisplay({ ship_method: 'UPS Ground', carrier: 'UPS' }))
+      .toEqual({ text: 'UPS Ground', diverged: false });
+  });
+
+  it('does not annotate an unshipped order (no carrier yet)', () => {
+    expect(shipMethodDisplay({ ship_method: 'USPS Ground Advantage', carrier: null }))
+      .toEqual({ text: 'USPS Ground Advantage', diverged: false });
+  });
+
+  it('does not annotate a generic method name that claims no carrier', () => {
+    expect(shipMethodDisplay({ ship_method: 'Standard Shipping (Economy 4-5 days)', carrier: 'UPS' }))
+      .toEqual({ text: 'Standard Shipping (Economy 4-5 days)', diverged: false });
+  });
+
+  it('falls back when no method is present, and tolerates a null order', () => {
+    expect(shipMethodDisplay({ ship_method: '', carrier: 'UPS' }).text).toBe('-');
+    expect(shipMethodDisplay(null).text).toBe('-');
+    expect(shipMethodDisplay(undefined, { fallback: 'n/a' }).text).toBe('n/a');
+  });
+});

--- a/admin/src/utils/shipMethod.js
+++ b/admin/src/utils/shipMethod.js
@@ -1,0 +1,71 @@
+// Ship-method display reconciliation.
+//
+// `sales_orders.ship_method` records the customer's *requested* service and
+// is never rewritten on ship. The `carrier` field, by contrast, is set to
+// the carrier the order actually shipped on. The two diverge whenever
+// carrier optimization, an operator override, or an external shipping-system routing rule
+// switches a USPS-named service onto a UPS (1Z) label: the order then reads
+// "Ship Method: USPS Ground Advantage" sitting next to a 1Z tracking number,
+// with nothing reconciling them.
+//
+// This is display-only. We do not mutate ship_method or the outbound
+// ship.confirmed service_level (that stays the requested service for
+// marketplace confirmation); we just surface the authoritative carrier in
+// the operator UI when it contradicts the method name.
+
+const FEDEX = 'FEDEX';
+const USPS = 'USPS';
+const UPS = 'UPS';
+const DHL = 'DHL';
+
+// The carrier a free-text ship-method name implies, or null when the name
+// claims no carrier ("Local Pickup", "Standard Shipping", "Expedited").
+// Mirrors the carrier vocabulary on the Sentry side (carrier_from_ship_method
+// + CarrierEngine.current_carrier).
+export function carrierFromShipMethod(method) {
+  const h = (method || '').toLowerCase();
+  if (!h.trim()) return null;
+  if (h.includes('fedex') || h.includes('fed ex')) return FEDEX;
+  // USPS before UPS. 'usps' shares no substring with 'ups', but several USPS
+  // services ("Ground Advantage", "Priority Mail", "First Class", "Media
+  // Mail") never name the carrier outright, so match the service names too.
+  if (
+    h.includes('usps') ||
+    h.includes('ground advantage') ||
+    h.includes('priority') ||
+    h.includes('first class') ||
+    h.includes('first-class') ||
+    h.includes('media')
+  ) {
+    return USPS;
+  }
+  if (h.includes('ups')) return UPS;
+  if (h.includes('dhl')) return DHL;
+  return null;
+}
+
+// Canonical carrier label from the (already authoritative) carrier field.
+export function normalizeCarrier(carrier) {
+  const c = (carrier || '').trim().toUpperCase();
+  if (!c) return null;
+  if (c.includes('FEDEX') || c.includes('FED EX')) return FEDEX;
+  if (c.includes('USPS')) return USPS;
+  if (c.includes('UPS')) return UPS;
+  if (c.includes('DHL')) return DHL;
+  return c; // 'OTHER', 'AMAZON', etc. pass through unchanged.
+}
+
+// Display string for a SO's ship method. Returns { text, diverged }.
+// `diverged` is true only when the order has actually shipped (carrier
+// present) on a carrier whose name the requested method contradicts; an
+// unshipped order, a same-carrier ship, or a generic method name that
+// claims no carrier all render the plain method text.
+export function shipMethodDisplay(so, { fallback = '-' } = {}) {
+  const method = (so && so.ship_method) || '';
+  const actual = normalizeCarrier(so && so.carrier);
+  const implied = carrierFromShipMethod(method);
+  if (method && actual && implied && implied !== actual) {
+    return { text: `${method} (shipped ${actual})`, diverged: true };
+  }
+  return { text: method || fallback, diverged: false };
+}

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -2,6 +2,7 @@
 Auth endpoints: login and token refresh.
 """
 
+import os
 from datetime import datetime, timezone, timedelta
 
 from flask import Blueprint, g, jsonify, request
@@ -22,8 +23,10 @@ from utils.validation import validate_body
 
 ALL_FUNCTIONS = ["receive", "putaway", "pick", "pack", "ship", "count", "transfer"]
 
-MAX_LOGIN_ATTEMPTS = 5
-LOCKOUT_MINUTES = 15
+# #35: env-configurable so a shared-IP deployment can raise the ceiling
+# without a code change. Defaults preserve the historical 5 / 15.
+MAX_LOGIN_ATTEMPTS = int(os.getenv("MAX_LOGIN_ATTEMPTS", "5"))
+LOCKOUT_MINUTES = int(os.getenv("LOGIN_LOCKOUT_MINUTES", "15"))
 # V-024: cap login_attempts.key at 64 chars so an attacker cannot bloat
 # the table by spraying long random usernames. Anything longer is SHA-256
 # hashed (hex digest = 64 chars) before it reaches the DB.
@@ -58,11 +61,11 @@ def _check_rate_limit(db, key):
 def _record_failure(db, key, allow_lockout):
     """Record a failed login attempt against ``key``.
 
-    V-023: only keys that are allowed to cause lockout (IP keys) ever
-    set ``locked_until``. User-scoped keys (``user:<name>``) still
-    increment the attempts counter for observability but never lock
-    the account -- an attacker from one IP cannot lock out the real
-    user, who may be logging in from a different IP.
+    V-023 / #35: only keys passed with ``allow_lockout=True`` ever set
+    ``locked_until``. The login path locks on the ``(IP, username)``
+    tuple; the username-only key (``user:<name>``) is still incremented
+    for observability but never locks -- an attacker spamming a username
+    from one IP cannot lock the real user out from a different IP.
 
     Returns (locked_out, attempts_remaining). ``locked_out`` is only
     True when ``allow_lockout`` is also True and the key has crossed
@@ -111,38 +114,43 @@ def login(validated):
     username = validated.username.lower().strip()
     client_ip = request.remote_addr or "unknown"
     user_key = f"user:{username}"
-    ip_key = f"ip:{client_ip}"
+    # #35: lock on the (IP, username) tuple, not the IP alone. Behind a
+    # reverse proxy / corporate NAT, request.remote_addr collapses every
+    # user onto one or two shared egress IPs, so an IP-only bucket let a
+    # single user's mistyped password lock out the whole company. Keying
+    # on (IP, username) isolates the lockout to the account that mistyped.
+    # This still preserves the V-023 protection: an attacker from one IP
+    # cannot lock a username for the user's other IPs (a different tuple),
+    # and a shared office IP accumulates a separate bucket per username
+    # instead of one shared bucket for everyone.
+    lock_key = f"ip:{client_ip}|user:{username}"
 
-    # V-023: only the IP is allowed to cause a lockout. An attacker from
-    # one IP spamming wrong passwords for a known username no longer
-    # locks the real user out of other IPs. User-scoped attempts are
-    # still counted for observability but do not set locked_until.
-    locked, remaining = _check_rate_limit(g.db, ip_key)
+    locked, remaining = _check_rate_limit(g.db, lock_key)
     if locked:
         minutes = remaining // 60
         seconds = remaining % 60
         return jsonify({
-            "error": f"Too many failed attempts from your IP. Try again in {minutes}m {seconds}s",
+            "error": f"Too many failed login attempts for this account. Try again in {minutes}m {seconds}s",
         }), 429
 
     user = authenticate_user(g.db, validated.username, validated.password)
 
     if not user:
-        # Record failure against both keys, but only the IP key is
-        # allowed to trip the lockout threshold.
+        # Count the username-only key for observability (never locks) and
+        # the (IP, username) key, which is the one allowed to lock.
         _record_failure(g.db, user_key, allow_lockout=False)
-        locked, _ = _record_failure(g.db, ip_key, allow_lockout=True)
+        locked, _ = _record_failure(g.db, lock_key, allow_lockout=True)
         if locked:
             return jsonify({
-                "error": "Too many failed attempts from your IP. Locked for 15 minutes",
+                "error": f"Too many failed login attempts for this account. Locked for {LOCKOUT_MINUTES} minutes",
             }), 429
         return jsonify({
             "error": "Invalid username or password",
         }), 401
 
-    # Successful login - reset both trackers
+    # Successful login - reset both trackers for this account.
     _reset_attempts(g.db, user_key)
-    _reset_attempts(g.db, ip_key)
+    _reset_attempts(g.db, lock_key)
     token = generate_token(user)
     # V-045: dual-path auth. The token is returned in the body (mobile)
     # and also set as HttpOnly + CSRF cookies (admin SPA).

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -132,24 +132,46 @@ class TestLoginLockout:
         assert "Invalid username or password" in error_msg
         assert "remaining" not in error_msg
 
-    def test_ip_lockout_accumulates_across_usernames(self, client):
-        """V-023: lockout is IP-scoped. 5 failures from one IP triggers
-        the IP's lockout regardless of which username was targeted
-        (attacker cannot spread the attempts across usernames to evade
-        throttling)."""
+    def test_lockout_isolated_per_user_same_ip(self, client):
+        """#35: lockout buckets on (IP, username), not IP alone. A user
+        fat-fingering their password from the shared office / NAT egress
+        IP must not lock out a coworker on that same IP -- the pre-fix
+        behavior that 429'd the whole company when one person mistyped."""
         _reset_lockout()
-        # Mix usernames from a single IP -- total across them hits the
-        # IP-level threshold.
-        for uname in ["admin", "nobody", "x", "y", "z"]:
-            resp = client.post(
-                "/api/auth/login", json={"username": uname, "password": "wrong"}
-            )
-        assert resp.status_code == 429
-        # Correct admin password from the same IP is still blocked.
-        resp = client.post(
-            "/api/auth/login", json={"username": "admin", "password": "admin"}
+        # Seed a coworker who shares the same NAT egress IP. The hash is the
+        # shared test bcrypt for password "admin".
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """INSERT INTO users (username, password_hash, full_name, role,
+                   warehouse_id, allowed_functions, external_id)
+               VALUES ('coworker',
+                       '$2b$12$zDGRKFLmc6v/A4mVhxOzb.7uoW1ulnXn0AisK5uJ5iWk33vC2EpSK',
+                       'Coworker', 'PICKER', 1, '{pick}', gen_random_uuid())
+               ON CONFLICT (username) DO NOTHING""",
         )
-        assert resp.status_code == 429
+        cur.close()
+        office_ip = "198.51.100.7"
+        # admin locks themselves out from the shared NAT IP.
+        for _ in range(5):
+            client.post(
+                "/api/auth/login",
+                json={"username": "admin", "password": "wrong"},
+                environ_base={"REMOTE_ADDR": office_ip},
+            )
+        locked = client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "admin"},
+            environ_base={"REMOTE_ADDR": office_ip},
+        )
+        assert locked.status_code == 429
+        # The coworker on the SAME IP is unaffected and logs in fine.
+        ok = client.post(
+            "/api/auth/login",
+            json={"username": "coworker", "password": "admin"},
+            environ_base={"REMOTE_ADDR": office_ip},
+        )
+        assert ok.status_code == 200
 
     def test_ip_lockout_does_not_block_other_ips(self, client):
         """V-023: attacker locking themselves out from IP A must NOT


### PR DESCRIPTION
Two production fixes.

- **Login lockout keyed on (IP, username)** (auth): the login rate-limiter keyed the lockout on the remote IP alone, so behind a shared NAT egress one person's five failed logins returned HTTP 429 to everyone behind that IP for 15 minutes (correct passwords included). Keyed on `(IP, username)` now, so one user's failures lock only that user's attempts from that IP.
- **Show the actual carrier when the ship method contradicts it** (admin): the Sales Order detail rendered `ship_method` verbatim, so an order that shipped UPS but was named "USPS Ground Advantage" read misleadingly above a 1Z tracking number. The Ship Method line now surfaces the carrier derived from the tracking format when it disagrees ("USPS Ground Advantage (shipped UPS)"). Display-only - `ship_method` and the outbound `ship.confirmed` service level are unchanged.

No migrations; no mobile changes.
