### PR TITLE
Channel availability (Pipe C) - v1.30.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,46 @@ SENTRY_ALLOW_HTTP_WEBHOOKS=false
 SENTRY_ALLOW_INTERNAL_WEBHOOKS=false
 
 # ----------------------------------------------------------------------
+# Connector-publisher tunables (v1.30.0, Pipe C)
+# ----------------------------------------------------------------------
+# The connector-publisher daemon reconciles per-channel availability and
+# debounce-publishes dirty rows to each channel's HTTP sink. Ranges are
+# enforced at boot (api/services/connector_publisher/env_validator.py);
+# out-of-range values refuse boot naming the offender. The daemon reuses
+# the SSRF guard above, so SENTRY_ALLOW_INTERNAL_WEBHOOKS also governs
+# whether it will publish to a private-range sink (dev/CI only).
+#
+# Optional. When unset, the daemon uses DATABASE_URL. For production, run
+# db/role-publisher.sql once to create the least-privilege sentry_publisher
+# role (read inventory, write only the channel tables), then point the
+# daemon at it.
+#
+# Example:
+#   PUBLISHER_DATABASE_URL=postgresql://sentry_publisher:<strong-pw>@db:5432/sentry
+PUBLISHER_DATABASE_URL=
+
+# Kill switch. "false" stops publishing without removing the container;
+# the heartbeat keeps the healthcheck green. Anything other than the
+# literal lowercase "false" is treated as enabled.
+CONNECTOR_PUBLISHER_ENABLED=true
+
+# Fallback poll interval when the integration_events_visible NOTIFY
+# misses. Range: 250-60000 ms.
+CONNECTOR_PUBLISHER_FALLBACK_POLL_MS=2000
+
+# Periodic full reconcile, the self-healing guarantee that catches
+# allocation changes (which emit no event). Range: 5-3600 s.
+CONNECTOR_PUBLISHER_RECONCILE_INTERVAL_S=60
+
+# Drain window on SIGTERM before exit. Range: 1-300 s.
+CONNECTOR_PUBLISHER_SHUTDOWN_DRAIN_S=30
+
+# Per-operation HTTP timeouts on the sink POST. Range: 500-60000 /
+# 500-120000 ms.
+CONNECTOR_PUBLISHER_HTTP_CONNECT_TIMEOUT_MS=5000
+CONNECTOR_PUBLISHER_HTTP_READ_TIMEOUT_MS=8000
+
+# ----------------------------------------------------------------------
 # v1.5.1 V-206 (#147) -- NEVER SET TRUST_PROXY=true AND API_BIND_HOST=0.0.0.0
 # TOGETHER.
 # ----------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Sentry WMS will be documented in this file.
 
+## [v1.30.0] - 2026-06-19
+
+"Channel availability (Pipe C)" release. A new outbound surface that publishes per-channel sellable availability to a configured HTTP sink per channel (a marketplace connector receives it; first-party connectors are a later release). Inventory changes are collapsed into a current-state number per (channel, SKU) and debounce-published, so a busy warehouse does not fan every stock tick out to every marketplace.
+
+**Mobile.** Zero mobile/ diffs on this release. The current mobile build (version 1.29.0, versionCode 10) remains current; no new APK for v1.30.0.
+
+### Added
+
+- **Channel availability materialization (Pipe C)** (#424): a new `channel_availability` table holds sellable quantity (`on_hand - allocated`, Pickable / PickableStaging bins only) per channel and SKU, with a `current_version` / `last_version` pattern marking a row dirty only when the number actually changes. A `connector-publisher` daemon reconciles availability against live inventory - on the `integration_events_visible` wake and a periodic interval - and debounce-publishes dirty rows to each channel's sink. Reading live inventory rather than replaying events, it converges to the truth even for allocation changes that emit no event (reserve-at-creation, cancel), so it never publishes a stale count. Migration 075; least-privilege `sentry_publisher` role; new `connector-publisher` compose service.
+- **Per-channel config + admin Channels page** (#424): channels carry a delivery URL, a SKU scope (skus / categories / warehouses), a declarative transform (field rename + constant injection, for the Amazon FBA vs MFN distinction), and rate / batch / debounce knobs. CRUD under `/api/admin/channels` with a dispatch-time SSRF guard on the sink, pause/resume, soft-delete, and a DLQ view; a new admin Channels page mirrors the Webhooks page. Every config change writes an audit_log row.
+
 ## [v1.29.1] - 2026-06-19
 
 Two production fixes.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
   
   <p><em>Open-source warehouse management system built for barcode scanners</em></p>
 
-  ![Version](https://img.shields.io/badge/version-1.29.1-8e2716)
-  ![Tests](https://img.shields.io/badge/tests-2809%20passing-34a853)
+  ![Version](https://img.shields.io/badge/version-1.30.0-8e2716)
+  ![Tests](https://img.shields.io/badge/tests-2851%20passing-34a853)
   ![License](https://img.shields.io/badge/license-Apache_2.0-blue)
   
   **[Documentation](https://hightower-systems.github.io/sentry-wms)** | **[API Reference](https://hightower-systems.github.io/sentry-wms/api-reference/)** | **[Releases](https://github.com/hightower-systems/sentry-wms/releases)**
@@ -276,7 +276,7 @@ docker compose exec api python -m pytest tests/ -v --tb=short
 
 ## Project Status
 
-**v1.29.1 - Production fixes. The login rate-limiter now keys the lockout on (IP, username) instead of the IP alone, so a shared NAT egress no longer lets one person's failed logins return HTTP 429 to everyone behind that IP. And the Sales Order detail surfaces the actual carrier (derived from the tracking number) when it contradicts the named ship method, instead of showing a misleading "USPS" above a UPS label. Display-only; no migrations; no mobile changes (build stays 1.29.0 / versionCode 10).**
+**v1.30.0 - Channel availability (Pipe C). A new outbound surface that publishes per-channel sellable availability (`on_hand - allocated`, sellable bins only) to a configured HTTP sink per channel. The connector-publisher daemon reconciles each channel against live inventory and debounce-publishes only the rows whose number actually changed, so a busy warehouse does not fan every stock tick out to every marketplace - and because it reads live inventory rather than replaying events, it stays truthful even for allocation changes that emit no event. Per-channel SKU scope, a declarative transform (FBA vs MFN), and a new admin Channels page. Migration 075; new `sentry_publisher` role and `connector-publisher` service; no mobile changes (build stays 1.29.0 / versionCode 10).**
 
 | Version | Milestone | Status |
 |---------|-----------|--------|
@@ -341,6 +341,7 @@ docker compose exec api python -m pytest tests/ -v --tb=short
 | **v1.28.0** | **Local pickup and refund status - a Local Pickup dashboard (ship method "local"/"pickup", per-row "Picked Up?", Open+Picked worklist, opt-in filter) + a distinct REFUNDED status: a full POS refund lands the original in REFUNDED not CANCELLED (supersedes v1.22.0), mig 074 backfills existing refunds. RMA operator memo; returns kept out of the picking queue. No mobile diffs.** | ✅ **Released** |
 | **v1.29.0** | **Turbo receiving - the handheld receive screen scans continuously (optimistic local counts + batched background submit, no per-scan round-trip); a failed batch rolls back and refetches, leaving a PO drains the queue. Receive handler resolves external-ids once per request and defers audit writes to commit. Mobile build 1.29.0 / versionCode 10; APK rebuild.** | ✅ **Released** |
 | **v1.29.1** | **Production fixes - login lockout keyed on (IP, username) not the IP alone (a shared NAT egress no longer locks out everyone behind it); the SO detail shows the actual carrier from the tracking number when it contradicts the named ship method. Display-only; no migrations; no mobile diffs.** | ✅ **Released** |
+| **v1.30.0** | **Channel availability (Pipe C) - per-channel sellable-availability materialization (`current_version` / `last_version` dirty-row pattern) + a `connector-publisher` daemon that reconciles against live inventory and debounce-publishes to each channel's HTTP sink; per-channel SKU scope + declarative transform + SSRF guard; admin Channels page. Migration 075. No mobile diffs.** | ✅ **Released** |
 | v2.0.0 | First-party ERP + commerce connectors (NetSuite, QuickBooks, Shopify, Fabric) on top of the v1.3 connector framework | Planned |
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
@@ -353,4 +354,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 Apache License 2.0 - see [LICENSE](LICENSE) and [NOTICE](NOTICE) for details. Pre-v1.7.0 tagged releases remain MIT-licensed; v1.7.0 and later are Apache 2.0.
 
-Built by [Hightower Systems L.L.C.](https://github.com/hightower-systems) · v1.29.1
+Built by [Hightower Systems L.L.C.](https://github.com/hightower-systems) · v1.30.0

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin",
-      "version": "1.29.1",
+      "version": "1.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react": "^19.2.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin",
   "private": true,
-  "version": "1.29.1",
+  "version": "1.30.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -31,6 +31,7 @@ import Tokens from './pages/Tokens.jsx';
 import InboundActivity from './pages/InboundActivity.jsx';
 import ConsumerGroups from './pages/ConsumerGroups.jsx';
 import Webhooks from './pages/Webhooks.jsx';
+import Channels from './pages/Channels.jsx';
 import Notifications from './pages/Notifications.jsx';
 import AuditLog from './pages/AuditLog.jsx';
 import PreferredBins from './pages/PreferredBins.jsx';
@@ -135,6 +136,7 @@ export default function App() {
         <Route path="/inbound" element={<ErrorBoundary fallbackMessage="Could not load Inbound activity."><InboundActivity /></ErrorBoundary>} />
         <Route path="/consumer-groups" element={<ErrorBoundary fallbackMessage="Could not load consumer groups."><ConsumerGroups /></ErrorBoundary>} />
         <Route path="/webhooks" element={<ErrorBoundary fallbackMessage="Could not load webhooks."><Webhooks /></ErrorBoundary>} />
+        <Route path="/channels" element={<ErrorBoundary fallbackMessage="Could not load channels."><Channels /></ErrorBoundary>} />
         <Route path="/notifications" element={<ErrorBoundary fallbackMessage="Could not load notifications."><Notifications /></ErrorBoundary>} />
         <Route path="/audit-log" element={<ErrorBoundary fallbackMessage="Could not load audit log."><AuditLog /></ErrorBoundary>} />
         <Route path="/settings" element={<ErrorBoundary fallbackMessage="Could not load settings."><Settings /></ErrorBoundary>} />

--- a/admin/src/components/Sidebar.jsx
+++ b/admin/src/components/Sidebar.jsx
@@ -69,6 +69,7 @@ const NAV = [
       { to: '/inbound', label: 'Inbound activity', pageKey: 'inbound' },
       { to: '/consumer-groups', label: 'Consumer groups', pageKey: 'consumer-groups' },
       { to: '/webhooks', label: 'Webhooks', pageKey: 'webhooks' },
+      { to: '/channels', label: 'Channels', pageKey: 'channels' },
       // v1.13.0 mig 064 notification_webhooks. Sibling to /webhooks
       // because both are outbound-delivery surfaces; this one carries
       // chat-channel destinations (Teams adaptive cards), the other

--- a/admin/src/pages/Channels.jsx
+++ b/admin/src/pages/Channels.jsx
@@ -1,0 +1,345 @@
+import { useState, useEffect } from 'react';
+import { api } from '../api.js';
+import DataTable from '../components/DataTable.jsx';
+import PageHeader from '../components/PageHeader.jsx';
+import Modal from '../components/Modal.jsx';
+
+// Pipe C availability channels. Mirrors the Webhooks page: a list with
+// per-channel publish stats, a create / edit modal, pause-resume, soft-delete,
+// and a DLQ viewer for parked rows.
+
+const STATUS_BADGE = {
+  active: { label: 'active', color: 'var(--text-secondary)' },
+  paused: { label: 'paused', color: '#c49100' },
+  revoked: { label: 'revoked', color: 'var(--danger)' },
+};
+
+function Badge({ label, color }) {
+  return (
+    <span style={{
+      display: 'inline-block', padding: '1px 8px', borderRadius: 10,
+      fontSize: 11, fontWeight: 600, color: '#fff', background: color,
+    }}>{label}</span>
+  );
+}
+
+const TRANSFORM_PLACEHOLDER =
+  '{\n  "rename": { "sku": "seller_sku" },\n  "constants": { "fulfillment_channel": "AMAZON_NA" }\n}';
+
+const splitCsv = (s) => (s || '').split(',').map((x) => x.trim()).filter(Boolean);
+const splitCsvInts = (s) => splitCsv(s).map(Number).filter((n) => Number.isInteger(n));
+
+function buildScope(f) {
+  const scope = {};
+  const skus = splitCsv(f.skus);
+  const cats = splitCsv(f.categories);
+  const whs = splitCsvInts(f.warehouse_ids);
+  if (skus.length) scope.skus = skus;
+  if (cats.length) scope.categories = cats;
+  if (whs.length) scope.warehouse_ids = whs;
+  return scope;
+}
+
+function emptyForm() {
+  return {
+    channel_id: '', display_name: '', delivery_url: '',
+    skus: '', categories: '', warehouse_ids: '',
+    transform: '',
+    rate_limit_per_second: '10', batch_size: '100', debounce_seconds: '30',
+  };
+}
+
+function rowToForm(row) {
+  const scope = row.sku_scope || {};
+  return {
+    channel_id: row.channel_id,
+    display_name: row.display_name,
+    delivery_url: row.delivery_url,
+    skus: (scope.skus || []).join(', '),
+    categories: (scope.categories || []).join(', '),
+    warehouse_ids: (scope.warehouse_ids || []).join(', '),
+    transform: row.transform && Object.keys(row.transform).length
+      ? JSON.stringify(row.transform, null, 2) : '',
+    rate_limit_per_second: String(row.rate_limit_per_second),
+    batch_size: String(row.batch_size),
+    debounce_seconds: String(row.debounce_seconds),
+  };
+}
+
+// Build the request body shared by create + edit. Returns [body, error].
+function formToBody(f) {
+  let transform = {};
+  if (f.transform.trim()) {
+    try { transform = JSON.parse(f.transform); }
+    catch { return [null, 'Transform must be valid JSON.']; }
+  }
+  return [{
+    display_name: f.display_name.trim(),
+    delivery_url: f.delivery_url.trim(),
+    sku_scope: buildScope(f),
+    transform,
+    rate_limit_per_second: Number(f.rate_limit_per_second),
+    batch_size: Number(f.batch_size),
+    debounce_seconds: Number(f.debounce_seconds),
+  }, null];
+}
+
+function ChannelForm({ form, setForm, isEdit }) {
+  const set = (k) => (e) => setForm({ ...form, [k]: e.target.value });
+  return (
+    <>
+      {!isEdit && (
+        <div className="form-group">
+          <label>Channel ID</label>
+          <input className="form-input mono" value={form.channel_id}
+                 onChange={set('channel_id')} placeholder="amazon-fba" />
+        </div>
+      )}
+      <div className="form-group">
+        <label>Display name</label>
+        <input className="form-input" value={form.display_name}
+               onChange={set('display_name')} placeholder="Amazon FBA" />
+      </div>
+      <div className="form-group">
+        <label>Delivery URL (sink)</label>
+        <input className="form-input mono" value={form.delivery_url}
+               onChange={set('delivery_url')} placeholder="https://sink.example.com/availability" />
+      </div>
+      <div className="form-group">
+        <label>SKU scope &ndash; skus (comma-separated, blank = all)</label>
+        <input className="form-input" value={form.skus} onChange={set('skus')}
+               placeholder="TST-001, TST-002" />
+      </div>
+      <div className="form-group">
+        <label>SKU scope &ndash; categories</label>
+        <input className="form-input" value={form.categories}
+               onChange={set('categories')} placeholder="reels, waders" />
+      </div>
+      <div className="form-group">
+        <label>SKU scope &ndash; warehouse IDs (blank = all)</label>
+        <input className="form-input" value={form.warehouse_ids}
+               onChange={set('warehouse_ids')} placeholder="1, 2" />
+      </div>
+      <div className="form-group">
+        <label>Transform (JSON: rename + constants, blank = none)</label>
+        <textarea className="form-input mono" rows={5} value={form.transform}
+                  onChange={set('transform')} placeholder={TRANSFORM_PLACEHOLDER} />
+      </div>
+      <div style={{ display: 'flex', gap: 12 }}>
+        <div className="form-group" style={{ flex: 1 }}>
+          <label>Rate (per sec)</label>
+          <input className="form-input" type="number" value={form.rate_limit_per_second}
+                 onChange={set('rate_limit_per_second')} />
+        </div>
+        <div className="form-group" style={{ flex: 1 }}>
+          <label>Batch size</label>
+          <input className="form-input" type="number" value={form.batch_size}
+                 onChange={set('batch_size')} />
+        </div>
+        <div className="form-group" style={{ flex: 1 }}>
+          <label>Debounce (sec)</label>
+          <input className="form-input" type="number" value={form.debounce_seconds}
+                 onChange={set('debounce_seconds')} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default function Channels() {
+  const [channels, setChannels] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [pageError, setPageError] = useState('');
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [form, setForm] = useState(emptyForm());
+  const [createError, setCreateError] = useState('');
+
+  const [editing, setEditing] = useState(null);
+  const [editForm, setEditForm] = useState(emptyForm());
+  const [editError, setEditError] = useState('');
+
+  const [confirmDelete, setConfirmDelete] = useState(null);
+  const [dlqChannel, setDlqChannel] = useState(null);
+  const [dlqRows, setDlqRows] = useState([]);
+
+  async function load() {
+    setLoading(true);
+    setPageError('');
+    const res = await api.get('/admin/channels');
+    if (res?.ok) {
+      const data = await res.json();
+      setChannels(data.channels || []);
+    } else {
+      setPageError('Could not load channels.');
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => { load(); }, []);
+
+  async function submitCreate() {
+    setCreateError('');
+    const [body, err] = formToBody(form);
+    if (err) { setCreateError(err); return; }
+    body.channel_id = form.channel_id.trim();
+    const res = await api.post('/admin/channels', body);
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) { setShowCreate(false); setForm(emptyForm()); load(); }
+    else { setCreateError(data.detail || data.error || 'Create failed.'); }
+  }
+
+  async function submitEdit() {
+    setEditError('');
+    const [body, err] = formToBody(editForm);
+    if (err) { setEditError(err); return; }
+    const res = await api.patch(`/admin/channels/${editing.channel_id}`, body);
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) { setEditing(null); load(); }
+    else { setEditError(data.detail || data.error || 'Update failed.'); }
+  }
+
+  async function setStatus(channel, status) {
+    await api.patch(`/admin/channels/${channel.channel_id}`, { status });
+    load();
+  }
+
+  async function doDelete() {
+    await api.delete(`/admin/channels/${confirmDelete.channel_id}`);
+    setConfirmDelete(null);
+    load();
+  }
+
+  async function openDlq(channel) {
+    setDlqChannel(channel);
+    setDlqRows([]);
+    const res = await api.get(`/admin/channels/${channel.channel_id}/dlq`);
+    if (res?.ok) {
+      const data = await res.json();
+      setDlqRows(data.parked || []);
+    }
+  }
+
+  const columns = [
+    { key: 'channel_id', label: 'Channel', mono: true },
+    { key: 'display_name', label: 'Name' },
+    {
+      key: 'status', label: 'Status',
+      render: (r) => {
+        const b = STATUS_BADGE[r.status] || STATUS_BADGE.active;
+        return <Badge label={b.label} color={b.color} />;
+      },
+    },
+    { key: 'item_count', label: 'Items' },
+    { key: 'dirty_count', label: 'Pending' },
+    {
+      key: 'dlq_count', label: 'DLQ',
+      render: (r) => (
+        <span style={{ color: r.dlq_count ? 'var(--danger)' : 'inherit' }}>
+          {r.dlq_count}
+        </span>
+      ),
+    },
+    {
+      key: 'last_published_at', label: 'Last publish',
+      render: (r) => (r.last_published_at
+        ? new Date(r.last_published_at).toLocaleString() : '—'),
+    },
+    {
+      key: 'actions', label: '',
+      render: (r) => (
+        <div style={{ display: 'flex', gap: 6 }}>
+          <button className="btn btn-sm" onClick={() => {
+            setEditing(r); setEditForm(rowToForm(r)); setEditError('');
+          }}>Edit</button>
+          {r.status === 'active' ? (
+            <button className="btn btn-sm" onClick={() => setStatus(r, 'paused')}>Pause</button>
+          ) : (
+            <button className="btn btn-sm" onClick={() => setStatus(r, 'active')}>Resume</button>
+          )}
+          <button className="btn btn-sm" onClick={() => openDlq(r)}>DLQ</button>
+          <button className="btn btn-sm btn-danger" onClick={() => setConfirmDelete(r)}>
+            Delete
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <PageHeader title="Channels">
+        <button className="btn btn-primary" onClick={() => {
+          setForm(emptyForm()); setCreateError(''); setShowCreate(true);
+        }}>New channel</button>
+      </PageHeader>
+
+      {pageError && <div className="form-error">{pageError}</div>}
+
+      {loading ? (
+        <p style={{ color: 'var(--text-secondary)' }}>Loading&hellip;</p>
+      ) : (
+        <DataTable columns={columns} data={channels}
+                   emptyMessage="No channels configured yet." />
+      )}
+
+      {showCreate && (
+        <Modal title="New channel" onClose={() => setShowCreate(false)} footer={
+          <>
+            <button className="btn" onClick={() => setShowCreate(false)}>Cancel</button>
+            <button className="btn btn-primary" onClick={submitCreate}>Create</button>
+          </>
+        }>
+          {createError && <div className="form-error">{createError}</div>}
+          <ChannelForm form={form} setForm={setForm} isEdit={false} />
+        </Modal>
+      )}
+
+      {editing && (
+        <Modal title={`Edit ${editing.channel_id}`} onClose={() => setEditing(null)} footer={
+          <>
+            <button className="btn" onClick={() => setEditing(null)}>Cancel</button>
+            <button className="btn btn-primary" onClick={submitEdit}>Save</button>
+          </>
+        }>
+          {editError && <div className="form-error">{editError}</div>}
+          <ChannelForm form={editForm} setForm={setEditForm} isEdit />
+        </Modal>
+      )}
+
+      {confirmDelete && (
+        <Modal title="Revoke channel" onClose={() => setConfirmDelete(null)} footer={
+          <>
+            <button className="btn" onClick={() => setConfirmDelete(null)}>Cancel</button>
+            <button className="btn btn-danger" onClick={doDelete}>Revoke</button>
+          </>
+        }>
+          <p>
+            Revoke <span className="mono">{confirmDelete.channel_id}</span>? The
+            publisher stops sending to it; the config is kept for the record.
+          </p>
+        </Modal>
+      )}
+
+      {dlqChannel && (
+        <Modal title={`DLQ — ${dlqChannel.channel_id}`}
+               onClose={() => setDlqChannel(null)} size="large">
+          {dlqRows.length === 0 ? (
+            <p style={{ color: 'var(--text-secondary)' }}>No parked rows.</p>
+          ) : (
+            <DataTable
+              columns={[
+                { key: 'sku', label: 'SKU', mono: true },
+                { key: 'available_qty', label: 'Available' },
+                { key: 'attempt_count', label: 'Attempts' },
+                { key: 'last_error', label: 'Last error' },
+              ]}
+              data={dlqRows}
+              emptyMessage="No parked rows."
+            />
+          )}
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/api/constants.py
+++ b/api/constants.py
@@ -326,6 +326,10 @@ ALL_PAGE_KEYS = (
     "adjustments", "inter-warehouse-transfers", "transfer-orders",
     "warehouses", "bins", "zones", "preferred-bins",
     "users", "api-tokens", "inbound", "consumer-groups",
+    # Channels (Pipe C): per-channel availability config + the publish
+    # health view. Holders see the /channels page and can CRUD channels,
+    # pause/resume, and inspect the DLQ.
+    "channels",
     # Notifications: per-warehouse Teams notification webhooks for the
     # backorder.* event family. Holders see the /notifications page and
     # can CRUD + test-send destinations. Distinct from 'webhooks'

--- a/api/constants.py
+++ b/api/constants.py
@@ -223,6 +223,15 @@ ACTION_WEBHOOK_SUBSCRIPTION_DELETE_HARD = "WEBHOOK_SUBSCRIPTION_DELETE_HARD"
 ACTION_WEBHOOK_SECRET_ROTATE = "WEBHOOK_SECRET_ROTATE"
 ACTION_WEBHOOK_DELIVERY_REPLAY_SINGLE = "WEBHOOK_DELIVERY_REPLAY_SINGLE"
 ACTION_WEBHOOK_DELIVERY_REPLAY_BATCH = "WEBHOOK_DELIVERY_REPLAY_BATCH"
+
+# v1.30.0 Pipe C channel-availability config CRUD audit coverage. Same
+# shape as the webhook subscription writes: one row per mutation, config
+# snapshot in details (channel_id, scope, transform, ceilings, rate) so
+# forensics survive a delete. entity_id=0 sentinel; channel_id (VARCHAR)
+# lives in details.
+ACTION_CHANNEL_CREATE = "CHANNEL_CREATE"
+ACTION_CHANNEL_UPDATE = "CHANNEL_UPDATE"
+ACTION_CHANNEL_DELETE = "CHANNEL_DELETE"
 # #232: dispatcher auto-pause when subscription_filter fails
 # Pydantic validation. user_id is the daemon's identity ("system");
 # details.subscription_id + details.parse_error capture the

--- a/api/routes/admin/__init__.py
+++ b/api/routes/admin/__init__.py
@@ -47,6 +47,7 @@ def _admin_integrity_error(exc):
 
 
 from routes.admin import (  # noqa: E402, F401
+    admin_channels,
     admin_connectors,
     admin_consumer_groups,
     admin_inbound,

--- a/api/routes/admin/admin_channels.py
+++ b/api/routes/admin/admin_channels.py
@@ -1,0 +1,386 @@
+"""Admin CRUD for Pipe C availability channels (v1.30.0).
+
+A channel owns an HTTP sink (delivery_url), a SKU scope, a declarative transform,
+and rate / batch / debounce knobs. The connector-publisher daemon reconciles and
+debounce-publishes against these rows. Every mutation writes an audit_log row;
+the create and any sku_scope change re-materialize the channel's availability so
+the operator sees it populate immediately.
+
+Mirrors the v1.6 webhook-subscription CRUD: strict-typed bodies, https/SSRF
+guards on the sink, soft-delete to 'revoked'.
+"""
+
+import os
+import uuid
+from urllib.parse import urlparse
+
+from flask import g, jsonify
+from sqlalchemy import text
+
+from constants import (
+    ACTION_CHANNEL_CREATE,
+    ACTION_CHANNEL_DELETE,
+    ACTION_CHANNEL_UPDATE,
+)
+from middleware.auth_middleware import require_admin_or_page_permission, require_auth
+from middleware.db import with_db
+from routes.admin import admin_bp
+from schemas.channels import CreateChannelRequest, UpdateChannelRequest
+from services.audit_service import write_audit_log
+from services.channel_availability_service import recompute_channel
+from services.rate_limit import limiter
+from services.webhook_dispatcher import ssrf_guard
+from utils.validation import validate_body
+
+_PAGE = "channels"
+
+
+def _http_sink_allowed() -> bool:
+    # Reuse the dispatcher's HTTPS-only opt-out: only the literal 'true' relaxes
+    # it, and the dispatcher env validator refuses that in production.
+    return os.environ.get("SENTRY_ALLOW_HTTP_WEBHOOKS", "").lower() == "true"
+
+
+def _validate_sink(url: str):
+    """Return an (error_json, status) tuple on rejection, else None."""
+    scheme = urlparse(url).scheme
+    if scheme not in ("http", "https"):
+        return {"error": "delivery_url must be http or https"}, 400
+    if scheme == "http" and not _http_sink_allowed():
+        return {
+            "error": "https_required",
+            "detail": (
+                "delivery_url must use https. Set SENTRY_ALLOW_HTTP_WEBHOOKS=true "
+                "to relax this in dev / CI; production refuses the opt-out."
+            ),
+        }, 400
+    try:
+        ssrf_guard.assert_url_safe(url)
+    except ssrf_guard.SsrfRejected as exc:
+        return {"error": "private_destination", "detail": str(exc)}, 400
+    return None
+
+
+def _scope_dump(scope_model):
+    return scope_model.model_dump(exclude_none=True) if scope_model is not None else {}
+
+
+def _row_to_listing(row):
+    return {
+        "channel_id": row.channel_id,
+        "display_name": row.display_name,
+        "delivery_url": row.delivery_url,
+        "sku_scope": row.sku_scope,
+        "transform": row.transform,
+        "status": row.status,
+        "pause_reason": row.pause_reason,
+        "rate_limit_per_second": row.rate_limit_per_second,
+        "batch_size": row.batch_size,
+        "debounce_seconds": row.debounce_seconds,
+        "pending_ceiling": row.pending_ceiling,
+        "dlq_ceiling": row.dlq_ceiling,
+        "last_published_at": (
+            row.last_published_at.isoformat() if row.last_published_at else None
+        ),
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "item_count": int(getattr(row, "item_count", 0) or 0),
+        "dirty_count": int(getattr(row, "dirty_count", 0) or 0),
+        "dlq_count": int(getattr(row, "dlq_count", 0) or 0),
+    }
+
+
+_LIST_SELECT = """
+    SELECT c.*,
+           COALESCE(s.total, 0) AS item_count,
+           COALESCE(s.dirty, 0) AS dirty_count,
+           COALESCE(s.dlq,   0) AS dlq_count
+      FROM channels c
+      LEFT JOIN (
+            SELECT channel_id,
+                   COUNT(*)                                            AS total,
+                   COUNT(*) FILTER (WHERE current_version > last_version
+                                      AND dlq = FALSE)                 AS dirty,
+                   COUNT(*) FILTER (WHERE dlq = TRUE)                  AS dlq
+              FROM channel_availability
+             GROUP BY channel_id
+      ) s ON s.channel_id = c.channel_id
+"""
+
+
+@admin_bp.route("/channels", methods=["POST"])
+@require_auth
+@require_admin_or_page_permission(_PAGE)
+@limiter.limit("60 per minute")
+@validate_body(CreateChannelRequest)
+@with_db
+def create_channel(validated):
+    sink_error = _validate_sink(validated.delivery_url)
+    if sink_error is not None:
+        return jsonify(sink_error[0]), sink_error[1]
+
+    exists = g.db.execute(
+        text("SELECT 1 FROM channels WHERE channel_id = :c"),
+        {"c": validated.channel_id},
+    ).fetchone()
+    if exists:
+        return jsonify({"error": "channel_id_exists"}), 409
+
+    scope_dump = _scope_dump(validated.sku_scope)
+    transform_dump = _scope_dump(validated.transform)
+    g.db.execute(
+        text(
+            """
+            INSERT INTO channels (
+                channel_id, display_name, delivery_url, sku_scope, transform,
+                rate_limit_per_second, batch_size, debounce_seconds,
+                pending_ceiling, dlq_ceiling, created_by, external_id
+            ) VALUES (
+                :channel_id, :display_name, :delivery_url,
+                CAST(:sku_scope AS jsonb), CAST(:transform AS jsonb),
+                :rate, :batch, :debounce, :pending_ceiling, :dlq_ceiling,
+                :created_by, :external_id
+            )
+            """
+        ),
+        {
+            "channel_id": validated.channel_id,
+            "display_name": validated.display_name,
+            "delivery_url": validated.delivery_url,
+            "sku_scope": validated.sku_scope.model_dump_json(exclude_none=True),
+            "transform": validated.transform.model_dump_json(exclude_none=True),
+            "rate": validated.rate_limit_per_second,
+            "batch": validated.batch_size,
+            "debounce": validated.debounce_seconds,
+            "pending_ceiling": validated.pending_ceiling,
+            "dlq_ceiling": validated.dlq_ceiling,
+            "created_by": g.current_user["username"],
+            "external_id": str(uuid.uuid4()),
+        },
+    )
+
+    # Materialize the initial snapshot so the operator sees availability populate
+    # and the daemon has dirty rows to publish on its next cycle.
+    recompute_channel(g.db, validated.channel_id, scope_dump)
+
+    write_audit_log(
+        g.db,
+        action_type=ACTION_CHANNEL_CREATE,
+        entity_type="CHANNEL",
+        entity_id=0,
+        user_id=g.current_user["username"],
+        warehouse_id=None,
+        details={
+            "channel_id": validated.channel_id,
+            "display_name": validated.display_name,
+            "delivery_url": validated.delivery_url,
+            "sku_scope": scope_dump,
+            "transform": transform_dump,
+            "rate_limit_per_second": validated.rate_limit_per_second,
+            "batch_size": validated.batch_size,
+            "debounce_seconds": validated.debounce_seconds,
+        },
+    )
+    g.db.commit()
+    return jsonify({"channel_id": validated.channel_id, "status": "active"}), 201
+
+
+@admin_bp.route("/channels", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission(_PAGE)
+@with_db
+def list_channels():
+    rows = g.db.execute(
+        text(_LIST_SELECT + " WHERE c.status != 'revoked' ORDER BY c.created_at DESC")
+    ).fetchall()
+    return jsonify({"channels": [_row_to_listing(r) for r in rows]})
+
+
+@admin_bp.route("/channels/<channel_id>", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission(_PAGE)
+@with_db
+def get_channel(channel_id):
+    row = g.db.execute(
+        text(_LIST_SELECT + " WHERE c.channel_id = :c"), {"c": channel_id}
+    ).fetchone()
+    if row is None:
+        return jsonify({"error": "not_found"}), 404
+    return jsonify(_row_to_listing(row))
+
+
+@admin_bp.route("/channels/<channel_id>", methods=["PATCH"])
+@require_auth
+@require_admin_or_page_permission(_PAGE)
+@limiter.limit("60 per minute")
+@validate_body(UpdateChannelRequest)
+@with_db
+def update_channel(validated, channel_id):
+    current = g.db.execute(
+        text("SELECT * FROM channels WHERE channel_id = :c"), {"c": channel_id}
+    ).fetchone()
+    if current is None:
+        return jsonify({"error": "not_found"}), 404
+    if current.status == "revoked":
+        return jsonify({"error": "channel_revoked"}), 409
+
+    if validated.delivery_url is not None:
+        sink_error = _validate_sink(validated.delivery_url)
+        if sink_error is not None:
+            return jsonify(sink_error[0]), sink_error[1]
+
+    set_clauses = []
+    params = {"c": channel_id}
+    diff = {}
+    scope_changed = False
+
+    def _record(column, before, after):
+        diff[column] = {"before": before, "after": after}
+
+    def _scalar(field, column=None):
+        column = column or field
+        new = getattr(validated, field)
+        if new is not None and new != getattr(current, column):
+            set_clauses.append(f"{column} = :{column}")
+            params[column] = new
+            _record(column, getattr(current, column), new)
+
+    _scalar("display_name")
+    _scalar("delivery_url")
+    _scalar("rate_limit_per_second")
+    _scalar("batch_size")
+    _scalar("debounce_seconds")
+    _scalar("pending_ceiling")
+    _scalar("dlq_ceiling")
+
+    # status: only active/paused reach here (schema-gated). Pausing keeps the
+    # config; resuming clears any pause_reason.
+    if validated.status is not None and validated.status != current.status:
+        set_clauses.append("status = :status")
+        params["status"] = validated.status
+        if validated.status == "active":
+            set_clauses.append("pause_reason = NULL")
+        else:
+            set_clauses.append("pause_reason = 'manual'")
+        _record("status", current.status, validated.status)
+
+    if validated.sku_scope is not None:
+        new_scope = _scope_dump(validated.sku_scope)
+        if new_scope != (current.sku_scope or {}):
+            set_clauses.append("sku_scope = CAST(:sku_scope AS jsonb)")
+            params["sku_scope"] = validated.sku_scope.model_dump_json(exclude_none=True)
+            _record("sku_scope", current.sku_scope or {}, new_scope)
+            scope_changed = True
+
+    if validated.transform is not None:
+        new_transform = _scope_dump(validated.transform)
+        if new_transform != (current.transform or {}):
+            set_clauses.append("transform = CAST(:transform AS jsonb)")
+            params["transform"] = validated.transform.model_dump_json(exclude_none=True)
+            _record("transform", current.transform or {}, new_transform)
+
+    if not set_clauses:
+        return jsonify({"channel_id": channel_id, "updated_fields": []})
+
+    set_clauses.append("updated_at = NOW()")
+    g.db.execute(
+        text(f"UPDATE channels SET {', '.join(set_clauses)} WHERE channel_id = :c"),
+        params,
+    )
+
+    # A scope change redraws the in-scope item set. Drop the materialization and
+    # re-seed so de-scoped items stop tracking and newly-in-scope items publish.
+    if scope_changed:
+        g.db.execute(
+            text("DELETE FROM channel_availability WHERE channel_id = :c"),
+            {"c": channel_id},
+        )
+        recompute_channel(g.db, channel_id, _scope_dump(validated.sku_scope))
+
+    write_audit_log(
+        g.db,
+        action_type=ACTION_CHANNEL_UPDATE,
+        entity_type="CHANNEL",
+        entity_id=0,
+        user_id=g.current_user["username"],
+        warehouse_id=None,
+        details={"channel_id": channel_id, "diff": diff},
+    )
+    g.db.commit()
+    return jsonify({"channel_id": channel_id, "updated_fields": sorted(diff.keys())})
+
+
+@admin_bp.route("/channels/<channel_id>", methods=["DELETE"])
+@require_auth
+@require_admin_or_page_permission(_PAGE)
+@with_db
+def delete_channel(channel_id):
+    current = g.db.execute(
+        text("SELECT status FROM channels WHERE channel_id = :c"), {"c": channel_id}
+    ).fetchone()
+    if current is None:
+        return jsonify({"error": "not_found"}), 404
+    if current.status == "revoked":
+        return jsonify({"channel_id": channel_id, "status": "revoked"})
+
+    # Soft delete: the publisher skips non-active channels, and the row + its
+    # config snapshot survive for forensics. channel_availability rows stay
+    # (harmless) until a hard cleanup.
+    g.db.execute(
+        text(
+            "UPDATE channels SET status = 'revoked', pause_reason = NULL, "
+            "updated_at = NOW() WHERE channel_id = :c"
+        ),
+        {"c": channel_id},
+    )
+    write_audit_log(
+        g.db,
+        action_type=ACTION_CHANNEL_DELETE,
+        entity_type="CHANNEL",
+        entity_id=0,
+        user_id=g.current_user["username"],
+        warehouse_id=None,
+        details={"channel_id": channel_id},
+    )
+    g.db.commit()
+    return jsonify({"channel_id": channel_id, "status": "revoked"})
+
+
+@admin_bp.route("/channels/<channel_id>/dlq", methods=["GET"])
+@require_auth
+@require_admin_or_page_permission(_PAGE)
+@with_db
+def channel_dlq(channel_id):
+    rows = g.db.execute(
+        text(
+            """
+            SELECT ca.item_id, i.sku, ca.available_qty, ca.attempt_count,
+                   ca.last_error,
+                   ca.last_published_at, ca.updated_at
+              FROM channel_availability ca
+              JOIN items i ON i.item_id = ca.item_id
+             WHERE ca.channel_id = :c AND ca.dlq = TRUE
+             ORDER BY ca.updated_at DESC
+             LIMIT 500
+            """
+        ),
+        {"c": channel_id},
+    ).fetchall()
+    return jsonify(
+        {
+            "channel_id": channel_id,
+            "parked": [
+                {
+                    "item_id": r.item_id,
+                    "sku": r.sku,
+                    "available_qty": r.available_qty,
+                    "attempt_count": r.attempt_count,
+                    "last_error": r.last_error,
+                    "last_published_at": (
+                        r.last_published_at.isoformat() if r.last_published_at else None
+                    ),
+                    "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+                }
+                for r in rows
+            ],
+        }
+    )

--- a/api/schemas/channels.py
+++ b/api/schemas/channels.py
@@ -1,0 +1,107 @@
+"""Pydantic schemas for /api/admin/channels (v1.30.0, Pipe C).
+
+Strict-typed bodies for the channel-availability config CRUD. ``extra='forbid'``
+so an unknown field surfaces as a 400 rather than slipping past and dropping at
+the SQL projection. Mirrors the v1.6 webhook-subscription schema shape.
+"""
+
+import re
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Transform constants are injected verbatim into the outbound payload, so keep
+# them to JSON scalars -- no nested objects to smuggle structure through.
+_Scalar = Union[str, int, float, bool]
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+class ChannelScope(BaseModel):
+    """Which items publish on a channel and which warehouses count toward the
+    number. An absent / empty dimension imposes no restriction on that
+    dimension."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    skus: Optional[List[str]] = None
+    categories: Optional[List[str]] = None
+    warehouse_ids: Optional[List[int]] = None
+
+
+class ChannelTransform(BaseModel):
+    """Declarative outbound transform: rename payload keys, then inject
+    constants. No expression evaluation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rename: Optional[Dict[str, str]] = None
+    constants: Optional[Dict[str, _Scalar]] = None
+
+
+class CreateChannelRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str = Field(..., min_length=1, max_length=64)
+    display_name: str = Field(..., min_length=1, max_length=128)
+    delivery_url: str = Field(..., min_length=1, max_length=2048)
+    sku_scope: ChannelScope = Field(default_factory=ChannelScope)
+    transform: ChannelTransform = Field(default_factory=ChannelTransform)
+    rate_limit_per_second: int = Field(default=10, ge=1, le=1000)
+    batch_size: int = Field(default=100, ge=1, le=1000)
+    debounce_seconds: int = Field(default=30, ge=0, le=3600)
+    pending_ceiling: int = Field(default=100000, ge=100, le=1000000)
+    dlq_ceiling: int = Field(default=1000, ge=10, le=100000)
+
+    @field_validator("channel_id")
+    @classmethod
+    def _slug(cls, v: str) -> str:
+        v = v.strip()
+        if not _SLUG_RE.match(v):
+            raise ValueError(
+                "channel_id must be a lowercase slug: start alphanumeric, then "
+                "a-z, 0-9, hyphen or underscore"
+            )
+        return v
+
+    @field_validator("delivery_url")
+    @classmethod
+    def _strip_url(cls, v: str) -> str:
+        return v.strip()
+
+
+class UpdateChannelRequest(BaseModel):
+    """Body for PATCH /api/admin/channels/<id>. All fields optional; an absent
+    field leaves the column unchanged. ``status`` accepts only the operator
+    transitions 'active' / 'paused' -- the 'revoked' terminal status is reached
+    via DELETE, so a typo cannot revoke a channel."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: Optional[str] = Field(None, min_length=1, max_length=128)
+    delivery_url: Optional[str] = Field(None, min_length=1, max_length=2048)
+    sku_scope: Optional[ChannelScope] = None
+    transform: Optional[ChannelTransform] = None
+    rate_limit_per_second: Optional[int] = Field(None, ge=1, le=1000)
+    batch_size: Optional[int] = Field(None, ge=1, le=1000)
+    debounce_seconds: Optional[int] = Field(None, ge=0, le=3600)
+    pending_ceiling: Optional[int] = Field(None, ge=100, le=1000000)
+    dlq_ceiling: Optional[int] = Field(None, ge=10, le=100000)
+    status: Optional[str] = None
+
+    @field_validator("delivery_url")
+    @classmethod
+    def _strip_url(cls, v: Optional[str]) -> Optional[str]:
+        return v.strip() if v is not None else v
+
+    @field_validator("status")
+    @classmethod
+    def _status_only_active_or_paused(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if v not in ("active", "paused"):
+            raise ValueError(
+                "status accepts only 'active' or 'paused'. Use the DELETE "
+                "endpoint to revoke a channel."
+            )
+        return v

--- a/api/services/channel_availability_service.py
+++ b/api/services/channel_availability_service.py
@@ -1,0 +1,172 @@
+"""
+Pipe C recompute service: reconcile per-channel sellable availability against
+live inventory.
+
+Design: this is a RECONCILIATION sweep, not a delta applier. Each call recomputes
+``available = SUM(GREATEST(on_hand - allocated, 0))`` over a channel's in-scope
+warehouses (Pickable / PickableStaging bins only) straight from the current
+``inventory`` rows, and writes the result into ``channel_availability``. It does
+not trust an event payload's numbers; it reads the truth.
+
+Why a sweep and not pure event-driven: ``available`` depends on
+``quantity_allocated``, which moves at order ingestion (reserve-at-creation,
+v1.21) and on cancel / release / the manual stepper -- none of which emit an
+integration_event. A consumer that only replayed the event stream would miss the
+single most common availability change (a new order reserving stock) and would
+silently lie to the marketplace about sellable counts. Reconciling against live
+inventory is self-healing: it converges to the truth no matter which code path
+moved the numbers, including paths that emit nothing and paths that do not exist
+yet. The integration_events stream is used by the daemon (see
+``services/connector_publisher``) only to WAKE this sweep sooner than its periodic
+tick -- never as the source of the numbers.
+
+Version discipline: ``current_version`` is bumped (from
+``channel_availability_version_seq``) only for rows whose ``available_qty``
+actually changes. A sweep that finds nothing changed writes nothing and enqueues
+no publish, so a quiet warehouse produces zero outbound traffic. A bumped row is
+"dirty" (``current_version > last_version``) until the publisher delivers it.
+"""
+
+import json
+
+from sqlalchemy import text
+
+from constants import BIN_PICKABLE, BIN_PICKABLE_STAGING
+
+
+def _coerce_scope(sku_scope):
+    """Normalize a channel's sku_scope JSONB into (skus, categories,
+    warehouse_ids), each a non-empty list or None.
+
+    JSONB columns decode to dicts via psycopg2, but a str is tolerated (e.g. a
+    hand-built test row) and parsed. An absent or empty dimension imposes no
+    restriction on that dimension.
+    """
+    if not sku_scope:
+        return None, None, None
+    if isinstance(sku_scope, str):
+        sku_scope = json.loads(sku_scope)
+
+    def _clean(key):
+        vals = sku_scope.get(key)
+        return list(vals) if vals else None
+
+    return _clean("skus"), _clean("categories"), _clean("warehouse_ids")
+
+
+def recompute_channel(db, channel_id, sku_scope, *, item_ids=None):
+    """Reconcile one channel's availability against live inventory.
+
+    ``item_ids`` None runs a full sweep over every in-scope item (also the seed
+    path for a brand-new channel: every item is "new", so every in-scope row is
+    inserted dirty and the publisher sends the initial snapshot). Passing a
+    subset restricts the sweep to those items -- the event fast-path the daemon
+    can use to recompute just what an inventory event touched.
+
+    Returns the number of rows whose version was bumped (rows whose sellable
+    number actually changed). A return of 0 means the channel is already in sync.
+    """
+    skus, categories, warehouse_ids = _coerce_scope(sku_scope)
+
+    params = {
+        "cid": channel_id,
+        "bp": BIN_PICKABLE,
+        "bps": BIN_PICKABLE_STAGING,
+    }
+
+    # The warehouse filter scopes WHICH warehouses' stock counts toward the
+    # number. It lives in the pickable-inventory aggregate, not the outer item
+    # filter.
+    wh_clause = ""
+    if warehouse_ids:
+        wh_clause = "AND inv.warehouse_id = ANY(:wh_ids)"
+        params["wh_ids"] = warehouse_ids
+
+    # The item filters define WHICH items publish on this channel. skus OR
+    # categories: an item in scope if it matches either dimension that is set.
+    item_clauses = []
+    if skus:
+        item_clauses.append("i.sku = ANY(:skus)")
+        params["skus"] = skus
+    if categories:
+        item_clauses.append("i.category = ANY(:categories)")
+        params["categories"] = categories
+    scope_clause = ""
+    if item_clauses:
+        scope_clause = "AND (" + " OR ".join(item_clauses) + ")"
+
+    # Targeted subset (event fast-path / tests).
+    target_clause = ""
+    if item_ids is not None:
+        target_clause = "AND i.item_id = ANY(:item_ids)"
+        params["item_ids"] = list(item_ids)
+
+    # pickable_inv aggregates only Pickable / PickableStaging bins in the
+    # in-scope warehouses, so non-sellable Staging stock never inflates the
+    # number. computed then LEFT JOINs every in-scope active item to that
+    # aggregate, defaulting to 0 -- an item with no sellable stock publishes a
+    # truthful 0 rather than dropping out. changed keeps only rows whose number
+    # moved, so the upsert bumps a version (and enqueues a publish) for exactly
+    # those.
+    sql = f"""
+        WITH pickable_inv AS (
+            SELECT inv.item_id,
+                   SUM(GREATEST(inv.quantity_on_hand - inv.quantity_allocated, 0)) AS qty
+              FROM inventory inv
+              JOIN bins b ON b.bin_id = inv.bin_id
+             WHERE b.bin_type IN (:bp, :bps)
+               {wh_clause}
+             GROUP BY inv.item_id
+        ),
+        computed AS (
+            SELECT i.item_id,
+                   COALESCE(pi.qty, 0)::int AS qty
+              FROM items i
+              LEFT JOIN pickable_inv pi ON pi.item_id = i.item_id
+             WHERE i.is_active = TRUE
+               {scope_clause}
+               {target_clause}
+        ),
+        changed AS (
+            SELECT c.item_id, c.qty
+              FROM computed c
+              LEFT JOIN channel_availability ca
+                     ON ca.channel_id = :cid AND ca.item_id = c.item_id
+             WHERE ca.item_id IS NULL
+                OR ca.available_qty IS DISTINCT FROM c.qty
+        )
+        INSERT INTO channel_availability (
+            channel_id, item_id, available_qty,
+            current_version, last_version, updated_at
+        )
+        SELECT :cid, ch.item_id, ch.qty,
+               nextval('channel_availability_version_seq'), 0, NOW()
+          FROM changed ch
+        ON CONFLICT (channel_id, item_id) DO UPDATE
+           SET available_qty   = EXCLUDED.available_qty,
+               current_version = nextval('channel_availability_version_seq'),
+               attempt_count   = 0,
+               next_attempt_at = NULL,
+               dlq             = FALSE,
+               last_error      = NULL,
+               updated_at      = NOW()
+    """
+    return db.execute(text(sql), params).rowcount
+
+
+def recompute_active_channels(db, *, item_ids=None):
+    """Sweep every active channel. Returns {channel_id: rows_bumped}.
+
+    Paused / revoked channels are skipped: their config is frozen and the
+    publisher is not draining them, so there is no point materializing churn
+    against a channel nobody is shipping.
+    """
+    channels = db.execute(
+        text("SELECT channel_id, sku_scope FROM channels WHERE status = 'active'")
+    ).fetchall()
+    return {
+        ch.channel_id: recompute_channel(
+            db, ch.channel_id, ch.sku_scope, item_ids=item_ids
+        )
+        for ch in channels
+    }

--- a/api/services/connector_publisher/__init__.py
+++ b/api/services/connector_publisher/__init__.py
@@ -1,0 +1,284 @@
+"""Pipe C connector-publisher daemon.
+
+A standalone process (``python -m services.connector_publisher``) that, on each
+cycle:
+
+  1. reconciles per-channel sellable availability against live inventory
+     (services.channel_availability_service), and
+  2. debounce-publishes each active channel's dirty rows to its HTTP sink
+     (services.connector_publisher.publish).
+
+A cycle fires when the existing ``integration_events_visible`` NOTIFY wakes the
+daemon (an inventory event landed) or when the periodic reconcile interval
+elapses (the self-healing guarantee that catches allocation changes, which emit
+no event). Single main loop -- per-channel debounce + a per-channel token bucket
+provide the throttling the dispatcher needed threads for; availability is
+last-writer-wins, so there is no ordered-delivery requirement to isolate.
+"""
+
+import logging
+import os
+import select
+import signal
+import threading
+import time
+from datetime import datetime, timezone
+
+import psycopg2
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from services.channel_availability_service import recompute_active_channels
+from services.webhook_dispatcher.rate_limiter import TokenBucket
+
+from . import env_validator
+from . import publish as publish_module
+
+HEARTBEAT_FILE_DEFAULT = "/tmp/connector-publisher-heartbeat"
+HEARTBEAT_INTERVAL_S = 5
+LISTEN_CHANNEL = "integration_events_visible"
+
+LOGGER = logging.getLogger("connector_publisher")
+
+
+class ConnectorPublisher:
+    def __init__(self):
+        self._shutdown = threading.Event()
+        self._buckets = {}            # channel_id -> TokenBucket
+        self._engine = None
+        self._Session = None
+        self._listen_conn = None
+        self._database_url = None
+        self._heartbeat_file = env_validator.str_var(
+            "CONNECTOR_PUBLISHER_HEARTBEAT_FILE", HEARTBEAT_FILE_DEFAULT
+        )
+
+    @property
+    def enabled(self):
+        return env_validator.enabled()
+
+    # ---- lifecycle ----------------------------------------------------
+
+    def run(self):
+        env_validator.validate_or_die()
+        self._install_signal_handlers()
+
+        if not self.enabled:
+            LOGGER.critical(
+                "connector-publisher kill-switch active: "
+                "CONNECTOR_PUBLISHER_ENABLED=false; writing heartbeats but "
+                "publishing nothing. Unset it (or set true) and restart."
+            )
+            self._heartbeat_only_loop()
+            return
+
+        self._database_url = (
+            os.environ.get("PUBLISHER_DATABASE_URL") or os.environ["DATABASE_URL"]
+        )
+        self._engine = create_engine(
+            self._database_url, pool_pre_ping=True, pool_recycle=1800
+        )
+        self._Session = sessionmaker(bind=self._engine)
+        self._open_listen()
+        LOGGER.info("connector-publisher started")
+        try:
+            self._main_loop()
+        finally:
+            self._drain()
+
+    def _install_signal_handlers(self):
+        signal.signal(signal.SIGTERM, self._on_signal)
+        signal.signal(signal.SIGINT, self._on_signal)
+
+    def _on_signal(self, signum, _frame):
+        LOGGER.info("received signal %s; draining and shutting down", signum)
+        self._shutdown.set()
+
+    def _drain(self):
+        if self._listen_conn is not None:
+            try:
+                self._listen_conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+        if self._engine is not None:
+            self._engine.dispose()
+        LOGGER.info("connector-publisher stopped")
+
+    # ---- main loop ----------------------------------------------------
+
+    def _main_loop(self):
+        poll_s = env_validator.int_var("CONNECTOR_PUBLISHER_FALLBACK_POLL_MS") / 1000.0
+        reconcile_interval = env_validator.int_var(
+            "CONNECTOR_PUBLISHER_RECONCILE_INTERVAL_S"
+        )
+        last_reconcile = 0.0
+        last_heartbeat = 0.0
+        self._write_heartbeat()
+
+        while not self._shutdown.is_set():
+            woke = self._wait_for_wake(poll_s)
+            now = time.monotonic()
+            if woke or (now - last_reconcile) >= reconcile_interval:
+                try:
+                    self._cycle()
+                except Exception as exc:  # noqa: BLE001
+                    LOGGER.exception("publish cycle failed: %s", exc)
+                last_reconcile = time.monotonic()
+            if (time.monotonic() - last_heartbeat) >= HEARTBEAT_INTERVAL_S:
+                self._write_heartbeat()
+                last_heartbeat = time.monotonic()
+
+    def _heartbeat_only_loop(self):
+        # Kill-switch mode: keep the container's healthcheck green without doing
+        # any work, so an operator can disable the daemon without the
+        # orchestrator restarting it on a stale heartbeat.
+        while not self._shutdown.is_set():
+            self._write_heartbeat()
+            self._shutdown.wait(timeout=HEARTBEAT_INTERVAL_S)
+
+    # ---- one cycle ----------------------------------------------------
+
+    def _cycle(self):
+        session = self._Session()
+        try:
+            recompute_active_channels(session)
+            self._advance_cursor(session)
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+        self._publish_pass()
+
+    def _advance_cursor(self, session):
+        # Observability only: record how far the stream has been seen. The sweep
+        # reconciles against live inventory, so correctness does not depend on
+        # this cursor -- it just lets an operator see "swept through event N".
+        session.execute(
+            text(
+                """
+                UPDATE channel_recompute_state
+                   SET last_cursor = GREATEST(
+                           last_cursor,
+                           COALESCE((SELECT MAX(event_id) FROM integration_events
+                                      WHERE visible_at IS NOT NULL), 0)),
+                       updated_at = NOW()
+                 WHERE only_row = TRUE
+                """
+            )
+        )
+
+    def _publish_pass(self):
+        connect_s = env_validator.int_var("CONNECTOR_PUBLISHER_HTTP_CONNECT_TIMEOUT_MS") / 1000.0
+        read_s = env_validator.int_var("CONNECTOR_PUBLISHER_HTTP_READ_TIMEOUT_MS") / 1000.0
+
+        def http_post(url, payload):
+            return publish_module._default_http_post(
+                url, payload, connect_timeout_s=connect_s, read_timeout_s=read_s
+            )
+
+        session = self._Session()
+        try:
+            channels = session.execute(
+                text("SELECT * FROM channels WHERE status = 'active'")
+            ).fetchall()
+            now = datetime.now(timezone.utc)
+            for ch in channels:
+                if self._shutdown.is_set():
+                    break
+                if not self._due(ch, now):
+                    continue
+                self._drain_channel(session, ch, http_post)
+        finally:
+            session.close()
+
+    def _due(self, ch, now):
+        """A channel publishes at most once per debounce window. The window
+        collapses every change accumulated since the last publish into the next
+        batch, which is the whole point of Pipe C: marketplaces get a debounced
+        snapshot, not a fan-out of every inventory tick."""
+        if not ch.debounce_seconds or ch.last_published_at is None:
+            return True
+        return (now - ch.last_published_at).total_seconds() >= ch.debounce_seconds
+
+    def _drain_channel(self, session, ch, http_post):
+        bucket = self._bucket_for(ch)
+        while not self._shutdown.is_set():
+            if not bucket.acquire(timeout_s=1.0, shutdown=self._shutdown):
+                return
+            try:
+                result = publish_module.publish_channel(session, ch, http_post=http_post)
+                session.commit()
+            except Exception as exc:  # noqa: BLE001
+                session.rollback()
+                LOGGER.exception("channel %s publish failed: %s", ch.channel_id, exc)
+                return
+            # Keep draining only while full batches keep coming back; a partial
+            # or empty batch means the backlog is cleared. Stop on failure /
+            # pause so a sick channel is not hammered.
+            published = result.get("published")
+            if published is None or published < ch.batch_size:
+                return
+
+    def _bucket_for(self, ch):
+        bucket = self._buckets.get(ch.channel_id)
+        if bucket is None:
+            bucket = TokenBucket(ch.rate_limit_per_second)
+            self._buckets[ch.channel_id] = bucket
+        else:
+            bucket.set_rate(ch.rate_limit_per_second)  # pick up a config change
+        return bucket
+
+    # ---- LISTEN/NOTIFY wake -------------------------------------------
+
+    def _open_listen(self):
+        try:
+            self._listen_conn = psycopg2.connect(self._database_url)
+            self._listen_conn.autocommit = True
+            cur = self._listen_conn.cursor()
+            cur.execute(f"LISTEN {LISTEN_CHANNEL};")
+            cur.close()
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning(
+                "could not open LISTEN connection (%s); falling back to poll only",
+                exc,
+            )
+            self._listen_conn = None
+
+    def _wait_for_wake(self, timeout_s):
+        """Return True if a NOTIFY arrived within timeout_s, False on timeout.
+        Falls back to a plain sleep when the LISTEN connection is unavailable, so
+        the periodic reconcile still runs."""
+        if self._listen_conn is None:
+            self._shutdown.wait(timeout=timeout_s)
+            return False
+        try:
+            ready, _, _ = select.select([self._listen_conn], [], [], timeout_s)
+            if not ready:
+                return False
+            self._listen_conn.poll()
+            got = bool(self._listen_conn.notifies)
+            self._listen_conn.notifies.clear()
+            return got
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("LISTEN wake error: %s; reopening", exc)
+            self._open_listen()
+            return False
+
+    # ---- heartbeat ----------------------------------------------------
+
+    def _write_heartbeat(self):
+        try:
+            with open(self._heartbeat_file, "w") as fh:
+                fh.write(str(time.time()))
+        except OSError as exc:
+            LOGGER.warning("could not write heartbeat file: %s", exc)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    ConnectorPublisher().run()

--- a/api/services/connector_publisher/__main__.py
+++ b/api/services/connector_publisher/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point: ``python -m services.connector_publisher``."""
+
+from . import main
+
+main()

--- a/api/services/connector_publisher/env_validator.py
+++ b/api/services/connector_publisher/env_validator.py
@@ -1,0 +1,79 @@
+"""Boot-time config validation for the connector-publisher daemon.
+
+Mirrors services/webhook_dispatcher/env_validator: every CONNECTOR_PUBLISHER_*
+tunable has a documented [lo, hi] range and a default, read at use-time via
+int_var so a value can change with a restart and no code edit. validate_or_die()
+fails fast on a misconfiguration so a bad deploy crashes the container loudly
+rather than running with surprising behavior.
+"""
+
+import logging
+import os
+
+LOGGER = logging.getLogger("connector_publisher.env")
+
+# (name, lo, hi, default)
+_RANGE_VARS = [
+    ("CONNECTOR_PUBLISHER_FALLBACK_POLL_MS", 250, 60000, 2000),
+    ("CONNECTOR_PUBLISHER_RECONCILE_INTERVAL_S", 5, 3600, 60),
+    ("CONNECTOR_PUBLISHER_SHUTDOWN_DRAIN_S", 1, 300, 30),
+    ("CONNECTOR_PUBLISHER_HTTP_CONNECT_TIMEOUT_MS", 500, 60000, 5000),
+    ("CONNECTOR_PUBLISHER_HTTP_READ_TIMEOUT_MS", 500, 120000, 8000),
+]
+_DEFAULTS = {name: default for (name, _lo, _hi, default) in _RANGE_VARS}
+
+
+class ConfigError(SystemExit):
+    """Raised (as a SystemExit) when boot validation fails, so the container
+    exits non-zero and deployment automation flags the step."""
+
+
+def _read_str(name):
+    v = os.environ.get(name)
+    return v if v not in (None, "") else None
+
+
+def bool_var(name, default=False):
+    raw = _read_str(name)
+    return default if raw is None else raw.lower() == "true"
+
+
+def int_var(name):
+    """Always re-read from the environment (never cached at import) so a restart
+    picks up a new value. Falls back to the documented default."""
+    raw = _read_str(name)
+    if raw is None:
+        return _DEFAULTS[name]
+    return int(raw)
+
+
+def str_var(name, default=None):
+    return _read_str(name) or default
+
+
+def enabled():
+    # Default ON. Only the explicit string "false" disables, so an unrelated
+    # truthy value cannot silently engage the kill switch.
+    return os.environ.get("CONNECTOR_PUBLISHER_ENABLED", "true").lower() != "false"
+
+
+def _validate_range(name, lo, hi):
+    raw = _read_str(name)
+    if raw is None:
+        return
+    try:
+        val = int(raw)
+    except ValueError:
+        raise ConfigError(f"{name} must be an integer, got {raw!r}")
+    if not (lo <= val <= hi):
+        raise ConfigError(f"{name}={val} is out of range [{lo}, {hi}]")
+
+
+def validate_or_die():
+    for (name, lo, hi, _default) in _RANGE_VARS:
+        _validate_range(name, lo, hi)
+    if enabled() and not (_read_str("PUBLISHER_DATABASE_URL") or _read_str("DATABASE_URL")):
+        raise ConfigError(
+            "connector-publisher needs PUBLISHER_DATABASE_URL or DATABASE_URL"
+        )
+    LOGGER.info("connector-publisher env validated")

--- a/api/services/connector_publisher/healthcheck.py
+++ b/api/services/connector_publisher/healthcheck.py
@@ -1,0 +1,40 @@
+"""Healthcheck CLI for the docker-compose ``healthcheck`` directive.
+
+Invoked as ``python -m services.connector_publisher.healthcheck``. Exits 0 when
+the heartbeat file is newer than the staleness threshold, non-zero otherwise.
+Mirrors the webhook-dispatcher healthcheck so the daemon's liveness logic is
+version-controlled alongside it.
+
+Threshold defaults to 30s -- six times the 5s HEARTBEAT_INTERVAL_S. A miss means
+the loop has been wedged for several intervals and docker-compose should restart
+the container.
+"""
+
+import os
+import sys
+import time
+
+from . import HEARTBEAT_FILE_DEFAULT
+
+STALENESS_THRESHOLD_S = 30
+
+
+def is_healthy(heartbeat_file=None, threshold_s=STALENESS_THRESHOLD_S, now_fn=time.time):
+    """True when the heartbeat file's mtime is within threshold_s of now_fn().
+    now_fn is injectable so a test can assert at controlled timestamps."""
+    path = heartbeat_file or os.environ.get(
+        "CONNECTOR_PUBLISHER_HEARTBEAT_FILE", HEARTBEAT_FILE_DEFAULT
+    )
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        return False
+    return (now_fn() - mtime) <= threshold_s
+
+
+def main():
+    sys.exit(0 if is_healthy() else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/api/services/connector_publisher/publish.py
+++ b/api/services/connector_publisher/publish.py
@@ -1,0 +1,197 @@
+"""Per-channel publish: claim dirty availability rows, transform, POST to the
+channel's HTTP sink, advance or back off.
+
+Kept free of the daemon's threads / LISTEN loop so it is unit-testable: the
+caller injects ``http_post`` (a fake in tests, a real requests call in
+production) and a live DB session. The orchestration in ``__init__`` owns
+debounce, the per-channel rate-limit token bucket, and scheduling; this module
+owns one batch.
+
+Availability is current-state (last-writer-wins per channel+item), so a failed
+publish is never lost data -- the row stays dirty and the next cycle re-sends
+whatever the number is by then. Retries exist only to ride out a transient sink
+outage; the final attempt parks the batch in the per-row DLQ.
+"""
+
+import logging
+
+import requests
+from sqlalchemy import text
+
+from services.webhook_dispatcher.ssrf_guard import SsrfRejected, assert_url_safe
+
+LOGGER = logging.getLogger("connector_publisher")
+
+# Backoff (seconds) indexed by the row's new attempt_count. The attempt after
+# the last entry parks the row in the DLQ.
+RETRY_BACKOFF_S = [30, 120, 600, 3600]
+MAX_ATTEMPTS = len(RETRY_BACKOFF_S) + 1  # 5th failure -> DLQ
+
+
+def apply_transform(item, transform):
+    """Declarative per-item transform: rename keys, then inject constants. No
+    expression evaluation. ``{"rename": {"sku": "seller_sku"}, "constants":
+    {"fulfillment_channel": "AMAZON_NA"}}`` turns ``{"sku": "X", "available": 3}``
+    into ``{"seller_sku": "X", "available": 3, "fulfillment_channel": "AMAZON_NA"}``.
+    """
+    transform = transform or {}
+    renames = transform.get("rename") or {}
+    constants = transform.get("constants") or {}
+    out = {renames.get(k, k): v for k, v in item.items()}
+    out.update(constants)
+    return out
+
+
+def _default_http_post(url, payload, *, connect_timeout_s=5.0, read_timeout_s=8.0):
+    """Real sink POST. Returns (status_code, body_text). Network errors raise --
+    the caller treats a raise as a failed batch."""
+    resp = requests.post(url, json=payload, timeout=(connect_timeout_s, read_timeout_s))
+    return resp.status_code, (resp.text or "")[:512]
+
+
+def _claim_dirty(db, channel_id, batch_size):
+    return db.execute(
+        text(
+            """
+            SELECT ca.item_id, ca.current_version, ca.available_qty,
+                   ca.attempt_count, i.sku
+              FROM channel_availability ca
+              JOIN items i ON i.item_id = ca.item_id
+             WHERE ca.channel_id = :cid
+               AND ca.current_version > ca.last_version
+               AND ca.dlq = FALSE
+               AND (ca.next_attempt_at IS NULL OR ca.next_attempt_at <= NOW())
+             ORDER BY ca.current_version ASC
+             LIMIT :batch
+            """
+        ),
+        {"cid": channel_id, "batch": batch_size},
+    ).fetchall()
+
+
+def _build_payload(channel_id, rows, transform):
+    items = [
+        apply_transform({"sku": r.sku, "available": int(r.available_qty)}, transform)
+        for r in rows
+    ]
+    return {"channel_id": channel_id, "items": items}
+
+
+def _mark_published(db, channel_id, rows):
+    # last_version advances to the exact version published. If a concurrent
+    # recompute bumped current_version even higher meanwhile, the row stays
+    # dirty (current_version > last_version) and republishes next cycle with the
+    # newer number -- no update is ever silently dropped.
+    for r in rows:
+        db.execute(
+            text(
+                """
+                UPDATE channel_availability
+                   SET last_version      = :cv,
+                       last_published_at  = NOW(),
+                       attempt_count      = 0,
+                       next_attempt_at    = NULL,
+                       dlq                = FALSE,
+                       last_error         = NULL,
+                       updated_at         = NOW()
+                 WHERE channel_id = :cid AND item_id = :iid
+                """
+            ),
+            {"cv": r.current_version, "cid": channel_id, "iid": r.item_id},
+        )
+    db.execute(
+        text(
+            "UPDATE channels SET last_published_at = NOW(), updated_at = NOW() "
+            "WHERE channel_id = :cid"
+        ),
+        {"cid": channel_id},
+    )
+
+
+def _mark_failed(db, channel_id, rows, err):
+    for r in rows:
+        new_attempt = int(r.attempt_count) + 1
+        if new_attempt >= MAX_ATTEMPTS:
+            backoff = RETRY_BACKOFF_S[-1]
+            dlq = True
+        else:
+            backoff = RETRY_BACKOFF_S[new_attempt - 1]
+            dlq = False
+        db.execute(
+            text(
+                """
+                UPDATE channel_availability
+                   SET attempt_count   = :attempt,
+                       next_attempt_at  = NOW() + make_interval(secs => :backoff),
+                       dlq              = :dlq,
+                       last_error       = :err,
+                       updated_at       = NOW()
+                 WHERE channel_id = :cid AND item_id = :iid
+                """
+            ),
+            {
+                "attempt": new_attempt,
+                "backoff": backoff,
+                "dlq": dlq,
+                "err": (err or "")[:512],
+                "cid": channel_id,
+                "iid": r.item_id,
+            },
+        )
+
+
+def _pause_channel(db, channel_id, reason):
+    db.execute(
+        text(
+            "UPDATE channels SET status = 'paused', pause_reason = :r, "
+            "updated_at = NOW() WHERE channel_id = :cid AND status = 'active'"
+        ),
+        {"r": reason, "cid": channel_id},
+    )
+
+
+def publish_channel(db, channel, *, http_post=None, ssrf_check=None):
+    """Publish one batch of dirty rows for ``channel`` (a mapping/row with
+    channel_id, delivery_url, transform, batch_size). Returns a result dict:
+    ``{"published": n}`` on success, ``{"failed": n}`` on a sink error,
+    ``{"skipped": "no_dirty"}`` when nothing is pending, or
+    ``{"paused": reason}`` when the sink URL fails the SSRF guard.
+
+    ``ssrf_check`` defaults to the real dispatch-time guard; it is injectable so
+    a test can drive the pause branch without depending on DNS (the guard's own
+    private-IP detection is covered by the webhook-dispatcher SSRF tests). The
+    caller commits. All writes here are inside the caller's transaction so a
+    crash mid-batch rolls back cleanly and the rows stay dirty.
+    """
+    http_post = http_post or _default_http_post
+    ssrf_check = ssrf_check or assert_url_safe
+    channel_id = channel.channel_id
+    rows = _claim_dirty(db, channel_id, channel.batch_size)
+    if not rows:
+        return {"skipped": "no_dirty"}
+
+    # Dispatch-time SSRF guard, same posture as the webhook dispatcher: a sink
+    # that resolves to a private / loopback / IMDS address is a misconfiguration
+    # (or an attack), so pause the channel rather than POST to it.
+    try:
+        ssrf_check(channel.delivery_url)
+    except SsrfRejected as exc:
+        LOGGER.error("channel %s sink failed SSRF guard: %s", channel_id, exc)
+        _pause_channel(db, channel_id, "malformed_config")
+        return {"paused": "malformed_config"}
+
+    payload = _build_payload(channel_id, rows, channel.transform)
+    try:
+        status, body = http_post(channel.delivery_url, payload)
+    except Exception as exc:  # noqa: BLE001 -- any network error is a failed batch
+        LOGGER.warning("channel %s publish errored: %s", channel_id, exc)
+        _mark_failed(db, channel_id, rows, str(exc))
+        return {"failed": len(rows)}
+
+    if 200 <= status < 300:
+        _mark_published(db, channel_id, rows)
+        return {"published": len(rows)}
+
+    LOGGER.warning("channel %s sink returned HTTP %s: %s", channel_id, status, body)
+    _mark_failed(db, channel_id, rows, f"HTTP {status}: {body}")
+    return {"failed": len(rows)}

--- a/api/tests/test_admin_channels.py
+++ b/api/tests/test_admin_channels.py
@@ -1,0 +1,215 @@
+"""Admin CRUD contract for /api/admin/channels (v1.30.0, Pipe C).
+
+Exercises the full lifecycle through the Flask test client: create (with the
+https / SSRF guards), list with stats, detail, per-field PATCH, pause, the
+scope-change re-materialize, soft-delete, the DLQ view, and that every mutation
+writes an audit_log row. SSRF is bypassed via the documented dev/CI flag so the
+fake sink hostname does not need DNS.
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest  # noqa: E402
+
+from db_test_context import get_raw_connection  # noqa: E402
+
+_SINK = "https://sink.example.com/availability"
+
+
+@pytest.fixture(autouse=True)
+def _allow_internal_sink(monkeypatch):
+    # The create/update endpoints run the dispatch-time SSRF guard; a fake sink
+    # hostname would fail DNS. Bypass via the documented dev/CI flag (the guard's
+    # real behavior is covered in the publish tests).
+    monkeypatch.setenv("SENTRY_ALLOW_INTERNAL_WEBHOOKS", "true")
+
+
+# ---------------------------------------------------------------- helpers
+
+def _mk_item_with_stock(qty, category=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    sku = f"PC-{uuid.uuid4().hex[:10]}"
+    cur.execute(
+        "INSERT INTO items (sku, item_name, category, is_active, external_id) "
+        "VALUES (%s, %s, %s, TRUE, %s) RETURNING item_id",
+        (sku, sku, category, str(uuid.uuid4())),
+    )
+    item_id = cur.fetchone()[0]
+    cur.execute("SELECT bin_id, warehouse_id FROM bins WHERE bin_type='Pickable' "
+                "ORDER BY bin_id LIMIT 1")
+    bin_id, wh = cur.fetchone()
+    cur.execute(
+        "INSERT INTO inventory (item_id, bin_id, warehouse_id, quantity_on_hand) "
+        "VALUES (%s, %s, %s, %s)",
+        (item_id, bin_id, wh, qty),
+    )
+    cur.close()
+    return item_id, sku
+
+
+def _count_avail(channel_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM channel_availability WHERE channel_id=%s",
+                (channel_id,))
+    n = cur.fetchone()[0]
+    cur.close()
+    return n
+
+
+def _avail_skus(channel_id):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT i.sku FROM channel_availability ca JOIN items i ON i.item_id=ca.item_id "
+        "WHERE ca.channel_id=%s",
+        (channel_id,),
+    )
+    skus = {r[0] for r in cur.fetchall()}
+    cur.close()
+    return skus
+
+
+def _audit_count(action):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM audit_log WHERE action_type=%s", (action,))
+    n = cur.fetchone()[0]
+    cur.close()
+    return n
+
+
+def _create(client, auth_headers, **overrides):
+    payload = {
+        "channel_id": overrides.pop("channel_id", "amz"),
+        "display_name": "Amazon",
+        "delivery_url": _SINK,
+    }
+    payload.update(overrides)
+    return client.post("/api/admin/channels", json=payload, headers=auth_headers)
+
+
+# ---------------------------------------------------------------- create
+
+class TestCreate:
+    def test_create_materializes_and_audits(self, client, auth_headers):
+        _, sku = _mk_item_with_stock(7)
+        before = _audit_count("CHANNEL_CREATE")
+        resp = _create(client, auth_headers, sku_scope={"skus": [sku]})
+        assert resp.status_code == 201, resp.get_json()
+        assert resp.get_json()["channel_id"] == "amz"
+        # Initial snapshot materialized for the in-scope sku.
+        assert _avail_skus("amz") == {sku}
+        assert _audit_count("CHANNEL_CREATE") == before + 1
+
+    def test_duplicate_channel_id_409(self, client, auth_headers):
+        _create(client, auth_headers, channel_id="dup")
+        resp = _create(client, auth_headers, channel_id="dup")
+        assert resp.status_code == 409
+        assert resp.get_json()["error"] == "channel_id_exists"
+
+    def test_invalid_channel_id_400(self, client, auth_headers):
+        resp = _create(client, auth_headers, channel_id="Not A Slug")
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "validation_error"
+
+    def test_unknown_field_rejected_400(self, client, auth_headers):
+        resp = _create(client, auth_headers, surprise="x")
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "validation_error"
+
+    def test_http_sink_rejected(self, client, auth_headers):
+        resp = _create(client, auth_headers,
+                       delivery_url="http://sink.example.com/x")
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "https_required"
+
+
+# ---------------------------------------------------------------- read
+
+class TestRead:
+    def test_list_includes_stats(self, client, auth_headers):
+        _, sku = _mk_item_with_stock(3)
+        _create(client, auth_headers, channel_id="lst", sku_scope={"skus": [sku]})
+        body = client.get("/api/admin/channels", headers=auth_headers).get_json()
+        row = next(c for c in body["channels"] if c["channel_id"] == "lst")
+        assert row["item_count"] == 1
+        assert row["dirty_count"] == 1  # freshly materialized, unpublished
+
+    def test_detail_and_404(self, client, auth_headers):
+        _create(client, auth_headers, channel_id="det")
+        assert client.get("/api/admin/channels/det",
+                          headers=auth_headers).status_code == 200
+        assert client.get("/api/admin/channels/nope",
+                          headers=auth_headers).status_code == 404
+
+
+# ---------------------------------------------------------------- update
+
+class TestUpdate:
+    def test_patch_scalar_field(self, client, auth_headers):
+        _create(client, auth_headers, channel_id="upd")
+        resp = client.patch("/api/admin/channels/upd",
+                            json={"rate_limit_per_second": 25}, headers=auth_headers)
+        assert resp.status_code == 200
+        assert "rate_limit_per_second" in resp.get_json()["updated_fields"]
+        assert _audit_count("CHANNEL_UPDATE") >= 1
+
+    def test_pause_sets_reason(self, client, auth_headers):
+        _create(client, auth_headers, channel_id="pse")
+        client.patch("/api/admin/channels/pse",
+                     json={"status": "paused"}, headers=auth_headers)
+        detail = client.get("/api/admin/channels/pse",
+                            headers=auth_headers).get_json()
+        assert detail["status"] == "paused"
+        assert detail["pause_reason"] == "manual"
+
+    def test_status_revoked_rejected(self, client, auth_headers):
+        _create(client, auth_headers, channel_id="rev")
+        resp = client.patch("/api/admin/channels/rev",
+                            json={"status": "revoked"}, headers=auth_headers)
+        assert resp.status_code == 400  # schema only allows active/paused
+
+    def test_scope_change_rematerializes(self, client, auth_headers):
+        _, sku_a = _mk_item_with_stock(2)
+        _, sku_b = _mk_item_with_stock(2)
+        _create(client, auth_headers, channel_id="scp", sku_scope={"skus": [sku_a]})
+        assert _avail_skus("scp") == {sku_a}
+        # Repoint scope to sku_b: A drops out, B materializes.
+        resp = client.patch("/api/admin/channels/scp",
+                            json={"sku_scope": {"skus": [sku_b]}}, headers=auth_headers)
+        assert resp.status_code == 200
+        assert _avail_skus("scp") == {sku_b}
+
+
+# ---------------------------------------------------------------- delete
+
+class TestDelete:
+    def test_soft_delete_hides_from_list(self, client, auth_headers):
+        _create(client, auth_headers, channel_id="del")
+        resp = client.delete("/api/admin/channels/del", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "revoked"
+        body = client.get("/api/admin/channels", headers=auth_headers).get_json()
+        assert all(c["channel_id"] != "del" for c in body["channels"])
+        assert _audit_count("CHANNEL_DELETE") >= 1
+
+
+# ---------------------------------------------------------------- dlq
+
+class TestDlq:
+    def test_dlq_empty_initially(self, client, auth_headers):
+        _create(client, auth_headers, channel_id="dlqc")
+        body = client.get("/api/admin/channels/dlqc/dlq",
+                          headers=auth_headers).get_json()
+        assert body["parked"] == []

--- a/api/tests/test_channel_availability_service.py
+++ b/api/tests/test_channel_availability_service.py
@@ -1,0 +1,271 @@
+"""Recompute-service contract for Pipe C (services.channel_availability_service).
+
+The service reconciles per-channel sellable availability against live inventory.
+These tests pin the invariants that keep it from lying to a marketplace:
+
+- available = SUM(on_hand - allocated) over Pickable / PickableStaging bins only;
+  Staging stock never counts.
+- Allocation (reserve-at-creation, cancel, the manual stepper) moves the number,
+  not just on-hand changes.
+- A version is bumped ONLY when the sellable number actually changes, so a quiet
+  warehouse enqueues no publish.
+- sku_scope filters which items publish (sku / category) and which warehouses
+  count toward the number.
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import json  # noqa: E402
+
+from sqlalchemy import text as sa_text  # noqa: E402
+
+from db_test_context import get_raw_connection  # noqa: E402
+from services.channel_availability_service import (  # noqa: E402
+    recompute_active_channels,
+    recompute_channel,
+)
+
+
+# ----------------------------------------------------------------------
+# Seeding helpers (raw connection, shares the test transaction)
+# ----------------------------------------------------------------------
+
+def _mk_item(sku=None, category=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    sku = sku or f"PC-{uuid.uuid4().hex[:10]}"
+    cur.execute(
+        "INSERT INTO items (sku, item_name, category, is_active, external_id) "
+        "VALUES (%s, %s, %s, TRUE, %s) RETURNING item_id",
+        (sku, sku, category, str(uuid.uuid4())),
+    )
+    item_id = cur.fetchone()[0]
+    cur.close()
+    return item_id, sku
+
+
+def _bin_of_type(bin_type, *, warehouse_id=None):
+    """Return (bin_id, warehouse_id) for a seed bin of the given type."""
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    if warehouse_id is None:
+        cur.execute(
+            "SELECT bin_id, warehouse_id FROM bins WHERE bin_type = %s "
+            "ORDER BY bin_id LIMIT 1",
+            (bin_type,),
+        )
+    else:
+        cur.execute(
+            "SELECT bin_id, warehouse_id FROM bins "
+            "WHERE bin_type = %s AND warehouse_id = %s ORDER BY bin_id LIMIT 1",
+            (bin_type, warehouse_id),
+        )
+    row = cur.fetchone()
+    cur.close()
+    return (row[0], row[1]) if row else (None, None)
+
+
+def _set_inv(item_id, bin_id, warehouse_id, *, on_hand, allocated=0):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO inventory (item_id, bin_id, warehouse_id, "
+        "quantity_on_hand, quantity_allocated) VALUES (%s, %s, %s, %s, %s) "
+        "ON CONFLICT (item_id, bin_id, lot_number) DO UPDATE "
+        "SET quantity_on_hand = EXCLUDED.quantity_on_hand, "
+        "    quantity_allocated = EXCLUDED.quantity_allocated",
+        (item_id, bin_id, warehouse_id, on_hand, allocated),
+    )
+    cur.close()
+
+
+def _reserve(item_id, bin_id, allocated):
+    """Bump quantity_allocated on the existing inventory row, as
+    reserve-at-creation does when an order commits stock. A direct UPDATE (not a
+    second _set_inv) because ON CONFLICT cannot dedupe a NULL lot_number row
+    (V-030), which would otherwise insert a duplicate inventory row."""
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE inventory SET quantity_allocated = %s "
+        "WHERE item_id = %s AND bin_id = %s",
+        (allocated, item_id, bin_id),
+    )
+    cur.close()
+
+
+def _mk_channel(channel_id, sku_scope=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO channels (channel_id, display_name, delivery_url, "
+        "created_by, external_id, sku_scope) "
+        "VALUES (%s, %s, %s, %s, %s, %s::jsonb)",
+        (channel_id, channel_id, "https://sink.example.com/availability",
+         "tester", str(uuid.uuid4()), json.dumps(sku_scope or {})),
+    )
+    cur.close()
+
+
+def _mk_warehouse_pickable_bin():
+    """Create a fresh warehouse + zone + Pickable bin; return (warehouse_id,
+    bin_id). The apartment-lab seed puts every pickable bin in warehouse 1, so
+    the warehouse-scope test builds its own second warehouse to prove the filter.
+    """
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    sfx = uuid.uuid4().hex[:8]
+    cur.execute(
+        "INSERT INTO warehouses (warehouse_code, warehouse_name) "
+        "VALUES (%s, %s) RETURNING warehouse_id",
+        (f"W-{sfx}", f"WH {sfx}"),
+    )
+    wh = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO zones (warehouse_id, zone_code, zone_name, zone_type) "
+        "VALUES (%s, %s, %s, 'PICKING') RETURNING zone_id",
+        (wh, f"Z-{sfx}", f"Zone {sfx}"),
+    )
+    zone = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO bins (zone_id, warehouse_id, bin_code, bin_barcode, "
+        "bin_type, external_id) VALUES (%s, %s, %s, %s, 'Pickable', %s) "
+        "RETURNING bin_id",
+        (zone, wh, f"B-{sfx}", f"BC-{sfx}", str(uuid.uuid4())),
+    )
+    bin_id = cur.fetchone()[0]
+    cur.close()
+    return wh, bin_id
+
+
+def _avail(db, channel_id, item_id):
+    row = db.execute(
+        sa_text(
+            "SELECT available_qty, current_version, last_version, dlq "
+            "FROM channel_availability WHERE channel_id = :c AND item_id = :i"
+        ),
+        {"c": channel_id, "i": item_id},
+    ).fetchone()
+    return row  # None if the item is not in scope / not materialized
+
+
+# ----------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------
+
+class TestSellableComputation:
+    def test_staging_stock_is_excluded(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        item_id, sku = _mk_item()
+        pick_bin, wh = _bin_of_type("Pickable")
+        stag_bin, _ = _bin_of_type("Staging", warehouse_id=wh)
+        _set_inv(item_id, pick_bin, wh, on_hand=10)
+        _set_inv(item_id, stag_bin, wh, on_hand=5)
+
+        bumped = recompute_channel(db, "amz", {"skus": [sku]})
+        assert bumped == 1
+        row = _avail(db, "amz", item_id)
+        # 10 in the pickable bin counts; 5 in Staging does not.
+        assert row.available_qty == 10
+        # Fresh row is dirty (awaiting first publish).
+        assert row.current_version > row.last_version
+
+    def test_allocation_reduces_available(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        item_id, sku = _mk_item()
+        pick_bin, wh = _bin_of_type("Pickable")
+        _set_inv(item_id, pick_bin, wh, on_hand=10, allocated=3)
+
+        recompute_channel(db, "amz", {"skus": [sku]})
+        assert _avail(db, "amz", item_id).available_qty == 7  # 10 - 3
+
+        # Reserve the rest (what reserve-at-creation does on a new order).
+        _reserve(item_id, pick_bin, allocated=10)
+        v_before = _avail(db, "amz", item_id).current_version
+        recompute_channel(db, "amz", {"skus": [sku]})
+        row = _avail(db, "amz", item_id)
+        assert row.available_qty == 0
+        assert row.current_version > v_before  # change bumped the version
+
+
+class TestVersionDiscipline:
+    def test_unchanged_recompute_does_not_bump(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        item_id, sku = _mk_item()
+        pick_bin, wh = _bin_of_type("Pickable")
+        _set_inv(item_id, pick_bin, wh, on_hand=8)
+
+        first = recompute_channel(db, "amz", {"skus": [sku]})
+        assert first == 1
+        v1 = _avail(db, "amz", item_id).current_version
+
+        # Nothing moved; a second sweep must write nothing and bump no version.
+        second = recompute_channel(db, "amz", {"skus": [sku]})
+        assert second == 0
+        assert _avail(db, "amz", item_id).current_version == v1
+
+
+class TestScopeFiltering:
+    def test_sku_scope_excludes_other_items(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        in_id, in_sku = _mk_item()
+        out_id, _ = _mk_item()
+        pick_bin, wh = _bin_of_type("Pickable")
+        _set_inv(in_id, pick_bin, wh, on_hand=4)
+        _set_inv(out_id, pick_bin, wh, on_hand=4)
+
+        recompute_channel(db, "amz", {"skus": [in_sku]})
+        assert _avail(db, "amz", in_id) is not None
+        assert _avail(db, "amz", out_id) is None  # out of scope, never materialized
+
+    def test_category_scope(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        in_id, _ = _mk_item(category="reels")
+        out_id, _ = _mk_item(category="waders")
+        pick_bin, wh = _bin_of_type("Pickable")
+        _set_inv(in_id, pick_bin, wh, on_hand=2)
+        _set_inv(out_id, pick_bin, wh, on_hand=2)
+
+        recompute_channel(db, "amz", {"categories": ["reels"]})
+        assert _avail(db, "amz", in_id) is not None
+        assert _avail(db, "amz", out_id) is None
+
+    def test_warehouse_scope_limits_counted_stock(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        item_id, sku = _mk_item()
+        pick1, wh1 = _bin_of_type("Pickable")        # seed warehouse 1
+        wh2, pick2 = _mk_warehouse_pickable_bin()    # a fresh second warehouse
+        _set_inv(item_id, pick1, wh1, on_hand=6)
+        _set_inv(item_id, pick2, wh2, on_hand=9)
+
+        recompute_channel(db, "amz", {"skus": [sku], "warehouse_ids": [wh1]})
+        # Only wh1 stock counts toward the channel's number; wh2's 9 is excluded.
+        assert _avail(db, "amz", item_id).available_qty == 6
+
+
+class TestActiveChannelOrchestration:
+    def test_recompute_active_channels_reads_db_scope(self, _db_transaction):
+        db = _db_transaction
+        item_id, sku = _mk_item()
+        pick_bin, wh = _bin_of_type("Pickable")
+        _set_inv(item_id, pick_bin, wh, on_hand=5)
+        _mk_channel("livech", sku_scope={"skus": [sku]})
+
+        results = recompute_active_channels(db)
+        assert results.get("livech", 0) >= 1
+        assert _avail(db, "livech", item_id).available_qty == 5

--- a/api/tests/test_connector_publisher_cycle.py
+++ b/api/tests/test_connector_publisher_cycle.py
@@ -1,0 +1,162 @@
+"""End-to-end cycle test for Pipe C: the daemon's own _cycle() wired through the
+real recompute service and the real publish path, with only the sink HTTP call
+faked. Proves the headline acceptance criterion -- reserving all of a SKU drops
+its published availability to 0 on the next cycle -- through the actual code the
+container runs, not a reconstruction of it.
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from sqlalchemy import text as sa_text  # noqa: E402
+
+import models.database as md  # noqa: E402
+from db_test_context import get_raw_connection  # noqa: E402
+from services.connector_publisher import ConnectorPublisher  # noqa: E402
+from services.connector_publisher import publish as publish_module  # noqa: E402
+
+
+# ---------------------------------------------------------------- helpers
+
+def _mk_item_with_stock(qty):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    sku = f"PC-{uuid.uuid4().hex[:10]}"
+    cur.execute(
+        "INSERT INTO items (sku, item_name, is_active, external_id) "
+        "VALUES (%s, %s, TRUE, %s) RETURNING item_id",
+        (sku, sku, str(uuid.uuid4())),
+    )
+    item_id = cur.fetchone()[0]
+    cur.execute("SELECT bin_id, warehouse_id FROM bins WHERE bin_type='Pickable' "
+                "ORDER BY bin_id LIMIT 1")
+    bin_id, wh = cur.fetchone()
+    cur.execute(
+        "INSERT INTO inventory (item_id, bin_id, warehouse_id, quantity_on_hand) "
+        "VALUES (%s, %s, %s, %s)",
+        (item_id, bin_id, wh, qty),
+    )
+    cur.close()
+    return item_id, sku, bin_id
+
+
+def _mk_channel(channel_id, sku, *, debounce=0, transform="{}"):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO channels (channel_id, display_name, delivery_url, sku_scope, "
+        "transform, debounce_seconds, created_by, external_id) "
+        "VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, %s)",
+        (channel_id, channel_id, "https://sink.example.com/availability",
+         '{"skus": ["' + sku + '"]}', transform, debounce, "tester", str(uuid.uuid4())),
+    )
+    cur.close()
+
+
+def _reserve(item_id, bin_id, allocated):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute("UPDATE inventory SET quantity_allocated=%s WHERE item_id=%s AND bin_id=%s",
+                (allocated, item_id, bin_id))
+    cur.close()
+
+
+def _make_publisher(monkeypatch, sent):
+    # Bypass SSRF (fake sink hostname) and fake the sink POST so _cycle exercises
+    # the real recompute + publish path without touching the network.
+    monkeypatch.setenv("SENTRY_ALLOW_INTERNAL_WEBHOOKS", "true")
+    monkeypatch.setattr(
+        publish_module, "_default_http_post",
+        lambda url, payload, **kw: (sent.append(payload) or (200, "ok")),
+    )
+    pub = ConnectorPublisher()
+    pub._Session = md.SessionLocal
+    return pub
+
+
+# ---------------------------------------------------------------- tests
+
+class TestFullCycle:
+    def test_cycle_publishes_live_availability(self, _db_transaction, monkeypatch):
+        item_id, sku, _bin = _mk_item_with_stock(10)
+        _mk_channel("amz", sku)
+        sent = []
+        pub = _make_publisher(monkeypatch, sent)
+
+        pub._cycle()
+
+        assert len(sent) == 1
+        assert sent[0]["channel_id"] == "amz"
+        assert sent[0]["items"] == [{"sku": sku, "available": 10}]
+        # Row is now clean.
+        clean = md.SessionLocal().execute(
+            sa_text("SELECT current_version = last_version AS clean "
+                    "FROM channel_availability WHERE channel_id='amz' AND item_id=:i"),
+            {"i": item_id},
+        ).fetchone().clean
+        assert clean is True
+
+    def test_reserve_drops_published_to_zero(self, _db_transaction, monkeypatch):
+        item_id, sku, bin_id = _mk_item_with_stock(10)
+        _mk_channel("amz", sku, debounce=0)
+        sent = []
+        pub = _make_publisher(monkeypatch, sent)
+
+        pub._cycle()
+        assert sent[-1]["items"][0]["available"] == 10
+
+        # An order reserves the whole quantity (reserve-at-creation).
+        _reserve(item_id, bin_id, allocated=10)
+
+        pub._cycle()
+        # Next cycle reconciles from live inventory and publishes the truth: 0.
+        assert sent[-1]["items"][0]["available"] == 0
+
+    def test_quiet_cycle_publishes_nothing(self, _db_transaction, monkeypatch):
+        item_id, sku, _bin = _mk_item_with_stock(5)
+        _mk_channel("amz", sku, debounce=0)
+        sent = []
+        pub = _make_publisher(monkeypatch, sent)
+
+        pub._cycle()             # initial publish
+        assert len(sent) == 1
+        pub._cycle()             # nothing changed -> no version bump -> no publish
+        assert len(sent) == 1
+
+    def test_transform_applies_on_the_wire(self, _db_transaction, monkeypatch):
+        item_id, sku, _bin = _mk_item_with_stock(4)
+        _mk_channel(
+            "amz", sku, debounce=0,
+            transform='{"rename": {"sku": "seller_sku", "available": "quantity"}, '
+                      '"constants": {"fulfillment_channel": "AMAZON_NA"}}',
+        )
+        sent = []
+        pub = _make_publisher(monkeypatch, sent)
+
+        pub._cycle()
+        assert sent[0]["items"] == [
+            {"seller_sku": sku, "quantity": 4, "fulfillment_channel": "AMAZON_NA"}
+        ]
+
+    def test_paused_channel_is_not_published(self, _db_transaction, monkeypatch):
+        item_id, sku, _bin = _mk_item_with_stock(6)
+        _mk_channel("amz", sku, debounce=0)
+        conn = get_raw_connection()
+        cur = conn.cursor()
+        cur.execute("UPDATE channels SET status='paused' WHERE channel_id='amz'")
+        cur.close()
+        sent = []
+        pub = _make_publisher(monkeypatch, sent)
+
+        pub._cycle()
+        # recompute_active_channels and the publish pass both skip non-active
+        # channels, so nothing is materialized or sent.
+        assert sent == []

--- a/api/tests/test_connector_publisher_daemon.py
+++ b/api/tests/test_connector_publisher_daemon.py
@@ -1,0 +1,198 @@
+"""Daemon-orchestration contract for the connector-publisher: the debounce gate,
+the backlog drain loop, the healthcheck staleness check, and env validation. The
+per-batch publish itself is covered in test_connector_publisher_publish; here we
+exercise the loop logic around it with an injected http_post (no network).
+"""
+
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import json  # noqa: E402
+
+import pytest  # noqa: E402
+from sqlalchemy import text as sa_text  # noqa: E402
+
+import models.database as md  # noqa: E402
+from db_test_context import get_raw_connection  # noqa: E402
+from services.channel_availability_service import recompute_channel  # noqa: E402
+from services.connector_publisher import ConnectorPublisher, env_validator  # noqa: E402
+from services.connector_publisher.healthcheck import is_healthy  # noqa: E402
+
+
+# ---------------------------------------------------------------- helpers
+
+def _mk_channel(channel_id, *, batch_size=2, rate=1000):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO channels (channel_id, display_name, delivery_url, batch_size, "
+        "rate_limit_per_second, created_by, external_id) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+        (channel_id, channel_id, "https://sink.example.com/availability",
+         batch_size, rate, "tester", str(uuid.uuid4())),
+    )
+    cur.close()
+
+
+def _mk_item_with_stock(qty):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    sku = f"PC-{uuid.uuid4().hex[:10]}"
+    cur.execute(
+        "INSERT INTO items (sku, item_name, is_active, external_id) "
+        "VALUES (%s, %s, TRUE, %s) RETURNING item_id",
+        (sku, sku, str(uuid.uuid4())),
+    )
+    item_id = cur.fetchone()[0]
+    cur.execute("SELECT bin_id, warehouse_id FROM bins WHERE bin_type='Pickable' "
+                "ORDER BY bin_id LIMIT 1")
+    bin_id, wh = cur.fetchone()
+    cur.execute(
+        "INSERT INTO inventory (item_id, bin_id, warehouse_id, quantity_on_hand) "
+        "VALUES (%s, %s, %s, %s)",
+        (item_id, bin_id, wh, qty),
+    )
+    cur.close()
+    return item_id, sku
+
+
+def _channel_row(session, channel_id):
+    return session.execute(
+        sa_text("SELECT * FROM channels WHERE channel_id = :c"), {"c": channel_id}
+    ).fetchone()
+
+
+def _dirty_count(session, channel_id):
+    return session.execute(
+        sa_text("SELECT COUNT(*) AS n FROM channel_availability "
+                "WHERE channel_id = :c AND current_version > last_version"),
+        {"c": channel_id},
+    ).fetchone().n
+
+
+# ---------------------------------------------------------------- debounce
+
+class TestDebounceGate:
+    def test_due_logic(self):
+        pub = ConnectorPublisher()
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        # Never published -> due.
+        assert pub._due(SimpleNamespace(debounce_seconds=30, last_published_at=None), now)
+        # debounce 0 -> always due.
+        assert pub._due(SimpleNamespace(debounce_seconds=0, last_published_at=now), now)
+        # Inside the window -> not due.
+        recent = now - timedelta(seconds=10)
+        assert not pub._due(
+            SimpleNamespace(debounce_seconds=30, last_published_at=recent), now)
+        # Past the window -> due.
+        old = now - timedelta(seconds=40)
+        assert pub._due(
+            SimpleNamespace(debounce_seconds=30, last_published_at=old), now)
+
+
+# ---------------------------------------------------------------- drain loop
+
+class TestDrainChannel:
+    def test_backlog_drains_in_batches(self, _db_transaction, monkeypatch):
+        # Exercise the loop, not the SSRF guard: bypass the dispatch-time check
+        # (the fake sink hostname does not resolve). The guard's real behavior is
+        # covered in test_connector_publisher_publish.
+        monkeypatch.setenv("SENTRY_ALLOW_INTERNAL_WEBHOOKS", "true")
+        session = md.SessionLocal()
+        try:
+            _mk_channel("amz", batch_size=2)
+            skus = []
+            for _ in range(5):
+                _, sku = _mk_item_with_stock(3)
+                skus.append(sku)
+            recompute_channel(session, "amz", {"skus": skus})
+            session.commit()
+            assert _dirty_count(session, "amz") == 5
+
+            calls = []
+
+            def fake(url, payload):
+                calls.append(len(payload["items"]))
+                return 200, "ok"
+
+            pub = ConnectorPublisher()
+            pub._drain_channel(session, _channel_row(session, "amz"), fake)
+
+            # 5 rows, batch_size 2 -> 2 + 2 + 1 across three POSTs, backlog cleared.
+            assert calls == [2, 2, 1]
+            assert _dirty_count(session, "amz") == 0
+        finally:
+            session.close()
+
+    def test_drain_stops_on_failure(self, _db_transaction, monkeypatch):
+        monkeypatch.setenv("SENTRY_ALLOW_INTERNAL_WEBHOOKS", "true")
+        session = md.SessionLocal()
+        try:
+            _mk_channel("amz", batch_size=2)
+            skus = [sku for _, sku in (_mk_item_with_stock(3) for _ in range(4))]
+            recompute_channel(session, "amz", {"skus": skus})
+            session.commit()
+
+            calls = []
+
+            def failing(url, payload):
+                calls.append(1)
+                return 500, "boom"
+
+            pub = ConnectorPublisher()
+            pub._drain_channel(session, _channel_row(session, "amz"), failing)
+
+            # One failed batch, then stop -- a sick sink is not hammered.
+            assert calls == [1]
+            # Rows stay dirty (nothing advanced).
+            assert _dirty_count(session, "amz") == 4
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------- healthcheck
+
+class TestHealthcheck:
+    def test_fresh_heartbeat_is_healthy(self, tmp_path):
+        hb = tmp_path / "hb"
+        hb.write_text("x")
+        mtime = os.path.getmtime(str(hb))
+        assert is_healthy(str(hb), threshold_s=30, now_fn=lambda: mtime + 5)
+
+    def test_stale_heartbeat_is_unhealthy(self, tmp_path):
+        hb = tmp_path / "hb"
+        hb.write_text("x")
+        mtime = os.path.getmtime(str(hb))
+        assert not is_healthy(str(hb), threshold_s=30, now_fn=lambda: mtime + 100)
+
+    def test_missing_heartbeat_is_unhealthy(self, tmp_path):
+        assert not is_healthy(str(tmp_path / "nope"), threshold_s=30)
+
+
+# ---------------------------------------------------------------- env validation
+
+class TestEnvValidation:
+    def test_out_of_range_fails_fast(self, monkeypatch):
+        monkeypatch.setenv("CONNECTOR_PUBLISHER_RECONCILE_INTERVAL_S", "999999")
+        with pytest.raises(SystemExit):
+            env_validator.validate_or_die()
+
+    def test_defaults_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CONNECTOR_PUBLISHER_FALLBACK_POLL_MS", raising=False)
+        assert env_validator.int_var("CONNECTOR_PUBLISHER_FALLBACK_POLL_MS") == 2000
+
+    def test_kill_switch_flag(self, monkeypatch):
+        monkeypatch.setenv("CONNECTOR_PUBLISHER_ENABLED", "false")
+        assert env_validator.enabled() is False
+        monkeypatch.setenv("CONNECTOR_PUBLISHER_ENABLED", "true")
+        assert env_validator.enabled() is True

--- a/api/tests/test_connector_publisher_publish.py
+++ b/api/tests/test_connector_publisher_publish.py
@@ -1,0 +1,241 @@
+"""Per-batch publish contract for Pipe C (services.connector_publisher.publish).
+
+Covers the transform, the success advance (last_version -> current_version, and
+the row goes clean), failure backoff, DLQ on attempt exhaustion, and the
+dispatch-time SSRF pause. http_post is injected so no real network is touched.
+"""
+
+import os
+import sys
+import uuid
+
+os.environ.setdefault("DATABASE_URL", "postgresql://sentry:sentry@localhost:5432/sentry")
+os.environ.setdefault("JWT_SECRET", "NEVER_USE_THIS_IN_PRODUCTION_32!")
+os.environ.setdefault("SENTRY_ENCRYPTION_KEY", "t5hPIEVn_O41qfiMqAiPEnwzQh68o3Es46YfSOBvEK8=")
+os.environ.setdefault("SENTRY_TOKEN_PEPPER", "NEVER_USE_THIS_PEPPER_IN_PRODUCTION")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import json  # noqa: E402
+
+from sqlalchemy import text as sa_text  # noqa: E402
+
+from db_test_context import get_raw_connection  # noqa: E402
+from services.channel_availability_service import recompute_channel  # noqa: E402
+from services.connector_publisher.publish import (  # noqa: E402
+    MAX_ATTEMPTS,
+    apply_transform,
+    publish_channel,
+)
+from services.webhook_dispatcher.ssrf_guard import SsrfRejected  # noqa: E402
+
+# Most tests inject a no-op SSRF check: the real guard does live DNS resolution,
+# which a fake sink hostname would fail. The guard's private-IP detection is
+# covered by the webhook-dispatcher SSRF tests; here we drive the pause branch
+# explicitly with a raising stub.
+_SSRF_OK = lambda url: None  # noqa: E731
+
+
+# ---------------------------------------------------------------- helpers
+
+def _mk_item(sku=None):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    sku = sku or f"PC-{uuid.uuid4().hex[:10]}"
+    cur.execute(
+        "INSERT INTO items (sku, item_name, is_active, external_id) "
+        "VALUES (%s, %s, TRUE, %s) RETURNING item_id",
+        (sku, sku, str(uuid.uuid4())),
+    )
+    item_id = cur.fetchone()[0]
+    cur.close()
+    return item_id, sku
+
+
+def _pick_bin():
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT bin_id, warehouse_id FROM bins WHERE bin_type='Pickable' "
+                "ORDER BY bin_id LIMIT 1")
+    row = cur.fetchone()
+    cur.close()
+    return row[0], row[1]
+
+
+def _set_inv(item_id, bin_id, wh, on_hand, allocated=0):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO inventory (item_id, bin_id, warehouse_id, quantity_on_hand, "
+        "quantity_allocated) VALUES (%s, %s, %s, %s, %s)",
+        (item_id, bin_id, wh, on_hand, allocated),
+    )
+    cur.close()
+
+
+def _mk_channel(channel_id, *, delivery_url="https://sink.example.com/availability",
+                transform=None, batch_size=100):
+    conn = get_raw_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO channels (channel_id, display_name, delivery_url, batch_size, "
+        "transform, created_by, external_id) "
+        "VALUES (%s, %s, %s, %s, %s::jsonb, %s, %s)",
+        (channel_id, channel_id, delivery_url, batch_size,
+         json.dumps(transform or {}), "tester", str(uuid.uuid4())),
+    )
+    cur.close()
+
+
+def _channel_row(db, channel_id):
+    return db.execute(
+        sa_text("SELECT * FROM channels WHERE channel_id = :c"),
+        {"c": channel_id},
+    ).fetchone()
+
+
+def _avail(db, channel_id, item_id):
+    return db.execute(
+        sa_text("SELECT available_qty, current_version, last_version, attempt_count, "
+                "dlq, last_error FROM channel_availability "
+                "WHERE channel_id = :c AND item_id = :i"),
+        {"c": channel_id, "i": item_id},
+    ).fetchone()
+
+
+# ---------------------------------------------------------------- transform
+
+class TestTransform:
+    def test_rename_and_constants(self):
+        out = apply_transform(
+            {"sku": "TST-1", "available": 5},
+            {"rename": {"sku": "seller_sku", "available": "quantity"},
+             "constants": {"fulfillment_channel": "AMAZON_NA"}},
+        )
+        assert out == {"seller_sku": "TST-1", "quantity": 5,
+                       "fulfillment_channel": "AMAZON_NA"}
+
+    def test_empty_transform_is_identity(self):
+        out = apply_transform({"sku": "X", "available": 2}, {})
+        assert out == {"sku": "X", "available": 2}
+
+
+# ---------------------------------------------------------------- publish
+
+class TestPublishSuccess:
+    def test_success_advances_and_cleans_row(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        item_id, sku = _mk_item()
+        pb, wh = _pick_bin()
+        _set_inv(item_id, pb, wh, on_hand=7)
+        recompute_channel(db, "amz", {"skus": [sku]})
+
+        sent = []
+
+        def fake_post(url, payload):
+            sent.append((url, payload))
+            return 200, "ok"
+
+        result = publish_channel(db, _channel_row(db, "amz"), http_post=fake_post,
+                                 ssrf_check=_SSRF_OK)
+        assert result == {"published": 1}
+
+        # The sink received the sellable number.
+        assert sent[0][0] == "https://sink.example.com/availability"
+        assert sent[0][1]["items"] == [{"sku": sku, "available": 7}]
+
+        # Row is now clean (current_version == last_version).
+        row = _avail(db, "amz", item_id)
+        assert row.last_version == row.current_version
+        assert row.attempt_count == 0 and row.dlq is False
+
+    def test_no_dirty_rows_is_a_noop(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        result = publish_channel(db, _channel_row(db, "amz"),
+                                 http_post=lambda u, p: (200, "ok"))
+        assert result == {"skipped": "no_dirty"}
+
+
+class TestPublishFailure:
+    def test_http_error_backs_off_and_keeps_row_dirty(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        item_id, sku = _mk_item()
+        pb, wh = _pick_bin()
+        _set_inv(item_id, pb, wh, on_hand=3)
+        recompute_channel(db, "amz", {"skus": [sku]})
+
+        result = publish_channel(db, _channel_row(db, "amz"),
+                                 http_post=lambda u, p: (500, "boom"),
+                                 ssrf_check=_SSRF_OK)
+        assert result == {"failed": 1}
+        row = _avail(db, "amz", item_id)
+        assert row.attempt_count == 1
+        assert row.dlq is False
+        assert row.last_version < row.current_version  # still dirty -> will retry
+        assert "500" in row.last_error
+
+    def test_network_raise_is_a_failed_batch(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        item_id, sku = _mk_item()
+        pb, wh = _pick_bin()
+        _set_inv(item_id, pb, wh, on_hand=1)
+        recompute_channel(db, "amz", {"skus": [sku]})
+
+        def boom(url, payload):
+            raise RuntimeError("connection refused")
+
+        result = publish_channel(db, _channel_row(db, "amz"), http_post=boom,
+                                 ssrf_check=_SSRF_OK)
+        assert result == {"failed": 1}
+        assert _avail(db, "amz", item_id).attempt_count == 1
+
+    def test_dlq_after_attempts_exhausted(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        item_id, sku = _mk_item()
+        pb, wh = _pick_bin()
+        _set_inv(item_id, pb, wh, on_hand=1)
+        recompute_channel(db, "amz", {"skus": [sku]})
+
+        # Pre-age the row to one failure short of the DLQ threshold, and clear
+        # next_attempt_at so it is eligible to claim.
+        db.execute(
+            sa_text("UPDATE channel_availability SET attempt_count = :a, "
+                    "next_attempt_at = NULL WHERE channel_id='amz' AND item_id=:i"),
+            {"a": MAX_ATTEMPTS - 1, "i": item_id},
+        )
+        result = publish_channel(db, _channel_row(db, "amz"),
+                                 http_post=lambda u, p: (503, "down"),
+                                 ssrf_check=_SSRF_OK)
+        assert result == {"failed": 1}
+        row = _avail(db, "amz", item_id)
+        assert row.attempt_count == MAX_ATTEMPTS
+        assert row.dlq is True  # parked
+
+
+class TestSsrfPause:
+    def test_private_sink_pauses_channel(self, _db_transaction):
+        db = _db_transaction
+        _mk_channel("amz")
+        item_id, sku = _mk_item()
+        pb, wh = _pick_bin()
+        _set_inv(item_id, pb, wh, on_hand=4)
+        recompute_channel(db, "amz", {"skus": [sku]})
+
+        def reject(url):
+            raise SsrfRejected(f"refusing {url}: loopback")
+
+        posted = []
+        result = publish_channel(
+            db, _channel_row(db, "amz"),
+            http_post=lambda u, p: posted.append(1) or (200, "ok"),
+            ssrf_check=reject,
+        )
+        assert result == {"paused": "malformed_config"}
+        assert posted == []  # never POSTed to the rejected address
+        ch = _channel_row(db, "amz")
+        assert ch.status == "paused" and ch.pause_reason == "malformed_config"

--- a/api/version.py
+++ b/api/version.py
@@ -1,3 +1,3 @@
 """Sentry WMS version."""
 
-__version__ = "1.10.4"
+__version__ = "1.30.0"

--- a/db/migrations/075_channel_availability.sql
+++ b/db/migrations/075_channel_availability.sql
@@ -1,0 +1,188 @@
+-- ============================================================
+-- Migration 075: channel availability (Pipe C)
+-- ============================================================
+-- Pipe C materializes per-channel sellable availability and
+-- debounce-publishes it to a per-channel HTTP sink. It is separate
+-- from Pipe A (integration_events / webhooks) on purpose: fanning out
+-- every raw inventory change to every marketplace would blow past
+-- their rate limits within minutes. Instead Pipe C collapses many
+-- inventory changes into a current-state number per (channel, item)
+-- and the connector-publisher daemon sends the latest debounced
+-- snapshot.
+--
+-- Three tables + one sequence:
+--
+--   * channels                  -- per-channel config: delivery_url,
+--                                  SKU scope, transform map, rate /
+--                                  batch / debounce, status lifecycle.
+--   * channel_availability      -- the materialization, keyed
+--                                  (channel_id, item_id), carrying the
+--                                  current_version / last_version
+--                                  pattern. A row is "dirty" (awaiting
+--                                  publish) iff current_version >
+--                                  last_version.
+--   * channel_recompute_state   -- singleton cursor into
+--                                  integration_events for the recompute
+--                                  consumer.
+--   * channel_availability_version_seq -- global monotonic source for
+--                                  current_version bumps.
+--
+-- available_qty is sellable stock: SUM(on_hand - allocated) over the
+-- channel's in-scope warehouses, counting only Pickable /
+-- PickableStaging bins. The recompute service reads CURRENT inventory
+-- state (events are triggers, not deltas), so replaying an event is
+-- idempotent. current_version bumps only when the recomputed number
+-- actually differs from the stored one, so a no-op inventory churn
+-- does not enqueue a publish.
+--
+-- The publisher reuses the dispatcher's dispatch-time SSRF guard on
+-- delivery_url. Real Amazon / BigCommerce / Shopify API clients are
+-- deferred (v2.1+); the sink here is a generic HTTP receiver.
+--
+-- Additive only: no existing inventory or write path is touched, and
+-- no new trigger lands on a hot path. The recompute consumer wakes on
+-- the existing integration_events_visible NOTIFY (migration 031).
+--
+-- v1.8.0 mig discipline (#213): SET lock_timeout / statement_timeout,
+-- BEGIN/COMMIT-wrapped.
+-- ============================================================
+
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+BEGIN;
+
+-- Global monotonic version source. A single sequence across all
+-- channels/items is fine: per-row monotonicity is all the
+-- current_version > last_version comparison needs, and a global
+-- sequence trivially satisfies it.
+CREATE SEQUENCE IF NOT EXISTS channel_availability_version_seq AS BIGINT;
+
+CREATE TABLE IF NOT EXISTS channels (
+    channel_id            VARCHAR(64)  PRIMARY KEY,            -- operator slug, e.g. 'amazon-fba'
+    display_name          VARCHAR(128) NOT NULL,
+    delivery_url          TEXT         NOT NULL,
+    -- SKU scope: which items this channel publishes. An absent or
+    -- empty dimension means "no restriction on that dimension".
+    -- Shape (validated app-side): {"skus": [...], "categories": [...],
+    -- "warehouse_ids": [...]}.
+    sku_scope             JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    -- Declarative transform map applied to the outbound payload.
+    -- Shape (validated app-side): {"rename": {"sku": "seller_sku"},
+    -- "constants": {"fulfillment_channel": "AMAZON_NA"}}. No code
+    -- execution -- field rename + constant injection only.
+    transform             JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    status                VARCHAR(16)  NOT NULL DEFAULT 'active',
+    pause_reason          VARCHAR(32),
+    rate_limit_per_second INTEGER      NOT NULL DEFAULT 10,
+    batch_size            INTEGER      NOT NULL DEFAULT 100,
+    debounce_seconds      INTEGER      NOT NULL DEFAULT 30,
+    pending_ceiling       INTEGER      NOT NULL DEFAULT 100000,
+    dlq_ceiling           INTEGER      NOT NULL DEFAULT 1000,
+    last_published_at     TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    created_by            VARCHAR(100) NOT NULL,
+    updated_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    external_id           UUID         UNIQUE NOT NULL,
+    CONSTRAINT channels_delivery_url_scheme
+        CHECK (delivery_url ~ '^https?://'),
+    CONSTRAINT channels_rate_limit_range
+        CHECK (rate_limit_per_second BETWEEN 1 AND 1000),
+    CONSTRAINT channels_batch_size_range
+        CHECK (batch_size BETWEEN 1 AND 1000),
+    CONSTRAINT channels_debounce_range
+        CHECK (debounce_seconds BETWEEN 0 AND 3600),
+    CONSTRAINT channels_pending_ceiling_range
+        CHECK (pending_ceiling BETWEEN 100 AND 1000000),
+    CONSTRAINT channels_dlq_ceiling_range
+        CHECK (dlq_ceiling BETWEEN 10 AND 100000),
+    -- Column-level enforcement, mirroring webhook_subscriptions #236:
+    -- a privileged-role error or malicious migration cannot write an
+    -- out-of-band status. malformed_config is the publisher's
+    -- auto-pause value when a channel's transform/scope fails to load.
+    CONSTRAINT channels_status_enum
+        CHECK (status IN ('active', 'paused', 'revoked')),
+    CONSTRAINT channels_pause_reason_enum
+        CHECK (
+            pause_reason IS NULL
+            OR pause_reason IN (
+                'manual',
+                'pending_ceiling',
+                'dlq_ceiling',
+                'malformed_config'
+            )
+        )
+);
+
+CREATE INDEX IF NOT EXISTS ix_channels_active
+    ON channels (status)
+    WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS channel_availability (
+    channel_id        VARCHAR(64)  NOT NULL REFERENCES channels(channel_id) ON DELETE CASCADE,
+    item_id           INT          NOT NULL REFERENCES items(item_id),
+    available_qty     INTEGER      NOT NULL DEFAULT 0,   -- SUM(on_hand - allocated), scoped bins
+    current_version   BIGINT       NOT NULL DEFAULT 0,   -- bumped when available_qty changes
+    last_version      BIGINT       NOT NULL DEFAULT 0,   -- last version published to the sink
+    attempt_count     INTEGER      NOT NULL DEFAULT 0,
+    next_attempt_at   TIMESTAMPTZ,                       -- backoff gate; NULL = eligible now
+    dlq               BOOLEAN      NOT NULL DEFAULT FALSE,
+    last_error        TEXT,
+    last_published_at TIMESTAMPTZ,
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (channel_id, item_id)
+);
+
+-- Hot-query partial index. The publisher claim is
+-- "WHERE channel_id = :c AND current_version > last_version"; index
+-- only the dirty rows so a channel with millions of clean SKUs still
+-- claims in time proportional to its backlog, not its catalog.
+CREATE INDEX IF NOT EXISTS ix_channel_availability_dirty
+    ON channel_availability (channel_id, current_version)
+    WHERE current_version > last_version;
+
+-- DLQ view support: list parked rows per channel cheaply.
+CREATE INDEX IF NOT EXISTS ix_channel_availability_dlq
+    ON channel_availability (channel_id)
+    WHERE dlq = TRUE;
+
+-- Singleton cursor for the recompute consumer's position in
+-- integration_events. One consumer feeds every channel, so one
+-- global cursor (not per-channel).
+CREATE TABLE IF NOT EXISTS channel_recompute_state (
+    only_row     BOOLEAN     PRIMARY KEY DEFAULT TRUE,
+    last_cursor  BIGINT      NOT NULL DEFAULT 0,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT channel_recompute_state_singleton CHECK (only_row = TRUE)
+);
+
+-- Seed the singleton at cursor 0. The daemon fast-forwards a fresh
+-- (cursor = 0) install to MAX(event_id) on first boot so it does not
+-- replay the whole event history; events are triggers, and the
+-- channel seed materializes from a live inventory scan instead.
+INSERT INTO channel_recompute_state (only_row, last_cursor)
+VALUES (TRUE, 0)
+ON CONFLICT (only_row) DO NOTHING;
+
+COMMENT ON TABLE channels IS
+    'Pipe C per-channel availability config. Standalone (not linked to the v1.3 connectors stub): a channel owns its delivery_url HTTP sink, SKU scope, declarative transform map, and rate/batch/debounce knobs. status lifecycle mirrors webhook_subscriptions (active/paused/revoked).';
+
+COMMENT ON COLUMN channels.sku_scope IS
+    'Which items publish on this channel. {"skus": [...], "categories": [...], "warehouse_ids": [...]}. An absent or empty dimension imposes no restriction on that dimension; {} publishes every active item across every warehouse.';
+
+COMMENT ON COLUMN channels.transform IS
+    'Declarative outbound payload transform. {"rename": {"sku": "seller_sku"}, "constants": {"fulfillment_channel": "AMAZON_NA"}}. Field rename + constant injection only -- no expression evaluation (deferred). Covers the Amazon FBA vs MFN distinction.';
+
+COMMENT ON COLUMN channels.debounce_seconds IS
+    'Minimum seconds between consecutive publishes for this channel. The publisher collapses all dirty rows accumulated during the window into one batch on the next tick. 0 disables debounce (publish on every wake).';
+
+COMMENT ON TABLE channel_availability IS
+    'Materialized sellable availability per (channel, item). available_qty = SUM(on_hand - allocated) over the channel''s in-scope warehouses, Pickable/PickableStaging bins only. A row is dirty (awaiting publish) iff current_version > last_version; the publisher advances last_version to the value it published.';
+
+COMMENT ON COLUMN channel_availability.current_version IS
+    'nextval(channel_availability_version_seq) stamped each time the recompute service observes available_qty actually change. A no-op recompute does not bump it, so an inventory event that nets to the same sellable number enqueues no publish.';
+
+COMMENT ON COLUMN channel_availability.dlq IS
+    'TRUE once attempt_count exhausts the retry schedule. A parked row is skipped by the claim until a NEWER current_version arrives (a fresh inventory change), which resets dlq/attempt_count/next_attempt_at so current state always gets another chance.';
+
+COMMIT;

--- a/db/role-publisher.sql
+++ b/db/role-publisher.sql
@@ -1,0 +1,101 @@
+-- ============================================================
+-- Least-privilege DB role for connector-publisher (Pipe C)
+-- ============================================================
+-- Pipe C adds a connector-publisher daemon that (1) consumes
+-- integration_events to recompute per-channel sellable availability
+-- and (2) debounce-publishes the dirty rows to each channel's HTTP
+-- sink. It follows the V-214 #153 (snapshot-keeper) and #169
+-- (webhook-dispatcher) shape so a compromise of the api host does not
+-- grant the publisher's permissions, and vice versa.
+--
+-- Grants cover exactly the publisher's need-to-know:
+--
+--   * CONNECT on the database (and USAGE on the public schema)
+--   * SELECT on integration_events (cursor read: "what changed?")
+--   * SELECT on inventory, items, bins, warehouses (recompute the
+--     sellable number from current state)
+--   * SELECT / UPDATE on channels (read config; auto-pause status
+--     flip with pause_reason on ceiling breach)
+--   * SELECT / INSERT / UPDATE on channel_availability (materialize,
+--     version bump, publish-state transitions, DLQ park)
+--   * SELECT / UPDATE on channel_recompute_state (advance the cursor)
+--   * USAGE on channel_availability_version_seq (nextval stamps
+--     current_version; without USAGE the UPDATE surfaces a
+--     'permission denied for sequence' error)
+--   * LISTEN on integration_events_visible (migration 031) -- not
+--     granted explicitly; any role with CONNECT can LISTEN. Listed
+--     here for operator awareness.
+--
+-- Explicitly NOT granted:
+--
+--   * users, wms_tokens, wms_tokens_audit, audit_log, connectors
+--     (writes) -- the publisher has no admin / token / forensic
+--     write surface; a compromise must not reach the auth or audit
+--     layers. Channel config-change audit rows are written by the
+--     admin endpoints under the api role, not by this daemon.
+--   * webhook_subscriptions / webhook_deliveries / webhook_secrets --
+--     Pipe A is the dispatcher's surface, not the publisher's.
+--   * any INSERT/UPDATE/DELETE on inventory -- the publisher is a
+--     read-only observer of stock; it never mutates it.
+--
+-- This script is operator-driven, not auto-applied. Migrations cannot
+-- read a password from the environment and we do not bake a
+-- placeholder password into git. Run it once per deployment after the
+-- v1.30.0 upgrade; the operator supplies the password via a psql
+-- variable.
+--
+--   psql -v sentry_publisher_password=<strong-password> \
+--        -U <db-superuser> -d <database> \
+--        -f db/role-publisher.sql
+--
+-- (Pass the password unquoted; the script wraps it as an SQL string
+-- literal via psql's :'var' interpolation at the top level, NOT inside
+-- a DO $$ ... $$ block, because psql does not substitute :'var' inside
+-- dollar-quoted strings. The two CREATE / ALTER ROLE branches are
+-- guarded by WHERE clauses so exactly one fires per run.)
+--
+-- Then set PUBLISHER_DATABASE_URL in .env to
+--   postgresql://sentry_publisher:<strong-password>@db:5432/<database>
+-- and restart the connector-publisher container.
+--
+-- Idempotent: safe to re-run. Both \gexec branches are predicated on
+-- pg_roles existence so re-runs only ALTER (which carries the new
+-- password); the GRANTs are themselves idempotent.
+--
+-- ON_ERROR_STOP discipline: a failure exits non-zero so deployment
+-- automation flags the step (the V-214 #170 regression shipped
+-- because psql exited 0 despite role-creation failures).
+-- ============================================================
+
+\set ON_ERROR_STOP on
+
+-- Branch 1: CREATE ROLE on first run.
+SELECT format('CREATE ROLE sentry_publisher LOGIN PASSWORD %L',
+              :'sentry_publisher_password')
+ WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'sentry_publisher')
+\gexec
+
+-- Branch 2: ALTER ROLE on subsequent runs (also rotates the password
+-- if the operator supplies a new value).
+SELECT format('ALTER ROLE sentry_publisher WITH LOGIN PASSWORD %L',
+              :'sentry_publisher_password')
+ WHERE EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'sentry_publisher')
+\gexec
+
+-- GRANT CONNECT needs a literal database name; derive it from
+-- current_database() so the script works regardless of POSTGRES_DB.
+SELECT format('GRANT CONNECT ON DATABASE %I TO sentry_publisher',
+              current_database())
+\gexec
+
+GRANT USAGE ON SCHEMA public TO sentry_publisher;
+
+GRANT SELECT                 ON integration_events       TO sentry_publisher;
+GRANT SELECT                 ON inventory                TO sentry_publisher;
+GRANT SELECT                 ON items                    TO sentry_publisher;
+GRANT SELECT                 ON bins                     TO sentry_publisher;
+GRANT SELECT                 ON warehouses               TO sentry_publisher;
+GRANT SELECT, UPDATE         ON channels                 TO sentry_publisher;
+GRANT SELECT, INSERT, UPDATE ON channel_availability     TO sentry_publisher;
+GRANT SELECT, UPDATE         ON channel_recompute_state  TO sentry_publisher;
+GRANT USAGE                  ON SEQUENCE channel_availability_version_seq TO sentry_publisher;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2085,3 +2085,102 @@ CREATE TABLE IF NOT EXISTS user_page_permissions (
 
 CREATE INDEX IF NOT EXISTS ix_user_page_permissions_user
     ON user_page_permissions(user_id);
+
+-- ============================================================
+-- CHANNEL AVAILABILITY (Pipe C)
+-- ============================================================
+-- Per-channel sellable-availability materialization and
+-- debounce-publish. Separate from Pipe A (integration_events /
+-- webhooks): Pipe C collapses many inventory changes into a
+-- current-state number per (channel, item) so the connector-publisher
+-- daemon sends one debounced snapshot instead of fanning out every
+-- raw change. Incremental form lives in
+-- db/migrations/075_channel_availability.sql.
+
+CREATE SEQUENCE IF NOT EXISTS channel_availability_version_seq AS BIGINT;
+
+CREATE TABLE IF NOT EXISTS channels (
+    channel_id            VARCHAR(64)  PRIMARY KEY,            -- operator slug, e.g. 'amazon-fba'
+    display_name          VARCHAR(128) NOT NULL,
+    delivery_url          TEXT         NOT NULL,
+    -- {"skus": [...], "categories": [...], "warehouse_ids": [...]};
+    -- absent/empty dimension = no restriction on that dimension.
+    sku_scope             JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    -- {"rename": {"sku": "seller_sku"}, "constants": {...}}; field
+    -- rename + constant injection only, no expression evaluation.
+    transform             JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    status                VARCHAR(16)  NOT NULL DEFAULT 'active',
+    pause_reason          VARCHAR(32),
+    rate_limit_per_second INTEGER      NOT NULL DEFAULT 10,
+    batch_size            INTEGER      NOT NULL DEFAULT 100,
+    debounce_seconds      INTEGER      NOT NULL DEFAULT 30,
+    pending_ceiling       INTEGER      NOT NULL DEFAULT 100000,
+    dlq_ceiling           INTEGER      NOT NULL DEFAULT 1000,
+    last_published_at     TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    created_by            VARCHAR(100) NOT NULL,
+    updated_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    external_id           UUID         UNIQUE NOT NULL,
+    CONSTRAINT channels_delivery_url_scheme
+        CHECK (delivery_url ~ '^https?://'),
+    CONSTRAINT channels_rate_limit_range
+        CHECK (rate_limit_per_second BETWEEN 1 AND 1000),
+    CONSTRAINT channels_batch_size_range
+        CHECK (batch_size BETWEEN 1 AND 1000),
+    CONSTRAINT channels_debounce_range
+        CHECK (debounce_seconds BETWEEN 0 AND 3600),
+    CONSTRAINT channels_pending_ceiling_range
+        CHECK (pending_ceiling BETWEEN 100 AND 1000000),
+    CONSTRAINT channels_dlq_ceiling_range
+        CHECK (dlq_ceiling BETWEEN 10 AND 100000),
+    CONSTRAINT channels_status_enum
+        CHECK (status IN ('active', 'paused', 'revoked')),
+    CONSTRAINT channels_pause_reason_enum
+        CHECK (
+            pause_reason IS NULL
+            OR pause_reason IN (
+                'manual',
+                'pending_ceiling',
+                'dlq_ceiling',
+                'malformed_config'
+            )
+        )
+);
+
+CREATE INDEX IF NOT EXISTS ix_channels_active
+    ON channels (status)
+    WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS channel_availability (
+    channel_id        VARCHAR(64)  NOT NULL REFERENCES channels(channel_id) ON DELETE CASCADE,
+    item_id           INT          NOT NULL REFERENCES items(item_id),
+    available_qty     INTEGER      NOT NULL DEFAULT 0,   -- SUM(on_hand - allocated), scoped bins
+    current_version   BIGINT       NOT NULL DEFAULT 0,   -- bumped when available_qty changes
+    last_version      BIGINT       NOT NULL DEFAULT 0,   -- last version published to the sink
+    attempt_count     INTEGER      NOT NULL DEFAULT 0,
+    next_attempt_at   TIMESTAMPTZ,                       -- backoff gate; NULL = eligible now
+    dlq               BOOLEAN      NOT NULL DEFAULT FALSE,
+    last_error        TEXT,
+    last_published_at TIMESTAMPTZ,
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (channel_id, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_channel_availability_dirty
+    ON channel_availability (channel_id, current_version)
+    WHERE current_version > last_version;
+
+CREATE INDEX IF NOT EXISTS ix_channel_availability_dlq
+    ON channel_availability (channel_id)
+    WHERE dlq = TRUE;
+
+CREATE TABLE IF NOT EXISTS channel_recompute_state (
+    only_row     BOOLEAN     PRIMARY KEY DEFAULT TRUE,
+    last_cursor  BIGINT      NOT NULL DEFAULT 0,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT channel_recompute_state_singleton CHECK (only_row = TRUE)
+);
+
+INSERT INTO channel_recompute_state (only_row, last_cursor)
+VALUES (TRUE, 0)
+ON CONFLICT (only_row) DO NOTHING;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,6 +220,53 @@ services:
       retries: 3
       start_period: 15s
 
+  connector-publisher:
+    # v1.30.0 (Pipe C): channel-availability publisher daemon. Mirrors the
+    # webhook-dispatcher / snapshot-keeper shape (single Python process,
+    # heartbeat file, SIGTERM-aware loop). Each cycle reconciles per-channel
+    # availability against live inventory and debounce-publishes dirty rows to
+    # each channel's HTTP sink. No Redis dependency: it wakes on the existing
+    # integration_events_visible NOTIFY plus a periodic reconcile, and holds no
+    # cross-worker state. CONNECTOR_PUBLISHER_ENABLED=false stops publishing
+    # without removing the container.
+    build: ./api
+    container_name: sentry-connector-publisher
+    command: python -m services.connector_publisher
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PYTHONPATH: /app
+      DATABASE_URL: postgresql://${POSTGRES_USER:-sentry}:${POSTGRES_PASSWORD:-sentry}@db:5432/${POSTGRES_DB:-sentry}
+      # Operators who run db/role-publisher.sql set PUBLISHER_DATABASE_URL in
+      # .env to point at the dedicated least-privilege sentry_publisher role
+      # (read inventory, write only the channel tables). Defaults to
+      # DATABASE_URL above when unset so dev keeps working.
+      PUBLISHER_DATABASE_URL: ${PUBLISHER_DATABASE_URL:-}
+      CONNECTOR_PUBLISHER_HEARTBEAT_FILE: /tmp/connector-publisher-heartbeat
+      CONNECTOR_PUBLISHER_ENABLED: ${CONNECTOR_PUBLISHER_ENABLED:-true}
+      # Tunables (env_validator enforces bounds at boot). Values shown are the
+      # documented defaults.
+      CONNECTOR_PUBLISHER_FALLBACK_POLL_MS: ${CONNECTOR_PUBLISHER_FALLBACK_POLL_MS:-2000}
+      CONNECTOR_PUBLISHER_RECONCILE_INTERVAL_S: ${CONNECTOR_PUBLISHER_RECONCILE_INTERVAL_S:-60}
+      CONNECTOR_PUBLISHER_SHUTDOWN_DRAIN_S: ${CONNECTOR_PUBLISHER_SHUTDOWN_DRAIN_S:-30}
+      CONNECTOR_PUBLISHER_HTTP_CONNECT_TIMEOUT_MS: ${CONNECTOR_PUBLISHER_HTTP_CONNECT_TIMEOUT_MS:-5000}
+      CONNECTOR_PUBLISHER_HTTP_READ_TIMEOUT_MS: ${CONNECTOR_PUBLISHER_HTTP_READ_TIMEOUT_MS:-8000}
+      # Dispatch-time SSRF guard opt-out (dev/CI only). Safe default keeps the
+      # guard in effect; the dispatcher env validator refuses it in production.
+      SENTRY_ALLOW_INTERNAL_WEBHOOKS: ${SENTRY_ALLOW_INTERNAL_WEBHOOKS:-false}
+      FLASK_ENV: ${FLASK_ENV:-development}
+    volumes:
+      - ./api:/app
+      - ./db:/db
+    healthcheck:
+      test: ["CMD", "python", "-m", "services.connector_publisher.healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
   celery-worker:
     build: ./api
     container_name: sentry-celery


### PR DESCRIPTION
Pipe C: a new outbound surface that publishes per-channel sellable availability to a configured HTTP sink per channel. Inventory changes collapse into a current-state number per (channel, SKU) and are debounce-published, so a busy warehouse does not fan every stock tick out to every marketplace.

## What's in it
- `channel_availability` materialization (`on_hand - allocated`, Pickable / PickableStaging bins only) with a `current_version` / `last_version` dirty-row pattern (migration 075).
- `connector-publisher` daemon: reconciles against live inventory on the `integration_events_visible` wake plus a periodic interval, debounce-publishes dirty rows, per-channel rate limit + batch size, dispatch-time SSRF guard on the sink, per-row retry to a DLQ.
- Per-channel config: SKU scope (skus / categories / warehouses), a declarative transform (field rename + constant injection, for the Amazon FBA vs MFN distinction), and rate / batch / debounce knobs.
- Admin Channels page + `/api/admin/channels` CRUD with audit on every change.
- Least-privilege `sentry_publisher` role; new `connector-publisher` compose service.

## Notes
- Reads live inventory rather than replaying events, so it stays truthful for allocation changes that emit no event (reserve-at-creation, cancel) and never publishes a stale count.
- No mobile diffs; mobile build stays 1.29.0 / versionCode 10.
- 42 new tests covering the recompute math, publish / retry / DLQ, the daemon cycle, and admin CRUD.

Closes #424.